### PR TITLE
Reorganize CMake files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,101 +1,9 @@
 # SPDX-License-Identifier: MIT
-# Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
-
+# Copyright (C) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.
 cmake_minimum_required(VERSION 3.18.0)
-
 project(AIEBU HOMEPAGE_URL https://gitenterprise.xilinx.com/XRT/aiebu)
 
-if (NOT(AIEBU_GIT_SUBMODULE))
-  if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-    set(CMAKE_INSTALL_PREFIX "/opt/xilinx")
-  else()
-    set(CMAKE_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}/xilinx" CACHE PATH "..." FORCE)
-  endif()
-endif()
-
-set(Boost_USE_STATIC_LIBS ON)
-INCLUDE (FindBoost)
-message("-- Boost version: ${Boost_VERSION}")
-find_package(Boost REQUIRED)
-
-include (cmake/settings.cmake)
-include (cmake/utils.cmake)
-
-message("-- CMAKE_SYSTEM=${CMAKE_SYSTEM}")
-message("-- CMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}")
-
-# This flag is set to enable legacy linking in windows
-# If this is not set, aiebu will have hybrid linking
-message("-- AIEBU_MSVC_LEGACY_LINKING=${AIEBU_MSVC_LEGACY_LINKING}")
-
-# If this repository is used as a submodule, the parent repository may set the
-# following variables in CMake to make aiebu point to the parents copy of ELFIO
-# and/or AIE-RT. e.g, XRT parent repository can set the following in its CMake
-# for aiebu to inherit it:
-# set(AIEBU_AIE_RT_BIN_DIR ${XRT_BINARY_DIR})
-# set(AIEBU_ELFIO_SRC_DIR "${XRT_SOURCE_DIR}/src/runtime_src/core/common/elf")
-
-# These variables may be defined by the parent project as it may also include
-# AIE-RT and or ELFIO as a submodule
-# AIEBU_AIE_RT_BIN_DIR, AIEBU_AIE_RT_HEADER_DIR and AIEBU_ELFIO_SRC_DIR
-
-if (NOT (DEFINED AIEBU_AIE_RT_BIN_DIR))
-  set(AIEBU_AIE_RT_BIN_DIR ${AIEBU_BINARY_DIR})
-endif()
-
-if (NOT (DEFINED AIEBU_AIE_RT_HEADER_DIR))
-  set(AIEBU_AIE_RT_HEADER_DIR "${AIEBU_BINARY_DIR}/lib/aie-rt/driver/driver-src/include")
-endif()
-
-message("-- Using aie-rt headers from ${AIEBU_AIE_RT_HEADER_DIR}")
-message("-- Using aie-rt build from ${AIEBU_AIE_RT_BIN_DIR}")
-
-if (NOT (DEFINED AIEBU_ELFIO_SRC_DIR))
-  set(AIEBU_ELFIO_SRC_DIR "${AIEBU_SOURCE_DIR}/src/cpp/ELFIO")
-endif()
-
-message("-- Using ELFIO from ${AIEBU_ELFIO_SRC_DIR}")
-
-if (AIEBU_FULL STREQUAL "ON")
-  add_compile_options(-DAIEBU_FULL)
-
-  find_program (PYLINT pylint REQUIRED)
-  message("-- Pylint path: ${PYLINT}")
-
-  find_package(Python3 COMPONENTS Interpreter REQUIRED)
-  message("-- Python version: ${Python3_VERSION}")
-endif()
-
-if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-  find_package(PkgConfig REQUIRED)
-
-  pkg_check_modules(LIBELF REQUIRED libelf)
-  message("-- Libelf version: ${LIBELF_VERSION}")
-
-  if (AIEBU_FULL STREQUAL "ON")
-    find_program (READELF eu-readelf REQUIRED)
-    message("-- Readelf path: ${READELF}")
-  endif()
-endif()
-
-
-if (XRT_CLANG_TIDY STREQUAL "ON")
-  find_program(CLANG_TIDY "clang-tidy")
-  if(NOT CLANG_TIDY)
-    message("clang-tidy not found, cannot enable static analysis")
-  else()
-    message("-- Enabling clang-tidy")
-    set(CMAKE_CXX_CLANG_TIDY "clang-tidy")
-  endif()
-endif()
-
-if (AIEBU_GIT_SUBMODULE)
-  enable_testing()
-else()
-  # This enables valgrind but we should not include (CTest) when we are a submodule
-  # as it may conflict with configurations of the parent project
-  include (CTest)
-endif()
+include(cmake/settings.cmake)
 
 add_subdirectory(src/cpp/aiebu)
 
@@ -108,15 +16,4 @@ endif()
 add_subdirectory(lib)
 add_subdirectory(test)
 
-SET(PACKAGE_KIND "TGZ")
-SET(CPACK_GENERATOR "TGZ")
-message("-- ${CMAKE_BUILD_TYPE} ${PACKAGE_KIND} package")
-
-SET(CPACK_PACKAGE_VENDOR "Advanced Micro Devices Inc.")
-SET(CPACK_PACKAGE_CONTACT "runtimeca39d@amd.com")
-SET(CPACK_PACKAGE_DESCRIPTION_SUMMARY "AMD XDNA binutils package")
-SET(CPACK_RESOURCE_FILE_LICENSE "${AIEBU_SOURCE_DIR}/LICENSE")
-
-include (cmake/findpackage.cmake)
-
-INCLUDE(CPack)
+include(cmake/cpack.cmake)

--- a/cmake/boost.cmake
+++ b/cmake/boost.cmake
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+if(POLICY CMP0144)
+  cmake_policy(SET CMP0144 NEW)
+endif()
+
+# We use header only libraries
+find_package(Boost REQUIRED)
+message("-- Boost version: ${Boost_VERSION}")
+message("-- Boost include dir:${Boost_INCLUDE_DIRS}")
+
+# Some later versions of boost spews warnings form property_tree
+# but can be disabled with this setting
+add_compile_options("-DBOOST_BIND_GLOBAL_PLACEHOLDERS")
+include_directories(${Boost_INCLUDE_DIRS})

--- a/cmake/clang-tidy.cmake
+++ b/cmake/clang-tidy.cmake
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+if (XRT_CLANG_TIDY STREQUAL "ON")
+  find_program(CLANG_TIDY "clang-tidy")
+  if(NOT CLANG_TIDY)
+    message("clang-tidy not found, cannot enable static analysis")
+  else()
+    message("-- Enabling clang-tidy")
+    set(CMAKE_CXX_CLANG_TIDY "clang-tidy")
+  endif()
+endif()

--- a/cmake/cpack.cmake
+++ b/cmake/cpack.cmake
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+set(PACKAGE_KIND "TGZ")
+set(CPACK_GENERATOR "TGZ")
+message("-- ${CMAKE_BUILD_TYPE} ${PACKAGE_KIND} package")
+
+set(CPACK_PACKAGE_VENDOR "Advanced Micro Devices Inc.")
+set(CPACK_PACKAGE_CONTACT "runtimeca39d@amd.com")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "AMD XDNA binutils package")
+set(CPACK_RESOURCE_FILE_LICENSE "${AIEBU_SOURCE_DIR}/LICENSE")
+
+include(cmake/findpackage.cmake)
+include(CPack)

--- a/cmake/depends.cmake
+++ b/cmake/depends.cmake
@@ -32,8 +32,21 @@ file(REMOVE "${CMAKE_ARGV4}")
 execute_process(
   COMMAND ${DEPENDS_TOOL} ${DEPENDS_TOOL_SWITCH1} ${DEPENDS_TOOL_SWITCH2} ${CMAKE_ARGV3}
   OUTPUT_VARIABLE DEPENDS_OUT
-)
+  )
 
-message("${CMAKE_ARGV3}:\n${DEPENDS_OUT}")
+# For static executables DEPENDS_OUT is empty, here we make
+# sure the files has at least one line output
 file(WRITE ${CMAKE_ARGV4} "${CMAKE_ARGV3}:\n")
 file(APPEND ${CMAKE_ARGV4} "${DEPENDS_OUT}")
+
+# Fail if there are dynamic dependencies
+# This check only works on Linux
+if (DEPENDS_OUT MATCHES "=>")
+  message(FATAL_ERROR "Dynamic dependencies found for ${CMAKE_ARGV3}:\n${DEPENDS_OUT}")
+else()
+  message(STATUS "No dynamic dependencies found")
+endif()
+
+if (WIN32)
+  message("${CMAKE_ARGV3}:\n${DEPENDS_OUT}")
+endif()

--- a/cmake/linux.cmake
+++ b/cmake/linux.cmake
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+find_package(PkgConfig REQUIRED)
+
+pkg_check_modules(LIBELF REQUIRED libelf)
+message("-- Libelf version: ${LIBELF_VERSION}")
+
+if (AIEBU_FULL STREQUAL "ON")
+  find_program (READELF eu-readelf REQUIRED)
+  message("-- Readelf path: ${READELF}")
+endif()
+
+add_compile_options(-Wall -Wextra -Werror)

--- a/cmake/python.cmake
+++ b/cmake/python.cmake
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+if (AIEBU_FULL STREQUAL "ON")
+  find_program (PYLINT pylint REQUIRED)
+  message("-- Pylint path: ${PYLINT}")
+
+  find_package(Python3 COMPONENTS Interpreter REQUIRED)
+  message("-- Python version: ${Python3_VERSION}")
+endif()

--- a/cmake/settings.cmake
+++ b/cmake/settings.cmake
@@ -1,16 +1,29 @@
-# --- version settings ---
-
-set(AIEBU_INSTALL_DIR "aiebu")
-
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+################################################################
+# Version settings
+################################################################
 set(AIEBU_VERSION_RELEASE 202510)
 SET(AIEBU_VERSION_MAJOR 1)
 SET(AIEBU_VERSION_MINOR 0)
 
+if (DEFINED $ENV{AIEBU_VERSION_PATCH})
+  SET(AIEBU_VERSION_PATCH $ENV{AIEBU_VERSION_PATCH})
+else(DEFINED $ENV{AIEBU_VERSION_PATCH})
+  SET(AIEBU_VERSION_PATCH 0)
+endif(DEFINED $ENV{AIEBU_VERSION_PATCH})
+
+# Also update cache to set version for external plug-in .so
+set(AIEBU_SOVERSION ${AIEBU_VERSION_MAJOR} CACHE INTERNAL "")
+set(AIEBU_VERSION_STRING ${AIEBU_VERSION_MAJOR}.${AIEBU_VERSION_MINOR}.${AIEBU_VERSION_PATCH} CACHE INTERNAL "")
+
+################################################################
 # Standard code snippet to identify parent project if we are a submodule
+################################################################
 set(AIEBU_GIT_SUBMODULE FALSE)
 
 find_package(Git)
@@ -28,20 +41,67 @@ if(GIT_FOUND)
     set(AIEBU_GIT_SUBMODULE TRUE)
   endif()
 endif()
+################################################################
 
-set(AIEBU_SPECIFICATION_INSTALL_DIR "aiebu/share/specification")
+################################################################
+# Install directories
+################################################################
+if (NOT(AIEBU_GIT_SUBMODULE))
+  if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+    set(CMAKE_INSTALL_PREFIX "/opt/xilinx")
+  else()
+    set(CMAKE_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}/xilinx" CACHE PATH "..." FORCE)
+  endif()
+endif()
 
-if (DEFINED $ENV{AIEBU_VERSION_PATCH})
-  SET(AIEBU_VERSION_PATCH $ENV{AIEBU_VERSION_PATCH})
-else(DEFINED $ENV{AIEBU_VERSION_PATCH})
-  SET(AIEBU_VERSION_PATCH 0)
-endif(DEFINED $ENV{AIEBU_VERSION_PATCH})
+set(AIEBU_INSTALL_DIR "aiebu")
+set(AIEBU_INSTALL_BIN_DIR           "${AIEBU_INSTALL_DIR}/bin")
+set(AIEBU_INSTALL_LIB_DIR           "${AIEBU_INSTALL_DIR}/lib")
+set(AIEBU_INSTALL_INCLUDE_DIR       "${AIEBU_INSTALL_DIR}/include")
+set(AIEBU_PYTHON_INSTALL_DIR        "${AIEBU_INSTALL_DIR}/lib/python3")
+set(AIEBU_SPECIFICATION_INSTALL_DIR "${AIEBU_INSTALL_DIR}/share/specification")
 
-# Also update cache to set version for external plug-in .so
-set(AIEBU_SOVERSION ${AIEBU_VERSION_MAJOR} CACHE INTERNAL "")
-set(AIEBU_VERSION_STRING ${AIEBU_VERSION_MAJOR}.${AIEBU_VERSION_MINOR}.${AIEBU_VERSION_PATCH} CACHE INTERNAL "")
+# If this repository is used as a submodule, the parent repository may
+# set the following variables in CMake to make aiebu point to the
+# parents copy of ELFIO and/or AIE-RT. e.g, XRT parent repository can
+# set the following in its CMake for aiebu to inherit it:
+# set(AIEBU_AIE_RT_BIN_DIR ${XRT_BINARY_DIR})
+# set(AIEBU_ELFIO_SRC_DIR"${XRT_SOURCE_DIR}/src/runtime_src/core/common/elf")
 
-# Some later versions of boost spews warnings form property_tree
-# Default embedded boost is 1.74.0 which does spew warnings so
-# making this defined global
-add_compile_options("-DBOOST_BIND_GLOBAL_PLACEHOLDERS")
+# These variables may be defined by the parent project as it may also
+# include AIE-RT and or ELFIO as a submodule AIEBU_AIE_RT_BIN_DIR,
+# AIEBU_AIE_RT_HEADER_DIR and AIEBU_ELFIO_SRC_DIR
+if (NOT (DEFINED AIEBU_AIE_RT_BIN_DIR))
+  set(AIEBU_AIE_RT_BIN_DIR ${AIEBU_BINARY_DIR})
+endif()
+
+if (NOT (DEFINED AIEBU_AIE_RT_HEADER_DIR))
+  set(AIEBU_AIE_RT_HEADER_DIR "${AIEBU_BINARY_DIR}/lib/aie-rt/driver/driver-src/include")
+endif()
+
+message("-- Using aie-rt headers from ${AIEBU_AIE_RT_HEADER_DIR}")
+message("-- Using aie-rt build from ${AIEBU_AIE_RT_BIN_DIR}")
+
+if (NOT (DEFINED AIEBU_ELFIO_SRC_DIR))
+  set(AIEBU_ELFIO_SRC_DIR "${AIEBU_SOURCE_DIR}/src/cpp/ELFIO")
+endif()
+
+message("-- Using ELFIO from ${AIEBU_ELFIO_SRC_DIR}")
+################################################################
+# Global compile options
+################################################################
+if (AIEBU_FULL STREQUAL "ON")
+  add_compile_options(-DAIEBU_FULL)
+endif()
+
+if (MSVC)
+  include(cmake/windows.cmake)
+else()
+  include(cmake/linux.cmake)
+endif()
+
+include(cmake/utils.cmake)
+include(cmake/boost.cmake)
+include(cmake/clang-tidy.cmake)
+include(cmake/python.cmake)
+include(cmake/test.cmake)

--- a/cmake/test.cmake
+++ b/cmake/test.cmake
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+if (AIEBU_GIT_SUBMODULE)
+  enable_testing()
+else()
+  # This enables valgrind but we should not include (CTest) when we
+  # are a submodule as it may conflict with configurations of the
+  # parent project
+  include (CTest)
+endif()

--- a/cmake/windows.cmake
+++ b/cmake/windows.cmake
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+
+# This flag is set to enable legacy linking in windows
+# If this is not set, aiebu will have hybrid linking
+message("-- AIEBU_MSVC_LEGACY_LINKING=${AIEBU_MSVC_LEGACY_LINKING}")
+
+if (NOT AIEBU_MSVC_LEGACY_LINKING)
+  add_compile_options(/MT$<$<CONFIG:Debug>:d>  # static linking with the CRT
+    )
+  add_link_options(
+    /NODEFAULTLIB:libucrt$<$<CONFIG:Debug>:d>.lib  # Hybrid CRT
+    /DEFAULTLIB:ucrt$<$<CONFIG:Debug>:d>.lib       # Hybrid
+    )
+endif()
+
+add_compile_options(
+  /Zc:__cplusplus
+  /WX           # treat warnings as errors
+  /W2           # warning level
+  /Zi           # generate pdb files even in release mode
+  /sdl          # enable security checks
+  /Qspectre     # compile with the Spectre mitigations switch
+  /ZH:SHA_256   # enable secure source code hashing
+  /guard:cf     # enable compiler control guard feature (CFG) to prevent attackers from redirecting execution to unsafe locations
+  )
+add_link_options(
+  /DEBUG      # instruct linker to create debugging info
+  /guard:cf   # enable linker control guard feature (CFG) to prevent attackers from redirecting execution to unsafe locations
+  /CETCOMPAT  # enable Control-flow Enforcement Technology (CET) Shadow Stack mitigation
+  )

--- a/lib/src/CMakeLists.txt
+++ b/lib/src/CMakeLists.txt
@@ -12,6 +12,11 @@ file(MAKE_DIRECTORY ${GENERATOR_OUT_DIR})
 
 add_executable(${GENERATOR_EXE1} gen-preemption.cpp)
 
+# Argh, many folks don't know the difference between {0} and {}
+if (NOT MSVC)
+  target_compile_options(${GENERATOR_EXE1} PRIVATE -Wno-missing-field-initializers)
+endif()
+
 target_include_directories(
   ${GENERATOR_EXE1}
   PRIVATE
@@ -89,6 +94,11 @@ install(FILES ${GENERATOR_OUT_DIR}/preempt_restore_stx_4x1.bin
 set(GENERATOR_EXE2 "copy")
 
 add_executable(${GENERATOR_EXE2} gen-copy.cpp)
+
+# Argh, many folks don't know the difference between {0} and {}
+if (NOT MSVC)
+  target_compile_options(${GENERATOR_EXE2} PRIVATE -Wno-missing-field-initializers)
+endif()
 
 target_include_directories(
   ${GENERATOR_EXE2}

--- a/lib/src/gen-copy.cpp
+++ b/lib/src/gen-copy.cpp
@@ -214,7 +214,7 @@ static void generate_tran_and_elf(const std::string &filename, int type)
                 XAIE_MEM_TILE_NUM_ROWS,
                 XAIE_AIE_TILE_ROW_START,
                 XAIE_AIE_TILE_NUM_ROWS,
-                {0}
+                {}
         };
 
         // Declare and initialize device instance

--- a/lib/src/gen-preemption.cpp
+++ b/lib/src/gen-preemption.cpp
@@ -493,7 +493,7 @@ static std::vector<uint8_t> generate_tran(uint8_t device, enum PreemptOp type, u
         XAIE_MEM_TILE_NUM_ROWS,
         XAIE_AIE_TILE_ROW_START,
         XAIE_AIE_TILE_NUM_ROWS,
-        {0}
+        {}
     };
 
     XAie_InstDeclare(DevInst, &ConfigPtr);
@@ -505,7 +505,7 @@ static std::vector<uint8_t> generate_tran(uint8_t device, enum PreemptOp type, u
     const uint8_t channels[] = {0, 1};
     uint8_t nchans = sizeof(channels) / sizeof(channels[0]);
     uint32_t size = data_sz / nchans;
-    MergeSync completion = {0};
+    MergeSync completion {};
     AieRC RC;
 
     for (uint8_t col = UINT8_C(0); col < ncol; col++) {

--- a/src/cpp/aiebu/.dir-locals.el
+++ b/src/cpp/aiebu/.dir-locals.el
@@ -3,7 +3,7 @@
   (tab-width . 2)
   (c-basic-offset . 2)
   (c-file-style . "stroustrup")
-  (fill-column . 120)
+  (fill-column . 80)
   (eval . (progn
 	    (c-set-offset 'innamespace '0)
 	    (c-set-offset 'inline-open '0)))

--- a/src/cpp/aiebu/CMakeLists.txt
+++ b/src/cpp/aiebu/CMakeLists.txt
@@ -1,19 +1,4 @@
 # SPDX-License-Identifier: MIT
-# Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
-if (MSVC)
-  add_compile_options(/WX /W2)
-  # Use Hybrid linking on Windows
-  if (NOT (AIEBU_MSVC_LEGACY_LINKING))
-    add_compile_options(/MT$<$<CONFIG:Debug>:d>  # static linking with the CRT
-      )
-    add_link_options(
-      /NODEFAULTLIB:libucrt$<$<CONFIG:Debug>:d>.lib  # Hybrid CRT
-      /DEFAULTLIB:ucrt$<$<CONFIG:Debug>:d>.lib       # Hybrid CRT
-      )
-  endif()
-else()
-  add_compile_options(-Wall -Wextra -Werror)
-endif()
-
+# Copyright (C) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.
 add_subdirectory(src)
 add_subdirectory(utils)

--- a/src/cpp/aiebu/src/CMakeLists.txt
+++ b/src/cpp/aiebu/src/CMakeLists.txt
@@ -18,6 +18,12 @@ add_library(aiebu_library_objects OBJECT
 target_include_directories(aiebu_library_objects
   PRIVATE
   ${AIEBU_AIE_RT_HEADER_DIR}
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  ${Boost_INCLUDE_DIRS}
+  ${AIEBU_BINARY_DIR}/lib
+  ${AIEBU_SOURCE_DIR}/src/cpp/ELFIO
+
+  # The following should be spelled out in code
   ${CMAKE_CURRENT_SOURCE_DIR}/include
   ${CMAKE_CURRENT_SOURCE_DIR}/preprocessor
   ${CMAKE_CURRENT_SOURCE_DIR}/preprocessor/aie2
@@ -30,8 +36,6 @@ target_include_directories(aiebu_library_objects
   ${CMAKE_CURRENT_SOURCE_DIR}/elf
   ${CMAKE_CURRENT_SOURCE_DIR}/elf/aie2
   ${AIEBU_BINARY_DIR}/lib/gen
-  ${AIEBU_SOURCE_DIR}/src/cpp/ELFIO/
-  ${Boost_INCLUDE_DIRS}
   )
 
 set_target_properties(aiebu_library_objects PROPERTIES

--- a/src/cpp/aiebu/src/CMakeLists.txt
+++ b/src/cpp/aiebu/src/CMakeLists.txt
@@ -1,39 +1,22 @@
 # SPDX-License-Identifier: MIT
-# Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
-
-set(AIEBU_INSTALL_BIN_DIR       "${AIEBU_INSTALL_DIR}/bin")
-set(AIEBU_INSTALL_LIB_DIR       "${AIEBU_INSTALL_DIR}/lib")
-set(AIEBU_INSTALL_INCLUDE_DIR       "${AIEBU_INSTALL_DIR}/include")
-set(GENERATOR_OUT_DIR "${AIEBU_BINARY_DIR}/lib/gen")
-
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
-file(GLOB_RECURSE AIEBU_CPP_FILES "*.cpp")
-
-if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-  list(FILTER AIEBU_CPP_FILES EXCLUDE REGEX "windows/*")
-endif()
-
-list(FILTER AIEBU_CPP_FILES EXCLUDE REGEX "windows/uid_md5.cpp")
-
-if (AIEBU_FULL STREQUAL "OFF")
-  list(FILTER AIEBU_CPP_FILES EXCLUDE REGEX "/aie2ps/*")
-  list(FILTER AIEBU_CPP_FILES EXCLUDE REGEX "/pager.cpp")
-endif()
-
-message("-- AIEBU_CPP_FILES: ${AIEBU_CPP_FILES}")
-
-set(CMAKE_CXX_VISIBILITY_PRESET hidden)
-set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 add_library(aiebu_library_objects OBJECT
-  ${AIEBU_CPP_FILES}
+  analyzer/reporter.cpp
+  analyzer/transaction.cpp
+  assembler/aiebu_assembler.cpp
+  assembler/assembler.cpp
+  common/aiebu_error.cpp
+  common/writer.cpp
+  common/assembler_state.cpp
+  elf/elfwriter.cpp
+  preprocessor/aie2/aie2_blob_preprocessor_input.cpp
+  preprocessor/aie2/aie2_asm_preprocessor_input.cpp
+  preprocessor/asm/asm_parser.cpp
+  ops/ops.cpp
   )
 
-add_dependencies(aiebu_library_objects ctrlcodelib)
-
-target_include_directories(aiebu_library_objects PRIVATE
+target_include_directories(aiebu_library_objects
+  PRIVATE
   ${AIEBU_AIE_RT_HEADER_DIR}
   ${CMAKE_CURRENT_SOURCE_DIR}/include
   ${CMAKE_CURRENT_SOURCE_DIR}/preprocessor
@@ -46,10 +29,34 @@ target_include_directories(aiebu_library_objects PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/assembler
   ${CMAKE_CURRENT_SOURCE_DIR}/elf
   ${CMAKE_CURRENT_SOURCE_DIR}/elf/aie2
-  ${GENERATOR_OUT_DIR}
+  ${AIEBU_BINARY_DIR}/lib/gen
   ${AIEBU_SOURCE_DIR}/src/cpp/ELFIO/
   ${Boost_INCLUDE_DIRS}
   )
+
+set_target_properties(aiebu_library_objects PROPERTIES
+  CXX_VISIBILITY_PRESET hidden
+  POSITION_INDEPENDENT_CODE ON
+  )
+
+add_dependencies(aiebu_library_objects ctrlcodelib)
+
+if (AIEBU_FULL STREQUAL "ON")
+  target_sources(aiebu_library_objects
+    PRIVATE
+    encoder/aie2ps/aie2ps_encoder.cpp
+    preprocessor/aie2ps/aie2ps_preprocessor_input.cpp
+    preprocessor/asm/pager.cpp
+    )
+  target_include_directories(aiebu_library_objects
+    PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/preprocessor/aie2ps
+    ${CMAKE_CURRENT_SOURCE_DIR}/encoder/aie2ps
+    ${CMAKE_CURRENT_SOURCE_DIR}/elf/aie2ps
+    ${CMAKE_CURRENT_BINARY_DIR}/../../../python/
+    )
+  add_dependencies(aiebu_library_objects cpp-assembler-stubs)
+endif()
 
 add_library(aiebu SHARED
   $<TARGET_OBJECTS:aiebu_library_objects>
@@ -66,21 +73,6 @@ if (MSVC)
   target_link_libraries(aiebu_static advapi32)
 endif()
 
-#target_link_libraries(aiebu_static xaiengine)
-
-
-if (AIEBU_FULL STREQUAL "ON")
-  target_include_directories(aiebu_library_objects PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/preprocessor/aie2ps
-    ${CMAKE_CURRENT_SOURCE_DIR}/encoder/aie2ps
-    ${CMAKE_CURRENT_SOURCE_DIR}/elf/aie2ps
-    ${CMAKE_CURRENT_BINARY_DIR}/../../../python/
-  )
-
-  add_dependencies(aiebu_library_objects cpp-assembler-stubs)
-endif()
-
-
 install (TARGETS aiebu
   LIBRARY DESTINATION ${AIEBU_INSTALL_LIB_DIR}
   RUNTIME DESTINATION ${AIEBU_INSTALL_BIN_DIR}
@@ -91,9 +83,10 @@ install (TARGETS aiebu aiebu_static
   LIBRARY DESTINATION ${AIEBU_INSTALL_LIB_DIR}
 )
 
-install(
-  FILES
-  include/aiebu.h include/aiebu_assembler.h include/aiebu_error.h
+install(FILES
+  include/aiebu.h
+  include/aiebu_assembler.h
+  include/aiebu_error.h
   DESTINATION ${AIEBU_INSTALL_INCLUDE_DIR}
   CONFIGURATIONS Debug Release COMPONENT Runtime
 )

--- a/src/cpp/aiebu/utils/asm/CMakeLists.txt
+++ b/src/cpp/aiebu/utils/asm/CMakeLists.txt
@@ -1,77 +1,48 @@
 # SPDX-License-Identifier: MIT
-# Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.
+add_library(aiebu_asm_objects OBJECT
+  asm.cpp
+  ${AIEBU_SOURCE_DIR}/src/cpp/aiebu/utils/target/target.cpp
+  ${AIEBU_SOURCE_DIR}/src/cpp/aiebu/utils/common/utils.cpp
+  )
 
-set(GENERATOR_OUT_DIR "${AIEBU_BINARY_DIR}/lib/gen")
-set(AIEBU_INSTALL_BINARY_DIR "${AIEBU_INSTALL_DIR}/bin/")
-set(ASM_TGT "aiebu-asm")
-list(APPEND TGT_LIST ${ASM_TGT})
+target_include_directories(aiebu_asm_objects
+  PRIVATE
+  ${AIEBU_SOURCE_DIR}/src/cpp/aiebu/src
+  ${Boost_INCLUDE_DIRS}
+
+  # these should be spelled out in source code
+  ${AIEBU_SOURCE_DIR}/src/cpp/aiebu/src/include
+  ${AIEBU_SOURCE_DIR}/src/cpp/aiebu/src/assembler
+  ${AIEBU_SOURCE_DIR}/src/cpp/aiebu/utils/common
+  ${AIEBU_SOURCE_DIR}/src/cpp/aiebu/utils/target
+  ${AIEBU_SOURCE_DIR}/src/cpp/cxxopts/include
+  )
+
+add_executable(aiebu-asm $<TARGET_OBJECTS:aiebu_asm_objects>)
+target_link_libraries(aiebu-asm PRIVATE aiebu_static)
 
 if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+  target_link_options(aiebu-asm PRIVATE "-static")
+  set_target_properties(aiebu-asm PROPERTIES INSTALL_RPATH "" BUILD_RPATH "")
+
   # Create a dynamically linked executable. aiebu-asm-dyn, on Linux for running
   # valgrind, etc. This binary is not released for deployment but only used for
-  # internal testing. Note that valgrind known to report many glibc related errors
-  # when running with fully statically linked executables, hence the dynamically
-  # linked binary for testing
-  set(ASM_TGT_DYN "aiebu-asm-dyn")
-  list(APPEND TGT_LIST ${ASM_TGT_DYN})
+  # internal testing. Note that valgrind known to report many glibc related
+  # errors when running with fully statically linked executables, hence the
+  # dynamically linked binary for testing
+  add_executable(aiebu-asm-dyn $<TARGET_OBJECTS:aiebu_asm_objects>)
+  target_link_libraries(aiebu-asm-dyn PRIVATE aiebu_static)
 endif()
 
-set(TARGET_DEPENDS_LIST_FILE "${ASM_TGT}_depends.txt")
-
-foreach(TGT ${TGT_LIST})
-  add_executable(${TGT}
-    asm.cpp
-    ${AIEBU_SOURCE_DIR}/src/cpp/aiebu/utils/target/target.cpp
-    ${AIEBU_SOURCE_DIR}/src/cpp/aiebu/utils/common/utils.cpp
+# This custom target fails if aiebu-asm has any dynamic dependencies
+add_custom_target(check_dynamic_deps ALL
+  COMMAND ${CMAKE_COMMAND} -E echo "Checking for dynamic dependencies ..."
+  COMMAND ${CMAKE_COMMAND} -P "${AIEBU_SOURCE_DIR}/cmake/depends.cmake" $<TARGET_FILE:aiebu-asm> aiebu-asm_depends.txt
+  DEPENDS aiebu-asm
   )
 
-  if ((${CMAKE_SYSTEM_NAME} STREQUAL "Linux") AND (${TGT} STREQUAL "aiebu-asm"))
-    # Static linking on Linux
-    target_link_options(${TGT} PRIVATE "-static")
-    set_target_properties(${ASM_TGT} PROPERTIES INSTALL_RPATH "" BUILD_RPATH "")
-  endif()
-
-  if (MSVC AND (NOT (AIEBU_MSVC_LEGACY_LINKING)))
-    # Hybrid linking on Windows
-    target_compile_options(${TGT}
-      PRIVATE
-      /MT$<$<CONFIG:Debug>:d>  # static linking with the CRT
-      )
-    target_link_options(${TGT}
-      PRIVATE
-      /NODEFAULTLIB:libucrt$<$<CONFIG:Debug>:d>.lib  # Hybrid CRT
-      /DEFAULTLIB:ucrt$<$<CONFIG:Debug>:d>.lib       # Hybrid CRT
-      )
-  endif()
-
-  target_link_libraries(${TGT}
-    PRIVATE
-    aiebu_static
-  )
-
-  target_include_directories(${TGT} PRIVATE
-    ${AIEBU_SOURCE_DIR}/src/cpp/aiebu/src/include
-    ${AIEBU_SOURCE_DIR}/src/cpp/aiebu/src/assembler/
-    ${AIEBU_SOURCE_DIR}/src/cpp/aiebu/utils/common/
-    ${AIEBU_SOURCE_DIR}/src/cpp/aiebu/utils/target/
-    ${AIEBU_SOURCE_DIR}/src/cpp/cxxopts/include/
-    ${Boost_INCLUDE_DIRS}
-  )
-endforeach()
-
-add_custom_command(
-  OUTPUT "${TARGET_DEPENDS_LIST_FILE}"
-  COMMAND "${CMAKE_COMMAND}" -P "${AIEBU_SOURCE_DIR}/cmake/depends.cmake" $<TARGET_FILE:${ASM_TGT}> "${TARGET_DEPENDS_LIST_FILE}"
-  DEPENDS ${ASM_TGT}
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-)
-
-add_custom_target(
-  dependencylist ALL
-  DEPENDS ${TARGET_DEPENDS_LIST_FILE}
-)
-
-install(TARGETS ${ASM_TGT}
-  RUNTIME DESTINATION ${AIEBU_INSTALL_BINARY_DIR}
+install(TARGETS aiebu-asm
+  RUNTIME DESTINATION ${AIEBU_INSTALL_BIN_DIR}
   CONFIGURATIONS Debug Release COMPONENT Runtime
 )


### PR DESCRIPTION
#### Problem solved by the commit
CMake files are getting the way of making progress, see for example is
PR#158 on GE.  This is first attempt to restructure how cmake is
configured.

More PRs to come.

This PR amends #46 to include a rewrite of asm/CMakeLists.txt

- Leverage shared settings.
- Fail build if any asm dynamic dependencies.
- Prep for fewer include search paths.
