### PR TITLE
Remove AIEBU_FULL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install pyyaml jinja2 Markdown pylint colorama gitPython wrapt
         cmake -B ${{github.workspace}}/build/Release \
-        -DAIEBU_FULL=ON \
         -DCMAKE_BUILD_TYPE=Release
 
     - name: Save Python Path for ise with CMake
@@ -69,7 +68,6 @@ jobs:
         # configure cmake specifying path to python
         cmake -B ${{github.workspace}}/build/Release `
         -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake `
-        -DAIEBU_FULL=ON `
         -DCMAKE_BUILD_TYPE=Release `
         -DPython3_EXECUTABLE=${{ env.PYTHON_EXECUTABLE }}
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,11 +7,6 @@ include(cmake/settings.cmake)
 
 add_subdirectory(src/cpp/aiebu)
 
-if (AIEBU_FULL STREQUAL "ON")
-  add_subdirectory(src/python)
-  add_subdirectory(scripts)
-endif()
-
 add_subdirectory(specification)
 
 add_subdirectory(lib)

--- a/build/build.sh
+++ b/build/build.sh
@@ -20,12 +20,6 @@ function compile {
     local build=$2
     local cmakeflags="-DCMAKE_BUILD_TYPE=$config"
 
-    if [[ $build == "aie2" ]]; then
-      cmakeflags="$cmakeflags -DAIEBU_FULL=OFF"
-    else
-      cmakeflags="$cmakeflags -DAIEBU_FULL=ON"
-    fi
-
     mkdir -p $config
     cd $config
     if [[ $config == "Debug" ]]; then
@@ -35,9 +29,6 @@ function compile {
     cmake $cmakeflags ../../
 
     make -j $CORE VERBOSE=1
-    if [[ $build != "aie2" ]]; then
-      make -j $CORE VERBOSE=1 isa-spec
-    fi
     make -j $CORE VERBOSE=1 install
     make -j $CORE VERBOSE=1 test
     make -j $CORE VERBOSE=1 test ARGS="-L memcheck -T memcheck"

--- a/build/build22.bat
+++ b/build/build22.bat
@@ -110,11 +110,6 @@ REM --------------------------------------------------------------------------
 :DebugBuild
 echo ====================== Windows Debug Build ============================
 set CMAKEFLAGS=%CMAKEFLAGS% -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=%BUILDDIR%/WDebug
-if [%AIEBU_BUILD%] == ["aie2"] (
-  set CMAKEFLAGS=%CMAKEFLAGS% -DAIEBU_FULL=OFF
-) else (
-  set CMAKEFLAGS=%CMAKEFLAGS% -DAIEBU_FULL=ON
-)
 
 ECHO CMAKEFLAGS=%CMAKEFLAGS%
 
@@ -147,11 +142,6 @@ REM --------------------------------------------------------------------------
 :ReleaseBuild
 ECHO ====================== Windows Release Build ============================
 set CMAKEFLAGS=%CMAKEFLAGS% -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=%BUILDDIR%/WRelease
-if [%AIEBU_BUILD%] == ["aie2"] (
-  set CMAKEFLAGS=%CMAKEFLAGS% -DAIEBU_FULL=OFF
-) else (
-  set CMAKEFLAGS=%CMAKEFLAGS% -DAIEBU_FULL=ON
-)
 ECHO CMAKEFLAGS=%CMAKEFLAGS%
 
 MKDIR %BUILDDIR%\WRelease
@@ -160,11 +150,6 @@ PUSHD %BUILDDIR%\WRelease
 if [%NOCMAKE%] == [0] (
    cmake -G "Visual Studio 17 2022" %CMAKEFLAGS% ../../
    IF errorlevel 1 (POPD & exit /B %errorlevel%)
-)
-
-if not [%AIEBU_BUILD%] == ["aie2"] (
-  cmake --build . --verbose --config Release --target cpp-assembler-stubs
-  IF errorlevel 1 (POPD & exit /B %errorlevel%)
 )
 
 cmake --build . --verbose --config Release

--- a/cmake/linux.cmake
+++ b/cmake/linux.cmake
@@ -5,9 +5,5 @@ find_package(PkgConfig REQUIRED)
 pkg_check_modules(LIBELF REQUIRED libelf)
 message("-- Libelf version: ${LIBELF_VERSION}")
 
-if (AIEBU_FULL STREQUAL "ON")
-  find_program (READELF eu-readelf REQUIRED)
-  message("-- Readelf path: ${READELF}")
-endif()
-
+find_program (READELF eu-readelf REQUIRED)
 add_compile_options(-Wall -Wextra -Werror)

--- a/cmake/python.cmake
+++ b/cmake/python.cmake
@@ -1,11 +1,9 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
-if (AIEBU_FULL STREQUAL "ON")
-  find_program (PYLINT pylint REQUIRED)
-  message("-- Pylint path: ${PYLINT}")
+find_program (PYLINT pylint REQUIRED)
+message("-- Pylint path: ${PYLINT}")
 
-  message("-- Python executable: ${Python3_EXECUTABLE}")
-  find_package(Python3 COMPONENTS Interpreter REQUIRED)
-  message("-- Python executable: ${Python3_EXECUTABLE}")
-  message("-- Python version: ${Python3_VERSION}")
-endif()
+message("-- Python executable: ${Python3_EXECUTABLE}")
+find_package(Python3 COMPONENTS Interpreter REQUIRED)
+message("-- Python executable: ${Python3_EXECUTABLE}")
+message("-- Python version: ${Python3_VERSION}")

--- a/cmake/settings.cmake
+++ b/cmake/settings.cmake
@@ -94,10 +94,6 @@ message("-- Using ELFIO from ${AIEBU_ELFIO_SRC_DIR}")
 ################################################################
 # Global compile options
 ################################################################
-if (AIEBU_FULL STREQUAL "ON")
-  add_compile_options(-DAIEBU_FULL)
-endif()
-
 if (MSVC)
   include(cmake/windows.cmake)
 else()

--- a/src/cpp/aiebu/src/CMakeLists.txt
+++ b/src/cpp/aiebu/src/CMakeLists.txt
@@ -47,21 +47,19 @@ set_target_properties(aiebu_library_objects PROPERTIES
 
 add_dependencies(aiebu_library_objects ctrlcodelib)
 
-if (AIEBU_FULL STREQUAL "ON")
-  target_sources(aiebu_library_objects
-    PRIVATE
-    encoder/aie2ps/aie2ps_encoder.cpp
-    preprocessor/aie2ps/aie2ps_preprocessor_input.cpp
-    preprocessor/asm/pager.cpp
-    )
-  target_include_directories(aiebu_library_objects
-    PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/preprocessor/aie2ps
-    ${CMAKE_CURRENT_SOURCE_DIR}/encoder/aie2ps
-    ${CMAKE_CURRENT_SOURCE_DIR}/elf/aie2ps
-    ${CMAKE_CURRENT_BINARY_DIR}
-    )
-endif()
+target_sources(aiebu_library_objects
+  PRIVATE
+  encoder/aie2ps/aie2ps_encoder.cpp
+  preprocessor/aie2ps/aie2ps_preprocessor_input.cpp
+  preprocessor/asm/pager.cpp
+  )
+target_include_directories(aiebu_library_objects
+  PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/preprocessor/aie2ps
+  ${CMAKE_CURRENT_SOURCE_DIR}/encoder/aie2ps
+  ${CMAKE_CURRENT_SOURCE_DIR}/elf/aie2ps
+  ${CMAKE_CURRENT_BINARY_DIR}
+  )
 
 add_library(aiebu SHARED
   $<TARGET_OBJECTS:aiebu_library_objects>

--- a/src/cpp/aiebu/src/assembler/aiebu_assembler.cpp
+++ b/src/cpp/aiebu/src/assembler/aiebu_assembler.cpp
@@ -51,13 +51,11 @@ aiebu_assembler(buffer_type type,
     aiebu::assembler a(assembler::elf_type::aie2_asm);
     elf_data = a.process(buffer1, libs, libpaths, patch_json, buffer2, ctrlpkt);
   }
-#ifdef AIEBU_FULL
   else if (type == buffer_type::asm_aie2ps)
   {
     aiebu::assembler a(assembler::elf_type::aie2ps_asm);
     elf_data = a.process(buffer1, libs, libpaths, patch_json);
   }
-#endif
   else {
     throw error(error::error_code::invalid_buffer_type, "Buffer_type not supported !!!");
   }

--- a/src/cpp/aiebu/src/assembler/assembler.cpp
+++ b/src/cpp/aiebu/src/assembler/assembler.cpp
@@ -6,12 +6,9 @@
 #include "aie2_asm_preprocessor.h"
 #include "aie2_blob_encoder.h"
 #include "aie2_blob_elfwriter.h"
-
-#ifdef AIEBU_FULL
 #include "aie2ps_preprocessor.h"
 #include "aie2ps_encoder.h"
 #include "aie2ps_elfwriter.h"
-#endif
 
 #include "aiebu_error.h"
 
@@ -45,7 +42,6 @@ assembler(const elf_type type)
     m_elfwriter = std::make_unique<aie2_blob_elf_writer>();
     m_ppi = std::make_shared<aie2_asm_preprocessor_input>();
   }
-#ifdef AIEBU_FULL
   else if (type == elf_type::aie2ps_asm)
   {
     m_preprocessor = std::make_unique<aie2ps_preprocessor>();
@@ -53,7 +49,6 @@ assembler(const elf_type type)
     m_elfwriter = std::make_unique<aie2ps_elf_writer>();
     m_ppi = std::make_shared<aie2ps_preprocessor_input>();
   }
-#endif
   else {
     throw error(error::error_code::invalid_buffer_type ,"Invalid elf type!!!");
   }

--- a/src/cpp/aiebu/src/assembler/assembler.h
+++ b/src/cpp/aiebu/src/assembler/assembler.h
@@ -28,9 +28,7 @@ public:
   {
     aie2_transaction_blob,
     aie2_dpu_blob,
-#ifdef AIEBU_FULL
     aie2ps_asm,
-#endif
     aie2_asm
   };
 

--- a/src/cpp/aiebu/src/include/aiebu.h
+++ b/src/cpp/aiebu/src/include/aiebu.h
@@ -31,9 +31,7 @@ enum aiebu_assembler_buffer_type {
   aiebu_assembler_buffer_type_blob_instr_prepost,
   aiebu_assembler_buffer_type_blob_instr_transaction,
   aiebu_assembler_buffer_type_blob_control_packet,
-#ifdef AIEBU_FULL
   aiebu_assembler_buffer_type_asm_aie2ps
-#endif
 };
 
 struct pm_ctrlpkt {

--- a/src/cpp/aiebu/src/include/aiebu_assembler.h
+++ b/src/cpp/aiebu/src/include/aiebu_assembler.h
@@ -31,9 +31,7 @@ class aiebu_assembler {
       blob_instr_prepost,
       blob_instr_transaction,
       blob_control_packet,
-#ifdef AIEBU_FULL
       asm_aie2ps,
-#endif
       asm_aie2
     };
 

--- a/src/cpp/aiebu/utils/asm/asm.cpp
+++ b/src/cpp/aiebu/utils/asm/asm.cpp
@@ -28,11 +28,7 @@ void main_helper(int argc, char** argv,
       .allow_unrecognised_options()
       .add_options()
       ("h,help", "show help message and exit", cxxopts::value<bool>()->default_value("false"))
-#ifdef AIEBU_FULL
       ("t,target", "supported targets aie2ps/aie2asm/aie2txn/aie2dpu", cxxopts::value<decltype(target_name)>())
-#else
-      ("t,target", "supported targets aie2txn/aie2dpu/aie2asm", cxxopts::value<decltype(target_name)>())
-#endif
     ;
 
     auto result = global_options.parse(argc, argv);
@@ -82,9 +78,7 @@ int main( int argc, char** argv )
   const std::string executable = "aiebu-asm";
 
   {
-#ifdef AIEBU_FULL
     targets.emplace_back(std::make_shared<aiebu::utilities::target_aie2ps>(executable));
-#endif
     targets.emplace_back(std::make_shared<aiebu::utilities::target_aie2>(executable));
     targets.emplace_back(std::make_shared<aiebu::utilities::target_aie2blob_transaction>(executable));
     targets.emplace_back(std::make_shared<aiebu::utilities::target_aie2blob_dpu>(executable));

--- a/src/cpp/aiebu/utils/target/target.cpp
+++ b/src/cpp/aiebu/utils/target/target.cpp
@@ -191,7 +191,6 @@ target_aie2::assemble(const sub_cmd_options &_options)
   }
 }
 
-#ifdef AIEBU_FULL
 void
 aiebu::utilities::
 target_aie2ps::assemble(const sub_cmd_options &_options)
@@ -263,4 +262,3 @@ target_aie2ps::assemble(const sub_cmd_options &_options)
     throw std::runtime_error(errMsg.str());
   }
 }
-#endif

--- a/src/cpp/aiebu/utils/target/target.h
+++ b/src/cpp/aiebu/utils/target/target.h
@@ -61,7 +61,6 @@ class target
 
 };
 
-#ifdef AIEBU_FULL
 class target_aie2ps: public target
 {
   public:
@@ -69,8 +68,6 @@ class target_aie2ps: public target
 
   target_aie2ps(const std::string& name): target(name, "aie2ps", "aie2ps asm assembler") {}
 };
-
-#endif
 
 class target_aie2blob: public target
 {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,10 +3,8 @@
 
 project(tests CXX C)
 
-if (AIEBU_FULL STREQUAL "ON")
-  if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-    add_subdirectory(aie2ps-ctrlcode)
-  endif()
+if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+  add_subdirectory(aie2ps-ctrlcode)
 endif()
 add_subdirectory(aie2-ctrlcode)
 add_subdirectory(cpp_test)

--- a/test/cpp_test/c_api/CMakeLists.txt
+++ b/test/cpp_test/c_api/CMakeLists.txt
@@ -16,13 +16,11 @@ target_link_libraries(${AIE2_TESTNAME}
 
 target_include_directories(${AIE2_TESTNAME} PRIVATE ${AIEBU_SOURCE_DIR}/src/cpp/aiebu/src/include)
 
-if (AIEBU_FULL STREQUAL "ON")
-  set(AIE2PS_TESTNAME "aie2ps_c.out")
-  add_executable(${AIE2PS_TESTNAME} aie2ps_test.c)
-  target_link_libraries(${AIE2PS_TESTNAME}
-    PRIVATE
-    aiebu_static
-    )
+set(AIE2PS_TESTNAME "aie2ps_c.out")
+add_executable(${AIE2PS_TESTNAME} aie2ps_test.c)
+target_link_libraries(${AIE2PS_TESTNAME}
+  PRIVATE
+  aiebu_static
+  )
 
-  target_include_directories(${AIE2PS_TESTNAME} PRIVATE ${AIEBU_SOURCE_DIR}/src/cpp/aiebu/src/include)
-endif()
+target_include_directories(${AIE2PS_TESTNAME} PRIVATE ${AIEBU_SOURCE_DIR}/src/cpp/aiebu/src/include)

--- a/test/cpp_test/cpp_api/CMakeLists.txt
+++ b/test/cpp_test/cpp_api/CMakeLists.txt
@@ -13,44 +13,41 @@ target_link_libraries(${AIE2_TESTNAME}
   )
 target_include_directories(${AIE2_TESTNAME} PRIVATE ${AIEBU_SOURCE_DIR}/src/cpp/aiebu/src/include)
 
-if (AIEBU_FULL STREQUAL "ON")
-  set(AIE2PS_TESTNAME "aie2ps_cpp")
-  set(CHECKSUMS_FILE "${CMAKE_CURRENT_BINARY_DIR}/checksums.txt")
-  add_executable(${AIE2PS_TESTNAME} aie2ps_test.cpp)
-  target_link_libraries(${AIE2PS_TESTNAME}
-    PRIVATE
-    aiebu_static
-    )
-  target_include_directories(${AIE2PS_TESTNAME} PRIVATE ${AIEBU_SOURCE_DIR}/src/cpp/aiebu/src/include)
+set(AIE2PS_TESTNAME "aie2ps_cpp")
+set(CHECKSUMS_FILE "${CMAKE_CURRENT_BINARY_DIR}/checksums.txt")
+add_executable(${AIE2PS_TESTNAME} aie2ps_test.cpp)
+target_link_libraries(${AIE2PS_TESTNAME}
+  PRIVATE
+  aiebu_static
+  )
+target_include_directories(${AIE2PS_TESTNAME} PRIVATE ${AIEBU_SOURCE_DIR}/src/cpp/aiebu/src/include)
 
-  add_custom_command(OUTPUT ctrl_pkt0.bin
-    COMMAND ${CMAKE_COMMAND} -P "${AIEBU_SOURCE_DIR}/cmake/b64.cmake" -d "${AIEBU_SOURCE_DIR}/test/cpp_test/aie2ps/eff_net_ctrlpacket/ctrl_pkt/ctrl_pkt0.b64" ctrl_pkt0.bin
-    # COMMAND ${CMAKE_COMMAND} -E copy "ctrl_pkt0.bin" "${AIEBU_SOURCE_DIR}/test/cpp_test/aie2ps/eff_net_ctrlpacket/ctrl_pkt/"
-    DEPENDS "${AIEBU_SOURCE_DIR}/test/cpp_test/aie2ps/eff_net_ctrlpacket/ctrl_pkt/ctrl_pkt0.b64"
-    COMMENT "Decoding base64 ctrlcode and ctrlpkt to binary in ${AIEBU_SOURCE_DIR}/test/cpp_test/aie2ps/eff_net_ctrlpacket"
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    VERBATIM)
+add_custom_command(OUTPUT ctrl_pkt0.bin
+  COMMAND ${CMAKE_COMMAND} -P "${AIEBU_SOURCE_DIR}/cmake/b64.cmake" -d "${AIEBU_SOURCE_DIR}/test/cpp_test/aie2ps/eff_net_ctrlpacket/ctrl_pkt/ctrl_pkt0.b64" ctrl_pkt0.bin
+  # COMMAND ${CMAKE_COMMAND} -E copy "ctrl_pkt0.bin" "${AIEBU_SOURCE_DIR}/test/cpp_test/aie2ps/eff_net_ctrlpacket/ctrl_pkt/"
+  DEPENDS "${AIEBU_SOURCE_DIR}/test/cpp_test/aie2ps/eff_net_ctrlpacket/ctrl_pkt/ctrl_pkt0.b64"
+  COMMENT "Decoding base64 ctrlcode and ctrlpkt to binary in ${AIEBU_SOURCE_DIR}/test/cpp_test/aie2ps/eff_net_ctrlpacket"
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  VERBATIM)
 
-  add_custom_target(aie2psbins ALL
+add_custom_target(aie2psbins ALL
   DEPENDS ctrl_pkt0.bin)
 
-  add_test(NAME "aie2ps_cpp_eff_net_coal"
-    COMMAND ${AIE2PS_TESTNAME} "eff_net_coal" "${AIEBU_SOURCE_DIR}/test/cpp_test/aie2ps/eff_net_coal/"
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+add_test(NAME "aie2ps_cpp_eff_net_coal"
+  COMMAND ${AIE2PS_TESTNAME} "eff_net_coal" "${AIEBU_SOURCE_DIR}/test/cpp_test/aie2ps/eff_net_coal/"
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
-  # add_test(NAME "aie2ps_cpp_eff_net_ctrlpacket"
-  #   COMMAND ${AIE2PS_TESTNAME} "eff_net_ctrlpacket" "${AIEBU_SOURCE_DIR}/test/cpp_test/aie2ps/eff_net_ctrlpacket/"
-  #   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+# add_test(NAME "aie2ps_cpp_eff_net_ctrlpacket"
+#   COMMAND ${AIE2PS_TESTNAME} "eff_net_ctrlpacket" "${AIEBU_SOURCE_DIR}/test/cpp_test/aie2ps/eff_net_ctrlpacket/"
+#   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
-  add_test(NAME "aie2ps_cpp_eff_net_coal_md5sum"
-    COMMAND cmake -P "${AIEBU_SOURCE_DIR}/cmake/md5sum-compare.cmake" "${CMAKE_CURRENT_BINARY_DIR}/eff_net_coal.elf" "${AIEBU_SOURCE_DIR}/test/cpp_test/aie2ps/eff_net_coal/gold.md5"
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+add_test(NAME "aie2ps_cpp_eff_net_coal_md5sum"
+  COMMAND cmake -P "${AIEBU_SOURCE_DIR}/cmake/md5sum-compare.cmake" "${CMAKE_CURRENT_BINARY_DIR}/eff_net_coal.elf" "${AIEBU_SOURCE_DIR}/test/cpp_test/aie2ps/eff_net_coal/gold.md5"
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
-  # add_test(NAME "aie2ps_cpp_eff_net_ctrlpacket_md5sum"
-  #   COMMAND cmake -P "${AIEBU_SOURCE_DIR}/cmake/md5sum-compare.cmake" "${CMAKE_CURRENT_BINARY_DIR}/eff_net_ctrlpacket.elf" "${AIEBU_SOURCE_DIR}/test/cpp_test/aie2ps/eff_net_ctrlpacket/gold.md5"
-  #   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-
-endif()
+# add_test(NAME "aie2ps_cpp_eff_net_ctrlpacket_md5sum"
+#   COMMAND cmake -P "${AIEBU_SOURCE_DIR}/cmake/md5sum-compare.cmake" "${CMAKE_CURRENT_BINARY_DIR}/eff_net_ctrlpacket.elf" "${AIEBU_SOURCE_DIR}/test/cpp_test/aie2ps/eff_net_ctrlpacket/gold.md5"
+#   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
 add_test(NAME "aie2_cpp_4x4"
   COMMAND ${AIE2_TESTNAME} "${AIEBU_BINARY_DIR}/lib/gen/preempt_restore_stx_4x4.bin"


### PR DESCRIPTION
#### Problem solved by the commit
All code protected by AIEBU_FULL=ON is now default enabled.

#### How problem was solved, alternative solutions (if any) and why they were rejected
This builds upon #65 where generated header files are checked in.

This PR removes build of src/python/ and scripts/.  Please acknowledge that is desired.
