### PR TITLE
Replace single occurence of boost::lexical_cast with stoul

### DIFF
--- a/src/cpp/aiebu/src/preprocessor/aie2/aie2_asm_preprocessor_input.cpp
+++ b/src/cpp/aiebu/src/preprocessor/aie2/aie2_asm_preprocessor_input.cpp
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: MIT
-// Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
-
-#include <boost/lexical_cast.hpp>
+// Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 #include <cstdint>
 #include <memory>
+#include <string>
 
 #include "aie2_blob_preprocessor_input.h"
 #include "asm/asm_parser.h"
@@ -130,7 +129,7 @@ public:
 
     auto op = reinterpret_cast<XAie_Write32Hdr *>(m_op);
     op->RegOff = std::stoull(regoff, nullptr, hexbase);
-    op->Value = (uint32_t)std::stoul(args[1], nullptr, hexbase);
+    op->Value = static_cast<uint32_t>(std::stoul(args[1], nullptr, hexbase));
     op->Size = sizeof(XAie_Write32Hdr);
   }
 
@@ -158,7 +157,7 @@ public:
     // Capture the extended values
     auto values = get_extended_storage<unsigned int>();
     for (unsigned int i = 0; idx < args.size(); idx++, i++)
-      values[i] = (uint32_t)std::stoul(args[idx], nullptr, hexbase);
+      values[i] = static_cast<uint32_t>(std::stoul(args[idx], nullptr, hexbase));
   }
 
   [[nodiscard]] size_t get_op_base_size() const override {
@@ -176,8 +175,8 @@ public:
 
     auto op = reinterpret_cast<XAie_MaskWrite32Hdr *>(m_op);
     op->RegOff = std::stoull(regoff, nullptr, hexbase);
-    op->Value = (uint32_t)std::stoul(args[1], nullptr, hexbase);
-    op->Mask = (uint32_t)std::stoul(args[2], nullptr, hexbase);
+    op->Value = static_cast<uint32_t>(std::stoul(args[1], nullptr, hexbase));
+    op->Mask = static_cast<uint32_t>(std::stoul(args[2], nullptr, hexbase));
     op->Size = sizeof(XAie_Write32Hdr);
   }
 
@@ -198,8 +197,8 @@ public:
 
     auto op = reinterpret_cast<XAie_MaskPoll32Hdr *>(m_op);
     op->RegOff = std::stoull(regoff, nullptr, hexbase);
-    op->Mask = (uint32_t)std::stoul(args[idx++], nullptr, hexbase);
-    op->Value = (uint32_t)std::stoul(args[idx++], nullptr, hexbase);
+    op->Mask = static_cast<uint32_t>(std::stoul(args[idx++], nullptr, hexbase));
+    op->Value = static_cast<uint32_t>(std::stoul(args[idx++], nullptr, hexbase));
     op->Size = sizeof(XAie_MaskPoll32Hdr);
   }
 
@@ -247,9 +246,9 @@ public:
     initialize_OpHdr();
 
     auto op = reinterpret_cast<XAie_LoadPdiHdr *>(m_op);
-    op->PdiId = (uint16_t)std::stoul(args[0], nullptr, hexbase);
-    op->PdiSize = boost::lexical_cast<uint16_t>(args[1]);
-    op->PdiAddress = (uint64_t)std::stoull(args[2], nullptr, hexbase);
+    op->PdiId = static_cast<uint16_t>(std::stoul(args[0], nullptr, hexbase));
+    op->PdiSize = static_cast<uint16_t>(std::stoul(args[1], nullptr, 0));
+    op->PdiAddress = static_cast<uint64_t>(std::stoull(args[2], nullptr, hexbase));
   }
 
   [[nodiscard]] size_t get_op_base_size() const override {
@@ -266,11 +265,11 @@ public:
     initialize_OpHdr();
 
     auto op = reinterpret_cast<XAie_PmLoadHdr *>(m_op);
-    const auto load_seq = (uint32_t)std::stoul(args[0], nullptr, hexbase);
+    const auto load_seq = static_cast<uint32_t>(std::stoul(args[0], nullptr, hexbase));
     for (unsigned int i = 0; i < 3; i++) {
-      op->LoadSequenceCount[i] = (uint8_t)((load_seq >> i) & 0xff);
+      op->LoadSequenceCount[i] = static_cast<uint8_t>((load_seq >> i) & 0xff);
     }
-    op->PmLoadId = (uint32_t)std::stoul(args[1]);
+    op->PmLoadId = static_cast<uint32_t>(std::stoul(args[1]));
   }
 
   [[nodiscard]] size_t get_op_base_size() const override {
@@ -290,8 +289,8 @@ public:
     op->Size = m_size;
 
     auto values = get_extended_storage<tct_op_t>();
-    values->word = (uint32_t)std::stoul(args[0], nullptr, hexbase);
-    values->config = (uint32_t)std::stoul(args[1], nullptr, hexbase);
+    values->word = static_cast<uint32_t>(std::stoul(args[0], nullptr, hexbase));
+    values->config = static_cast<uint32_t>(std::stoul(args[1], nullptr, hexbase));
   }
 
   [[nodiscard]] size_t get_op_base_size() const override {


### PR DESCRIPTION
#### Problem solved by the commit
No clear reason why boost::lexical_cast was cased.  Presumbly the size can be on decimal or hex, so using base=0 for std::stoul.

Also replace all c-style casts with static_cast.

#### Risks (if any) associated the changes in the commit
Not understanding the reason why boost::lexical_cast was used.

