### PR TITLE
Remove dllexport from enum class that have nothing to export

### DIFF
--- a/src/cpp/aiebu/src/include/aiebu_assembler.h
+++ b/src/cpp/aiebu/src/include/aiebu_assembler.h
@@ -26,7 +26,7 @@ class aiebu_assembler {
 
   public:
 
-    enum class DRIVER_DLLESPEC buffer_type {
+    enum class buffer_type {
       blob_instr_dpu,
       blob_instr_prepost,
       blob_instr_transaction,


### PR DESCRIPTION
No clear indication why the enum class was improperly decorated with dllexport.

