### PR TITLE
Disable checksum test with boost less than 1.71

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,10 @@ if (NOT(AIEBU_GIT_SUBMODULE))
   endif()
 endif()
 
+set(Boost_USE_STATIC_LIBS ON)
+INCLUDE (FindBoost)
+message("-- Boost version: ${Boost_VERSION}")
+find_package(Boost REQUIRED)
 
 include (cmake/settings.cmake)
 include (cmake/utils.cmake)
@@ -102,7 +106,6 @@ if (AIEBU_FULL STREQUAL "ON")
 endif()
 
 add_subdirectory(lib)
-
 add_subdirectory(test)
 
 SET(PACKAGE_KIND "TGZ")

--- a/src/cpp/aiebu/CMakeLists.txt
+++ b/src/cpp/aiebu/CMakeLists.txt
@@ -1,11 +1,5 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
-
-set(Boost_USE_STATIC_LIBS ON)
-INCLUDE (FindBoost)
-message("-- Boost version: ${Boost_VERSION}")
-find_package(Boost REQUIRED)
-
 if (MSVC)
   add_compile_options(/WX /W2)
   # Use Hybrid linking on Windows

--- a/test/aie2-ctrlcode/CMakeLists.txt
+++ b/test/aie2-ctrlcode/CMakeLists.txt
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024 Advanced Micro Devices, Inc.
-
 add_subdirectory(save-restore)
-add_subdirectory(basic)
+
+# MD5 name-based uuid generation was corrected to be
+# identical on all endian systems in 1.71.0 only.
+if (${Boost_VERSION} VERSION_GREATER_EQUAL "1.71.0")
+  add_subdirectory(basic)
+endif()


### PR DESCRIPTION
#### Problem solved by the commit
In Boost1.71 MD5 name-based uuid generation was corrected to be identical on all endian systems.  Test fails with incorrect checksum on lesser Boost versions.
