### PR TITLE
Remove building of shared library for aiebu

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -63,27 +63,15 @@ target_include_directories(aiebu_library_objects
   ${CMAKE_CURRENT_BINARY_DIR}
   )
 
-add_library(aiebu SHARED
-  $<TARGET_OBJECTS:aiebu_library_objects>
-  )
-
 add_library(aiebu_static STATIC
   $<TARGET_OBJECTS:aiebu_library_objects>
   )
 
-target_link_libraries(aiebu xaiengine)
-
 if (MSVC)
-  target_link_libraries(aiebu advapi32)
   target_link_libraries(aiebu_static advapi32)
 endif()
 
-install (TARGETS aiebu
-  LIBRARY DESTINATION ${AIEBU_INSTALL_LIB_DIR}
-  RUNTIME DESTINATION ${AIEBU_INSTALL_BIN_DIR}
-)
-
-install (TARGETS aiebu aiebu_static
+install (TARGETS aiebu_static
   ARCHIVE DESTINATION ${AIEBU_INSTALL_LIB_DIR}
   LIBRARY DESTINATION ${AIEBU_INSTALL_LIB_DIR}
 )

--- a/src/cpp/assembler/aiebu_assembler.cpp
+++ b/src/cpp/assembler/aiebu_assembler.cpp
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT
-// Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
-#include <map>
-#include <string>
 #include "assembler.h"
 #include "aiebu_assembler.h"
 #include "aiebu.h"
@@ -13,8 +11,10 @@
 #include "encoder.h"
 #include "elfwriter.h"
 #include "preprocessor_input.h"
-
 #include "reporter.h"
+
+#include <map>
+#include <string>
 
 namespace aiebu {
 
@@ -87,7 +87,6 @@ disassemble(const std::filesystem::path &root) const
 }
 }
 
-DRIVER_DLLESPEC
 int
 aiebu_assembler_get_elf(enum aiebu_assembler_buffer_type type,
                         const char* buffer1,

--- a/src/cpp/include/aiebu/aiebu.h
+++ b/src/cpp/include/aiebu/aiebu.h
@@ -1,20 +1,13 @@
 // SPDX-License-Identifier: MIT
-// Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
-
+// Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 #ifndef AIEBU_H_
 #define AIEBU_H_
 
-#ifdef __cplusplus
-extern "C" {
 #include <stddef.h>
-#endif
-
 #include <stdint.h>
 
-#if defined(_WIN32)
-#define DRIVER_DLLESPEC __declspec(dllexport)
-#else
-#define DRIVER_DLLESPEC __attribute__((visibility("default")))
+#ifdef __cplusplus
+extern "C" {
 #endif
 
 enum aiebu_error_code {
@@ -66,7 +59,6 @@ struct pm_ctrlpkt {
  * @ctrlpkt             array of pm_ctrlpkt holding pm buffer and id
  * @ctrlpkt_size        size of ctrlpkt array
  */
-DRIVER_DLLESPEC
 int
 aiebu_assembler_get_elf(enum aiebu_assembler_buffer_type type,
                         const char* buffer1,

--- a/src/cpp/include/aiebu/aiebu_assembler.h
+++ b/src/cpp/include/aiebu/aiebu_assembler.h
@@ -1,21 +1,12 @@
 // SPDX-License-Identifier: MIT
-// Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
-
+// Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 #ifndef AIEBU_ASSEMBLER_H_
 #define AIEBU_ASSEMBLER_H_
-
-#include <string>
 #include <cstdint>
-#include <vector>
-#include <iostream>
 #include <filesystem>
 #include <map>
-
-#if defined(_WIN32)
-#define DRIVER_DLLESPEC __declspec(dllexport)
-#else
-#define DRIVER_DLLESPEC __attribute__((visibility("default")))
-#endif
+#include <string>
+#include <vector>
 
 namespace aiebu {
 
@@ -62,7 +53,6 @@ class aiebu_assembler {
      * @libpaths       paths to search for libs
      * @ctrlpkt        map of pm id and pm control packet buffer
      */
-     DRIVER_DLLESPEC
      aiebu_assembler(buffer_type type,
                const std::vector<char>& buffer1,
                const std::vector<char>& buffer2,
@@ -82,7 +72,6 @@ class aiebu_assembler {
      * @libpaths       paths to search for libs
      * @patch_json     external_buffer_id json
      */
-    DRIVER_DLLESPEC
     aiebu_assembler(buffer_type type,
               const std::vector<char>& buffer,
               const std::vector<std::string>& libs = {},
@@ -100,20 +89,16 @@ class aiebu_assembler {
      *
      * return: vector of char with elf content
      */
-    [[nodiscard]]
-    DRIVER_DLLESPEC
     std::vector<char>
     get_elf() const;
 
     void
-    DRIVER_DLLESPEC
     get_report(std::ostream &stream) const;
 
     void
-    DRIVER_DLLESPEC
     disassemble(const std::filesystem::path &root) const;
 };
 
 } //namespace aiebu
 
-#endif // _AIEBU_ASSEMBLER_H_
+#endif // AIEBU_ASSEMBLER_H_

--- a/src/cpp/include/aiebu/aiebu_error.h
+++ b/src/cpp/include/aiebu/aiebu_error.h
@@ -1,17 +1,11 @@
 // SPDX-License-Identifier: MIT
-// Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
-
+// Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 #ifndef AIEBU_ERROR_H_
 #define AIEBU_ERROR_H_
-
-#include <system_error>
 #include "aiebu.h"
 
-#if defined(_WIN32)
-#define DRIVER_DLLESPEC __declspec(dllexport)
-#else
-#define DRIVER_DLLESPEC __attribute__((visibility("default")))
-#endif
+#include <string>
+#include <system_error>
 
 namespace aiebu {
 
@@ -19,7 +13,7 @@ class error : public std::system_error
 {
 public:
 
-  enum class DRIVER_DLLESPEC error_code : int
+  enum class error_code : int
   {
     invalid_asm = aiebu_invalid_asm,
     invalid_patch_schema = aiebu_invalid_patch_schema,
@@ -29,30 +23,22 @@ public:
     internal_error = aiebu_invalid_internal_error
   };
 
-  DRIVER_DLLESPEC
   error(error_code ec, const std::error_category& cat, const std::string& what = "");
 
   explicit
-  DRIVER_DLLESPEC
   error(error_code ec, const std::string& what = "");
 
   // Retrive underlying code for return plain error code
-  [[nodiscard]]
-  DRIVER_DLLESPEC
   int
   value() const;
 
-  [[nodiscard]]
-  DRIVER_DLLESPEC
   int
   get() const;
 
-  [[nodiscard]]
-  DRIVER_DLLESPEC
   int
   get_code() const;
 };
 
 }
 
-#endif //_AIEBU_ERROR_H_
+#endif // AIEBU_ERROR_H_


### PR DESCRIPTION
We want all clients to link statically with aiebu and now build and release only libaiebu_static.a (linux) and aiebu_static.lib (windows)

Import and export macros (dllimport/export) were not set up correctly on windows, building only the static library is simpler as it avoids import/export completely.

Revisit when/if there is a need for shared library.
