### PR TITLE
Add upload step for artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,3 +93,18 @@ jobs:
       if: runner.os == 'Windows'
       run: |
         cpack -G ZIP -B ${{github.workspace}}/build/Release -C Release --config build/Release/CPackConfig.cmake
+
+    - name: Upload (Linux)
+      if: runner.os == 'Linux' && (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
+      uses: actions/upload-artifact@v4
+      with:
+        name: aiebu_release_linux
+        path: ${{github.workspace}}/build/Release/AIEBU-*-Linux.tar.gz
+
+    - name: Upload (Windows)
+      if: runner.os == 'Linux' && (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
+      uses: actions/upload-artifact@v4
+      with:
+        name: aiebu_release_windows
+        path: ${{github.workspace}}/build/Release/AIEBU-*-win64.zip
+        retention-days: 7


### PR DESCRIPTION
Artifacts are uploaded when ci is run on schedule or dispatch, not on pull request.
