### PR TITLE
Release exported headers to include/aiebu

### DIFF
--- a/lib/src/CMakeLists.txt
+++ b/lib/src/CMakeLists.txt
@@ -69,7 +69,7 @@ endif()
 target_include_directories(${AIEBU_COPY_EXE}
   PRIVATE
   ${AIEBU_AIE_RT_HEADER_DIR}
-  ${AIEBU_SOURCE_DIR}/src/cpp/aiebu/src/include
+  ${AIEBU_SOURCE_DIR}/src/cpp/include
 )
 
 target_link_libraries(${AIEBU_COPY_EXE} xaiengine aiebu_static)

--- a/lib/src/gen-copy.cpp
+++ b/lib/src/gen-copy.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (C) 2024 Advanced Micro Devices, Inc.
+// Copyright (C) 2024-2025 Advanced Micro Devices, Inc.
 
 /**
  * This file generates transaction commands for data copy from L3 -> L2 and from L2 -> L3.
@@ -14,18 +14,18 @@
  *      3. Patch the col index of MemTile.
 **/
 
+#include "gen-common.h"
 
-#include <cassert>
-#include <iostream>
-#include <fstream>
+#include "aiebu/aiebu_assembler.h"
 
 // AIE Driver headers
 #include "xaiengine.h"
 #include "xaiengine/xaiegbl_params.h"
 
-#include "aiebu_assembler.h"
+#include <cassert>
+#include <fstream>
+#include <iostream>
 
-#include "gen-common.h"
 
 #define XAIE_NUM_ROWS 6
 #define XAIE_NUM_COLS 4

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -20,15 +20,15 @@ add_library(aiebu_library_objects OBJECT
 
 target_include_directories(aiebu_library_objects
   PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  ${CMAKE_CURRENT_SOURCE_DIR}/include
   ${AIEBU_SOURCE_DIR}
   ${AIEBU_AIE_RT_HEADER_DIR}
-  ${CMAKE_CURRENT_SOURCE_DIR}
-  ${Boost_INCLUDE_DIRS}
   ${AIEBU_BINARY_DIR}/lib
-  ${AIEBU_SOURCE_DIR}/src/cpp/ELFIO
+  ${Boost_INCLUDE_DIRS}
 
   # The following should be spelled out in code
-  ${CMAKE_CURRENT_SOURCE_DIR}/include/aiebu
+  ${CMAKE_CURRENT_SOURCE_DIR}/ELFIO
   ${CMAKE_CURRENT_SOURCE_DIR}/preprocessor
   ${CMAKE_CURRENT_SOURCE_DIR}/preprocessor/aie2
   ${CMAKE_CURRENT_SOURCE_DIR}/encoder
@@ -40,6 +40,11 @@ target_include_directories(aiebu_library_objects
   ${CMAKE_CURRENT_SOURCE_DIR}/elf
   ${CMAKE_CURRENT_SOURCE_DIR}/elf/aie2
   ${AIEBU_BINARY_DIR}/lib/gen
+  )
+
+target_compile_definitions(aiebu_library_objects
+  PRIVATE
+  -DAIEBU_EXPORTS
   )
 
 set_target_properties(aiebu_library_objects PROPERTIES
@@ -80,6 +85,15 @@ install(FILES
   include/aiebu/aiebu.h
   include/aiebu/aiebu_assembler.h
   include/aiebu/aiebu_error.h
+  DESTINATION ${AIEBU_INSTALL_INCLUDE_DIR}/aiebu
+  CONFIGURATIONS Debug Release COMPONENT Runtime
+)
+
+# Deprecated include path, redirects to aiebu/*.h with warning
+install(FILES
+  include/deprecated/aiebu.h
+  include/deprecated/aiebu_assembler.h
+  include/deprecated/aiebu_error.h
   DESTINATION ${AIEBU_INSTALL_INCLUDE_DIR}
   CONFIGURATIONS Debug Release COMPONENT Runtime
 )

--- a/src/cpp/aiebu/src/include/aiebu.h
+++ b/src/cpp/aiebu/src/include/aiebu.h
@@ -1,4 +1,4 @@
 // SPDX-License-Identifier: MIT
 // Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
-#pragma message("please replace src/cpp/aiebu/src/include/aiebu.h with src/cpp/include/aiebu/aiebu.h")
+#pragma message("Please replace inclusion of include/aiebu.h with include/aiebu/aiebu.h")
 #include "../../../include/aiebu/aiebu.h"

--- a/src/cpp/aiebu/src/include/aiebu_assembler.h
+++ b/src/cpp/aiebu/src/include/aiebu_assembler.h
@@ -1,4 +1,4 @@
 // SPDX-License-Identifier: MIT
 // Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
-#pragma message("please replace src/cpp/aiebu/src/include/aiebu_assembler.h with src/cpp/include/aiebu/aiebu_assembler.h")
+#pragma message("Please replace inclusion of include/aiebu_assembler.h with include/aiebu/aiebu_assembler.h")
 #include "../../../include/aiebu/aiebu_assembler.h"

--- a/src/cpp/aiebu/src/include/aiebu_error.h
+++ b/src/cpp/aiebu/src/include/aiebu_error.h
@@ -1,4 +1,4 @@
 // SPDX-License-Identifier: MIT
 // Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
-#pragma message("please replace src/cpp/aiebu/src/include/aiebu_error.h with src/cpp/include/aiebu/aiebu_error.h")
+#pragma message("Please replace inclusion of include/aiebu_error.h with include/aiebu/aiebu_error.h")
 #include "../../../include/aiebu/aiebu_error.h"

--- a/src/cpp/analyzer/reporter.cpp
+++ b/src/cpp/analyzer/reporter.cpp
@@ -1,14 +1,12 @@
 // SPDX-License-Identifier: MIT
-// Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
-
+// Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 #include "reporter.h"
-#include "aiebu_error.h"
-
 #include "transaction.hpp"
+
+#include "aiebu/aiebu_error.h"
 
 #include <boost/interprocess/streams/bufferstream.hpp>
 #include <elfio/elfio_dump.hpp>
-
 namespace aiebu {
 
     reporter::reporter(aiebu::aiebu_assembler::buffer_type /*type*/, const std::vector<char>& elf_data)

--- a/src/cpp/analyzer/reporter.h
+++ b/src/cpp/analyzer/reporter.h
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: MIT
-// Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+#ifndef AIEBU_REPORTER_H_
+#define AIEBU_REPORTER_H_
 
-#ifndef _AIEBU_REPORTER_H_
-#define _AIEBU_REPORTER_H_
-
-#include "aiebu_assembler.h"
+#include "aiebu/aiebu_assembler.h"
 
 #include <elfio/elfio_dump.hpp>
 

--- a/src/cpp/assembler/aiebu_assembler.cpp
+++ b/src/cpp/assembler/aiebu_assembler.cpp
@@ -1,17 +1,17 @@
 // SPDX-License-Identifier: MIT
 // Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
-
 #include "assembler.h"
-#include "aiebu_assembler.h"
-#include "aiebu.h"
-#include "aiebu_error.h"
-#include "symbol.h"
-#include "utils.h"
-#include "preprocessor.h"
-#include "encoder.h"
 #include "elfwriter.h"
+#include "encoder.h"
+#include "preprocessor.h"
 #include "preprocessor_input.h"
 #include "reporter.h"
+#include "symbol.h"
+#include "utils.h"
+
+#include "aiebu/aiebu.h"
+#include "aiebu/aiebu_assembler.h"
+#include "aiebu/aiebu_error.h"
 
 #include <map>
 #include <string>

--- a/src/cpp/assembler/assembler.cpp
+++ b/src/cpp/assembler/assembler.cpp
@@ -1,20 +1,19 @@
 // SPDX-License-Identifier: MIT
-// Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
-
+// Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 #include "assembler.h"
-#include "aie2_blob_preprocessor.h"
+
 #include "aie2_asm_preprocessor.h"
-#include "aie2_blob_encoder.h"
 #include "aie2_blob_elfwriter.h"
-#include "aie2ps_preprocessor.h"
-#include "aie2ps_encoder.h"
+#include "aie2_blob_encoder.h"
+#include "aie2_blob_preprocessor.h"
 #include "aie2ps_elfwriter.h"
-
-#include "aiebu_error.h"
-
-#include "preprocessor.h"
-#include "encoder.h"
+#include "aie2ps_encoder.h"
+#include "aie2ps_preprocessor.h"
 #include "elfwriter.h"
+#include "encoder.h"
+#include "preprocessor.h"
+
+#include "aiebu/aiebu_error.h"
 
 namespace aiebu {
 

--- a/src/cpp/common/aiebu_error.cpp
+++ b/src/cpp/common/aiebu_error.cpp
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: MIT
-// Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
+#include "aiebu/aiebu_error.h"
 #include <string>
-#include "aiebu_error.h"
+
 namespace aiebu {
 
 error::

--- a/src/cpp/common/assembler_state.cpp
+++ b/src/cpp/common/assembler_state.cpp
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: MIT
-// Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
-
+// Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 #include "assembler_state.h"
-#include "aiebu_error.h"
+
 #include "utils.h"
-#include <unordered_map>
+
+#include "aiebu/aiebu_error.h"
+
 #include <functional>
+#include <unordered_map>
 
 namespace aiebu {
 

--- a/src/cpp/common/utils.h
+++ b/src/cpp/common/utils.h
@@ -1,20 +1,18 @@
 // SPDX-License-Identifier: MIT
 // Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
+#ifndef AIEBU_COMMOM_UTILS_H_
+#define AIEBU_COMMOM_UTILS_H_
+#include "aiebu/aiebu_error.h"
 
-#ifndef _AIEBU_COMMOM_UTILS_H_
-#define _AIEBU_COMMOM_UTILS_H_
-
-#include <fstream>
-#include <filesystem>
-#include <iostream>
 #include <cassert>
 #include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <regex>
+#include <sstream>
 #include <string>
 #include <string_view>
-#include <sstream>
 #include <vector>
-#include <regex>
-#include "aiebu_error.h"
 
 #define BYTE_MASK 0xFF
 #define FIRST_BYTE_SHIFT 0
@@ -190,4 +188,4 @@ to_uinteger(const std::string& token) {
 }
 
 }
-#endif // _AIEBU_COMMOM_UTILS_H_
+#endif // AIEBU_COMMOM_UTILS_H_

--- a/src/cpp/common/writer.cpp
+++ b/src/cpp/common/writer.cpp
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: MIT
-// Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
-#include "writer.h"
-#include "aiebu_error.h"
 #include "utils.h"
+#include "writer.h"
+
+#include "aiebu/aiebu_error.h"
 
 namespace aiebu {
 

--- a/src/cpp/encoder/aie2ps/aie2ps_encoder.cpp
+++ b/src/cpp/encoder/aie2ps/aie2ps_encoder.cpp
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: MIT
-// Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
-
+// Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 #include "aie2ps_encoder.h"
-#include "aiebu_error.h"
+
+#include "aiebu/aiebu_error.h"
+
 #include <cassert>
 
 namespace aiebu {

--- a/src/cpp/include/aiebu/aiebu_assembler.h
+++ b/src/cpp/include/aiebu/aiebu_assembler.h
@@ -12,7 +12,8 @@ namespace aiebu {
 
 // Assembler Class
 
-class aiebu_assembler {
+class aiebu_assembler
+{
   std::vector<char> elf_data;
 
   public:

--- a/src/cpp/include/aiebu/aiebu_error.h
+++ b/src/cpp/include/aiebu/aiebu_error.h
@@ -2,7 +2,7 @@
 // Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 #ifndef AIEBU_ERROR_H_
 #define AIEBU_ERROR_H_
-#include "aiebu.h"
+#include "aiebu/aiebu.h"
 
 #include <string>
 #include <system_error>

--- a/src/cpp/include/aiebu/detail/config.h
+++ b/src/cpp/include/aiebu/detail/config.h
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#ifndef AIEBU_DETAIL_CONFIG_H
+#define AIEBU_DETAIL_CONFIG_H
+
+//------------------Enable dynamic linking on windows-------------------------//
+
+#ifdef _WIN32
+# ifndef AIEBU_STATIC_BUILD
+#  ifdef AIEBU_API_SOURCE
+#   define AIEBU_API_EXPORT __declspec(dllexport)
+#  else
+#   define AIEBU_API_EXPORT __declspec(dllimport)
+#  endif
+# endif
+#endif
+#ifdef __linux__
+# ifdef AIEBU_API_SOURCE
+#  define AIEBU_API_EXPORT __attribute__ ((visibility("default")))
+# else
+#  define AIEBU_API_EXPORT
+# endif
+#endif
+
+#ifndef AIEBU_API_EXPORT
+# define AIEBU_API_EXPORT
+#endif
+
+#endif

--- a/src/cpp/include/deprecated/aiebu.h
+++ b/src/cpp/include/deprecated/aiebu.h
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#pragma message("Please replace inclusion of aiebu.h with aiebu/aiebu.h")
+#include "aiebu/aiebu.h"

--- a/src/cpp/include/deprecated/aiebu_assembler.h
+++ b/src/cpp/include/deprecated/aiebu_assembler.h
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#pragma message("Please replace inclusion of aiebu_assembler.h with aiebu/aiebu_assembler.h")
+#include "aiebu/aiebu_assembler.h"

--- a/src/cpp/include/deprecated/aiebu_error.h
+++ b/src/cpp/include/deprecated/aiebu_error.h
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#pragma message("Please replace inclusion of aiebu_error.h with aiebu/aiebu_error.h")
+#include "aiebu/aiebu_error.h"

--- a/src/cpp/ops/ops.cpp
+++ b/src/cpp/ops/ops.cpp
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: MIT
-// Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
-
+// Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 #include "ops.h"
-#include "aiebu_error.h"
+
+#include "aiebu/aiebu_error.h"
+
 #include <string>
+
 namespace aiebu {
 
 offset_type

--- a/src/cpp/preprocessor/asm/asm_parser.cpp
+++ b/src/cpp/preprocessor/asm/asm_parser.cpp
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: MIT
-// Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+#include "asm_parser.h"
 
-#include "asm/asm_parser.h"
-#include "aiebu_error.h"
+#include "aiebu/aiebu_error.h"
+
+#include <iostream>
 
 namespace aiebu {
 

--- a/src/cpp/preprocessor/asm/asm_parser.h
+++ b/src/cpp/preprocessor/asm/asm_parser.h
@@ -1,20 +1,19 @@
 // SPDX-License-Identifier: MIT
-// Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+#ifndef AIEBU_PREPROCESSOR_ASM_ASM_PARSER_H_
+#define AIEBU_PREPROCESSOR_ASM_ASM_PARSER_H_
 
-#ifndef _AIEBU_PREPROCESSOR_ASM_ASM_PARSER_H_
-#define _AIEBU_PREPROCESSOR_ASM_ASM_PARSER_H_
-
-#include <vector>
-#include <string>
-#include <iostream>
-#include <memory>
-#include <sstream>
-#include <stack>
-#include <regex>
-#include <map>
-#include <unordered_map>
-#include "utils.h"
 #include "code_section.h"
+#include "utils.h"
+
+#include <map>
+#include <memory>
+#include <regex>
+#include <stack>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <vector>
 
 namespace aiebu {
 
@@ -359,4 +358,4 @@ public:
 
 
 }
-#endif //_AIEBU_PREPROCESSOR_ASM_ASM_PARSER_H_
+#endif // AIEBU_PREPROCESSOR_ASM_ASM_PARSER_H_

--- a/src/cpp/preprocessor/asm/pager.cpp
+++ b/src/cpp/preprocessor/asm/pager.cpp
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: MIT
-// Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+#include "pager.h"
+#include "utils.h"
+
+#include "aiebu/aiebu_error.h"
 
 #include <unordered_set>
-#include "asm/pager.h"
-#include "aiebu_error.h"
-#include "utils.h"
 
 namespace aiebu {
 

--- a/src/cpp/preprocessor/preprocessor_input.h
+++ b/src/cpp/preprocessor/preprocessor_input.h
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: MIT
-// Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+#ifndef AIEBU_PREPROCESSOR_PREPROCESSOR_INPUT_H_
+#define AIEBU_PREPROCESSOR_PREPROCESSOR_INPUT_H_
 
-#ifndef _AIEBU_PREPROCESSOR_PREPROCESSOR_INPUT_H_
-#define _AIEBU_PREPROCESSOR_PREPROCESSOR_INPUT_H_
+#include "symbol.h"
+#include "aiebu/aiebu_error.h"
 
-#include <vector>
-#include <string>
 #include <algorithm>
 #include <map>
-#include "symbol.h"
-#include "aiebu_error.h"
+#include <vector>
+#include <string>
 
 namespace aiebu {
 
@@ -62,4 +62,4 @@ public:
 };
 
 }
-#endif //_AIEBU_PREPROCESSOR_PREPROCESSOR_INPUT_H_
+#endif // AIEBU_PREPROCESSOR_PREPROCESSOR_INPUT_H_

--- a/src/cpp/utils/asm/CMakeLists.txt
+++ b/src/cpp/utils/asm/CMakeLists.txt
@@ -8,10 +8,10 @@ add_library(aiebu_asm_objects OBJECT
 target_include_directories(aiebu_asm_objects
   PRIVATE
   ${AIEBU_SOURCE_DIR}/src/cpp
+  ${AIEBU_SOURCE_DIR}/src/cpp/include
   ${Boost_INCLUDE_DIRS}
 
   # these should be spelled out in source code
-  ${AIEBU_SOURCE_DIR}/src/cpp/include/aiebu
   ${AIEBU_SOURCE_DIR}/src/cpp/assembler
   ${AIEBU_SOURCE_DIR}/src/cpp/common
   ${AIEBU_SOURCE_DIR}/src/cpp/utils/target

--- a/src/cpp/utils/target/target.h
+++ b/src/cpp/utils/target/target.h
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: MIT
-// Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.
+#ifndef AIEBU_UTILITIES_TARGET_H_
+#define AIEBU_UTILITIES_TARGET_H_
 
-#ifndef __AIEBU_UTILITIES_TARGET_H_
-#define __AIEBU_UTILITIES_TARGET_H_
+#include "aiebu/aiebu_assembler.h"
+#include "aiebu/aiebu_error.h"
 
-#include <fstream>
 #include <filesystem>
+#include <fstream>
 
-#include "aiebu_assembler.h"
-#include "aiebu_error.h"
 
 namespace aiebu::utilities {
 
@@ -117,4 +117,4 @@ class target_aie2blob_dpu: public target_aie2blob
 
 } //namespace aiebu::utilities
 
-#endif //__AIEBU_UTILITIES_TARGET_H_
+#endif // AIEBU_UTILITIES_TARGET_H_

--- a/test/cmake-test/sample/aie2_test.cpp
+++ b/test/cmake-test/sample/aie2_test.cpp
@@ -1,14 +1,13 @@
 // SPDX-License-Identifier: MIT
-// Copyright (C) 2023-2024 Advanced Micro Devices, Inc.
+// Copyright (C) 2023-2025 Advanced Micro Devices, Inc.
+#include "aiebu/aiebu_assembler.h"
 
+#include <algorithm>
+#include <cstring>
 #include <fstream>
 #include <iostream>
-#include <vector>
 #include <iterator>
-#include <cstring>
-#include <algorithm>
-
-#include "aiebu_assembler.h"
+#include <vector>
 
 void usage_exit(const char *exe, int status = 1)
 {

--- a/test/cpp_test/c_api/CMakeLists.txt
+++ b/test/cpp_test/c_api/CMakeLists.txt
@@ -14,7 +14,7 @@ target_link_libraries(${AIE2_TESTNAME}
   )
 
 
-target_include_directories(${AIE2_TESTNAME} PRIVATE ${AIEBU_SOURCE_DIR}/src/cpp/aiebu/src/include)
+target_include_directories(${AIE2_TESTNAME} PRIVATE ${AIEBU_SOURCE_DIR}/src/cpp/include)
 
 set(AIE2PS_TESTNAME "aie2ps_c.out")
 add_executable(${AIE2PS_TESTNAME} aie2ps_test.c)
@@ -23,4 +23,4 @@ target_link_libraries(${AIE2PS_TESTNAME}
   aiebu_static
   )
 
-target_include_directories(${AIE2PS_TESTNAME} PRIVATE ${AIEBU_SOURCE_DIR}/src/cpp/aiebu/src/include)
+target_include_directories(${AIE2PS_TESTNAME} PRIVATE ${AIEBU_SOURCE_DIR}/src/cpp/include)

--- a/test/cpp_test/c_api/aie2_test.c
+++ b/test/cpp_test/c_api/aie2_test.c
@@ -1,10 +1,10 @@
 /* SPDX-License-Identifier: MIT */
-/* Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved. */
+/* Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved. */
+#include "aie_test_common.h"
+#include "aiebu/aiebu.h"
 
 #include <stdio.h>
 #include <stdlib.h>
-#include "aiebu.h"
-#include "aie_test_common.h"
 
 void usage_exit()
 {

--- a/test/cpp_test/c_api/aie2ps_test.c
+++ b/test/cpp_test/c_api/aie2ps_test.c
@@ -1,10 +1,11 @@
 /* SPDX-License-Identifier: MIT */
-/* Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved. */
+/* Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved. */
 
-#include <stdio.h>
-#include <stdlib.h>
-#include "aiebu.h"
 #include "aie_test_common.h"
+#include "aiebu/aiebu.h"
+
+#include <stdlib.h>
+#include <stdio.h>
 
 void usage_exit()
 {

--- a/test/cpp_test/cpp_api/CMakeLists.txt
+++ b/test/cpp_test/cpp_api/CMakeLists.txt
@@ -11,7 +11,7 @@ target_link_libraries(${AIE2_TESTNAME}
   PRIVATE
   aiebu_static
   )
-target_include_directories(${AIE2_TESTNAME} PRIVATE ${AIEBU_SOURCE_DIR}/src/cpp/aiebu/src/include)
+target_include_directories(${AIE2_TESTNAME} PRIVATE ${AIEBU_SOURCE_DIR}/src/cpp/include)
 
 set(AIE2PS_TESTNAME "aie2ps_cpp")
 set(CHECKSUMS_FILE "${CMAKE_CURRENT_BINARY_DIR}/checksums.txt")
@@ -20,7 +20,7 @@ target_link_libraries(${AIE2PS_TESTNAME}
   PRIVATE
   aiebu_static
   )
-target_include_directories(${AIE2PS_TESTNAME} PRIVATE ${AIEBU_SOURCE_DIR}/src/cpp/aiebu/src/include)
+target_include_directories(${AIE2PS_TESTNAME} PRIVATE ${AIEBU_SOURCE_DIR}/src/cpp/include)
 
 add_custom_command(OUTPUT ctrl_pkt0.bin
   COMMAND ${CMAKE_COMMAND} -P "${AIEBU_SOURCE_DIR}/cmake/b64.cmake" -d "${AIEBU_SOURCE_DIR}/test/cpp_test/aie2ps/eff_net_ctrlpacket/ctrl_pkt/ctrl_pkt0.b64" ctrl_pkt0.bin

--- a/test/cpp_test/cpp_api/aie2_test.cpp
+++ b/test/cpp_test/cpp_api/aie2_test.cpp
@@ -1,12 +1,13 @@
 // SPDX-License-Identifier: MIT
-// Copyright (C) 2023-2024 Advanced Micro Devices, Inc.
+// Copyright (C) 2023-2025 Advanced Micro Devices, Inc.
 
+#include "aiebu/aiebu_assembler.h"
+
+#include <algorithm>
 #include <fstream>
 #include <iostream>
-#include <vector>
 #include <iterator>
-#include "aiebu_assembler.h"
-#include <algorithm>
+#include <vector>
 
 void usage_exit()
 {

--- a/test/cpp_test/cpp_api/aie2ps_test.cpp
+++ b/test/cpp_test/cpp_api/aie2ps_test.cpp
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: MIT
 // Copyright (C) 2023-2024 Advanced Micro Devices, Inc.
 
+#include "aiebu/aiebu_assembler.h"
+#include "aiebu/aiebu_error.h"
+
+#include <algorithm>
 #include <fstream>
 #include <iostream>
-#include <vector>
 #include <iterator>
-#include "aiebu_assembler.h"
-#include "aiebu_error.h"
-#include <algorithm>
+#include <vector>
 
 /* 2 testcases added
  * without ctrl_pkt: ./aie2ps_cpp eff_net_coal test/cpp_test/aie2ps/eff_net_coal


### PR DESCRIPTION
Exported API header files are released to `include/aiebu/*.h` and are to be included using `#include <aiebu/zzz.h>`.

This allows aiebu headers to be installed under a shared include directory within polluting top-level include.  This is similar to how XRT headers and many other project headers are installed.

Fix implementation to prefix public exported header include with `aiebu/`. Adjust include search path for implementation code.

End-user applications should adjust include search path as well but for the time being wrapper headers are released to legacy location while redirecting to new location with a warning.
