### PR TITLE
Fix symbol clash with kernel.lib

### DIFF
--- a/test/cpp_test/c_api/aie2_test.c
+++ b/test/cpp_test/c_api/aie2_test.c
@@ -24,11 +24,11 @@ int main(int argc, char **argv)
 
   size_t txn_buf_size, control_packet_buf_size = 0, external_buffer_id_json_buf_size = 0, elf_buf_size;
 
-  txn_buf = ReadFile(argv[1], (long *)&txn_buf_size);
+  txn_buf = aiebu_ReadFile(argv[1], (long *)&txn_buf_size);
   if (argc > 2)
   {
-    control_packet_buf = ReadFile(argv[2], (long *)&control_packet_buf_size);
-    external_buffer_id_json_buf = ReadFile(argv[3], (long *)&external_buffer_id_json_buf_size);
+    control_packet_buf = aiebu_ReadFile(argv[2], (long *)&control_packet_buf_size);
+    external_buffer_id_json_buf = aiebu_ReadFile(argv[3], (long *)&external_buffer_id_json_buf_size);
   }
 
   elf_buf_size = aiebu_assembler_get_elf(aiebu_assembler_buffer_type_blob_instr_transaction,

--- a/test/cpp_test/c_api/aie_test_common.h
+++ b/test/cpp_test/c_api/aie_test_common.h
@@ -17,7 +17,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-char* ReadFile(char *name, long *s)
+char* aiebu_ReadFile(char *name, long *s)
 {
   FILE *file;
   char *buffer;


### PR DESCRIPTION
Rename ReadFile(...) to aiebu_ReadFile(...)

Adding simple named global functions in the global namespace is not cool for C.  In this case ReadFile clashes with ReadFile from windows.h.