### PR TITLE
Xclbin to ELF flow migration for aie2

### DIFF
--- a/src/cpp/assembler/aiebu_assembler.cpp
+++ b/src/cpp/assembler/aiebu_assembler.cpp
@@ -56,6 +56,11 @@ aiebu_assembler(buffer_type type,
     aiebu::assembler a(assembler::elf_type::aie2ps_asm);
     elf_data = a.process(buffer1, libs, libpaths, patch_json);
   }
+  else if (type == buffer_type::config)
+  {
+    aiebu::assembler a(assembler::elf_type::config);
+    elf_data = a.process(buffer1, libs, libpaths, patch_json, buffer2);
+  }
   else {
     throw error(error::error_code::invalid_buffer_type, "Buffer_type not supported !!!");
   }

--- a/src/cpp/assembler/assembler.cpp
+++ b/src/cpp/assembler/assembler.cpp
@@ -12,6 +12,8 @@
 #include "elfwriter.h"
 #include "encoder.h"
 #include "preprocessor.h"
+#include "elf/config/config_elfwriter.h"
+#include "config_preprocessor.h"
 
 #include "aiebu/aiebu_error.h"
 
@@ -47,6 +49,12 @@ assembler(const elf_type type)
     m_enoder = std::make_unique<aie2ps_encoder>();
     m_elfwriter = std::make_unique<aie2ps_elf_writer>();
     m_ppi = std::make_shared<aie2ps_preprocessor_input>();
+  }
+  else if (type == elf_type::config)  {
+    m_preprocessor = std::make_unique<config_preprocessor>();
+    m_enoder = std::make_unique<aie2_blob_encoder>();
+    m_elfwriter = std::make_unique<config_elf_writer>();
+    m_ppi = std::make_shared<config_preprocessor_input>();
   }
   else {
     throw error(error::error_code::invalid_buffer_type ,"Invalid elf type!!!");

--- a/src/cpp/assembler/assembler.h
+++ b/src/cpp/assembler/assembler.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
 #ifndef _ADSM_COMMOM_ASSEMBLER_H_
 #define _ADSM_COMMOM_ASSEMBLER_H_
@@ -29,7 +29,8 @@ public:
     aie2_transaction_blob,
     aie2_dpu_blob,
     aie2ps_asm,
-    aie2_asm
+    aie2_asm,
+    config
   };
 
   explicit assembler(const elf_type type);

--- a/src/cpp/common/file_utils.h
+++ b/src/cpp/common/file_utils.h
@@ -22,6 +22,10 @@ readfile(const std::string& filename)
 
   std::ifstream input(filename, std::ios::in | std::ios::binary);
   auto file_size = std::filesystem::file_size(filename);
+
+  if (!file_size)
+    throw error(error::error_code::invalid_asm, "filename " + filename + " is empty!!");
+
   std::vector<char> buffer(file_size);
   input.read(buffer.data(), static_cast<std::streamsize>(file_size));
   return buffer;

--- a/src/cpp/common/symbol.h
+++ b/src/cpp/common/symbol.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
 #ifndef _AIEBU_COMMOM_SYMBOL_H_
 #define _AIEBU_COMMOM_SYMBOL_H_
@@ -22,7 +22,8 @@ public:
     shim_dma_48 = 5,
     shim_dma_57_aie4 = 6,
     control_packet_57 = 7,
-    unknown = 8,
+    address_64 = 8,
+    unknown = 9,
   };
 
 private:

--- a/src/cpp/common/writer.h
+++ b/src/cpp/common/writer.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
 #ifndef _AIEBU_COMMON_WRITER_H_
 #define _AIEBU_COMMON_WRITER_H_
@@ -7,6 +7,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <unordered_map>
 #include "symbol.h"
 #include "code_section.h"
 
@@ -19,10 +20,14 @@ class writer
   const code_section m_type;
   std::vector<uint8_t> m_data;
   std::vector<symbol> m_symbols;
+  std::unordered_map<std::string, std::string> m_metadata;
 
 public:
-  writer(const std::string name, code_section type, std::vector<uint8_t>& data): m_name(name), m_type(type), m_data(std::move(data)) {}
-  writer(const std::string name, code_section type): m_name(name), m_type(type) {}
+  writer(std::string name, code_section type, std::vector<uint8_t>&& data)
+    : m_name(std::move(name)),
+      m_type(type),
+      m_data(std::move(data)) {}
+  writer(std::string name, code_section type): m_name(std::move(name)), m_type(type) {}
   virtual ~writer() = default;
 
   virtual void write_byte(uint8_t byte);
@@ -80,6 +85,17 @@ public:
   }
 
   void padding(offset_type size);
+
+  void add_metadata(std::unordered_map<std::string, std::string>&& metadata)
+  {
+    m_metadata = std::move(metadata);
+  }
+
+  std::string&
+  get_metadata(const std::string& key)
+  {
+    return m_metadata[key];
+  }
 };
 }
 #endif //_AIEBU_COMMON_WRITER_H_

--- a/src/cpp/elf/aie2ps/aie2ps_elfwriter.h
+++ b/src/cpp/elf/aie2ps/aie2ps_elfwriter.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
 #ifndef _AIEBU_ELF_AIE2PS_ELF_WRITER_H_
 #define _AIEBU_ELF_AIE2PS_ELF_WRITER_H_
@@ -10,8 +10,8 @@ namespace aiebu {
 
 class aie2ps_elf_writer: public elf_writer
 {
-  constexpr static int ob_abi = 0x40;
-  constexpr static int version = 0x02;
+  constexpr static unsigned char ob_abi = 0x40;
+  constexpr static unsigned char version = 0x02;
 public:
   aie2ps_elf_writer(): elf_writer(ob_abi, version)
   { }

--- a/src/cpp/elf/config/config_elfwriter.h
+++ b/src/cpp/elf/config/config_elfwriter.h
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+
+#ifndef AIEBU_ELF_CONFIG_ELF_WRITER_H_
+#define AIEBU_ELF_CONFIG_ELF_WRITER_H_
+
+#include <elfwriter.h>
+
+namespace aiebu {
+
+class config_elf_writer: public elf_writer
+{
+  constexpr static unsigned char ob_abi = 0x46;
+  constexpr static unsigned char version = 0x02;
+  const std::string const_configuration = "configuration";
+  const std::string xrt_configuration = ".note.xrt.configuration";
+  const std::string const_kernel_signature = "kernel.signature";
+
+public:
+  config_elf_writer(): elf_writer(ob_abi, version)
+  { }
+
+  std::vector<char>
+  process(std::vector<writer>& mwriter) override
+  {
+    process_common_helper(mwriter);
+    //std::string uuid = mwriter[0].get_metadata("kernel.config.uuid");
+    //if (!uuid.empty())
+    //  add_note(NT_XRT_UUID, ".note.xrt.kernel.config.uuid", uuid);
+
+    const std::string configuration = mwriter[0].get_metadata(const_configuration);
+    std::vector<char> configuration_vec(configuration.begin(), configuration.end());
+    if (!configuration.empty())
+      add_note(NT_XRT_PARTITION_SIZE, xrt_configuration, configuration_vec);
+
+    std::string kernel_signature = mwriter[0].get_metadata(const_kernel_signature);
+    if (!kernel_signature.empty())
+      add_symtab(kernel_signature);
+
+    return finalize();
+  }
+};
+
+}
+#endif //AIEBU_ELF_CONFIG_ELF_WRITER_H_

--- a/src/cpp/elf/elfwriter.cpp
+++ b/src/cpp/elf/elfwriter.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
 #include "elfwriter.h"
 
@@ -219,9 +219,33 @@ add_text_data_section(const std::vector<writer>& mwriter, std::vector<symbol>& s
   }
 }
 
-std::vector<char>
+void
 elf_writer::
-process(std::vector<writer>& mwriter)
+add_symtab(const std::string& name)
+{
+  std::call_once(symtab_flag, [this] {
+    str_sec = m_elfio.sections.add(".strtab");
+    str_sec->set_type(ELFIO::SHT_STRTAB);
+    str_sec->set_entry_size(0);
+    sym_sec = m_elfio.sections.add(".symtab");
+    sym_sec->set_type(ELFIO::SHT_SYMTAB);
+    sym_sec->set_info(1);
+    sym_sec->set_addr_align(0x4);
+    sym_sec->set_entry_size(m_elfio.get_default_entry_size(ELFIO::SHT_SYMTAB));
+    sym_sec->set_link(str_sec->get_index());
+  });
+
+  ELFIO::string_section_accessor stra(str_sec);
+  // Create symbol table writer
+  ELFIO::symbol_section_accessor syma( m_elfio, sym_sec );
+  // Another way to add symbol
+  syma.add_symbol( stra, name.c_str(), 0x00000000, 0, ELFIO::STB_WEAK, ELFIO::STT_FUNC, 0,
+                   ELFIO::SHN_UNDEF );
+}
+
+void
+elf_writer::
+process_common_helper(std::vector<writer>& mwriter)
 {
   // add sections
   std::vector<symbol> syms;
@@ -233,6 +257,13 @@ process(std::vector<writer>& mwriter)
     add_reldyn_section(syms);
     add_dynamic_section_segment();
   }
+}
+
+std::vector<char>
+elf_writer::
+process(std::vector<writer>& mwriter)
+{
+  process_common_helper(mwriter);
   return finalize();
 }
 

--- a/src/cpp/elf/elfwriter.h
+++ b/src/cpp/elf/elfwriter.h
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: MIT
-// Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
 #ifndef _AIEBU_ELF_ELF_WRITER_H_
 #define _AIEBU_ELF_ELF_WRITER_H_
 
 #include <sstream>
 #include <iterator>
+#include <mutex>
 #include "writer.h"
 #include "symbol.h"
 #include "elfio/elfio.hpp"
@@ -21,6 +22,8 @@ constexpr int program_header_static_count = 2;
 constexpr int program_header_dynamic_count = 3;
 
 constexpr ELFIO::Elf_Word NT_XRT_UID = 4;
+constexpr ELFIO::Elf_Word NT_XRT_UUID       = 5;
+constexpr ELFIO::Elf_Word NT_XRT_PARTITION_SIZE = 6;
 
 class elf_section
 {
@@ -69,6 +72,9 @@ class elf_writer
 {
 protected:
   ELFIO::elfio m_elfio;
+  ELFIO::section* str_sec = nullptr;
+  ELFIO::section* sym_sec = nullptr;
+  std::once_flag symtab_flag;
   uid_md5 m_uid;
 
   ELFIO::section* add_section(const elf_section& data);
@@ -80,7 +86,8 @@ protected:
   std::vector<char> finalize();
   void add_text_data_section(const std::vector<writer>& mwriter, std::vector<symbol>& syms);
   void add_note(ELFIO::Elf_Word type, const std::string& name, const std::vector<char>& dec);
-
+  void add_symtab(const std::string& name);
+  void process_common_helper(std::vector<writer>& mwriter);
 public:
 
   elf_writer(unsigned char abi, unsigned char version)
@@ -103,7 +110,7 @@ public:
 
   }
 
-  std::vector<char> process(std::vector<writer>& mwriter);
+  virtual std::vector<char> process(std::vector<writer>& mwriter);
 
   virtual ~elf_writer() = default;
 

--- a/src/cpp/encoder/aie2/aie2_blob_encoder.h
+++ b/src/cpp/encoder/aie2/aie2_blob_encoder.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
 #ifndef _AIEBU_ENCODER_AIE2_BLOB_ENCODER_H_
 #define _AIEBU_ENCODER_AIE2_BLOB_ENCODER_H_
@@ -24,12 +24,12 @@ public:
 
     for(auto key : rinput->get_keys())
       if ( !key.compare(".ctrltext") )
-        rwriter.emplace_back(key, code_section::text, rinput->get_data(key));
+        rwriter.emplace_back(key, code_section::text, std::move(rinput->get_data(key)));
       else
-        rwriter.emplace_back(key, code_section::data, rinput->get_data(key));
+        rwriter.emplace_back(key, code_section::data, std::move(rinput->get_data(key)));
 
     rwriter[0].add_symbols(rinput->get_symbols());
-
+    rwriter[0].add_metadata(std::move(rinput->get_metadata()));
     return rwriter;
   }
 };

--- a/src/cpp/include/aiebu/aiebu.h
+++ b/src/cpp/include/aiebu/aiebu.h
@@ -24,7 +24,8 @@ enum aiebu_assembler_buffer_type {
   aiebu_assembler_buffer_type_blob_instr_prepost,
   aiebu_assembler_buffer_type_blob_instr_transaction,
   aiebu_assembler_buffer_type_blob_control_packet,
-  aiebu_assembler_buffer_type_asm_aie2ps
+  aiebu_assembler_buffer_type_asm_aie2ps,
+  aiebu_assembler_buffer_type_config
 };
 
 struct pm_ctrlpkt {

--- a/src/cpp/include/aiebu/aiebu_assembler.h
+++ b/src/cpp/include/aiebu/aiebu_assembler.h
@@ -24,6 +24,7 @@ class aiebu_assembler
       blob_control_packet,
       asm_aie2ps,
       asm_aie2,
+      config,
       elf_aie2,
       elf_aie2ps,
       pdi_aie2,

--- a/src/cpp/preprocessor/aie2/aie2_blob_preprocessed_output.h
+++ b/src/cpp/preprocessor/aie2/aie2_blob_preprocessed_output.h
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: MIT
-// Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
 #ifndef _AIEBU_PREPROCESSOR_AIE2_BLOB_PREPROCESSED_OUTPUT_H_
 #define _AIEBU_PREPROCESSOR_AIE2_BLOB_PREPROCESSED_OUTPUT_H_
 
 #include <string>
 #include <map>
+#include <unordered_map>
 #include "symbol.h"
 #include "preprocessed_output.h"
 
@@ -19,6 +20,7 @@ class aie2_blob_preprocessed_output : public preprocessed_output
   // ELF binaries produced on Linux and Windows to look different .
   std::map<std::string, std::vector<uint8_t>> m_data;
   std::vector<symbol> m_sym;
+  std::unordered_map<std::string, std::string> m_metadata;
 
 public:
   aie2_blob_preprocessed_output() {}
@@ -57,6 +59,16 @@ public:
     if (it == m_data.end())
       throw error(error::error_code::internal_error, "Key (" + key + ") not found!!!");
     return m_data[key];
+  }
+
+  void add_metadata(std::unordered_map<std::string, std::string>&& metadata)
+  {
+    m_metadata = std::move(metadata);
+  }
+
+  std::unordered_map<std::string, std::string>& get_metadata()
+  {
+    return m_metadata;
   }
 };
 

--- a/src/cpp/preprocessor/aie2/aie2_blob_preprocessor_input.cpp
+++ b/src/cpp/preprocessor/aie2/aie2_blob_preprocessor_input.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
-// Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
+#include <filesystem>
 #include "aie2_blob_preprocessor_input.h"
 #include "xaiengine.h"
 #include "stx_save_restore_map.h"
@@ -199,7 +200,8 @@ add_preemption_code(uint32_t col)
   void
   aie2_blob_preprocessor_input::
   extract_coalesed_buffers(const std::string& name,
-                           const boost::property_tree::ptree& pt)
+                           const boost::property_tree::ptree& pt,
+                           const std::string& instance_id)
   {
     uint32_t buffer_size = get_32_bit_property(pt, "size_in_bytes");
     const auto coalesed_buffers_pt = pt.get_child_optional("coalesed_buffers");
@@ -213,37 +215,43 @@ add_preemption_code(uint32_t col)
       // Check if the buffer offset is within the buffer size
       validate_json(buffer_offset, buffer_size, arg_index, offset_type::COALESED_BUFFER);
       // extract control packet patch
-      extract_control_packet_patch(name, arg_index, coalesed_buffer.second);
+      extract_control_packet_patch(name, arg_index, coalesed_buffer.second, instance_id);
     }
   }
 
   void
   aie2_blob_preprocessor_input::
   extract_control_packet_patch(const std::string& name,
-                               const uint32_t arg_index,
-                               const boost::property_tree::ptree& pt)
+                               uint32_t arg_index,
+                               const boost::property_tree::ptree& pt,
+                               const std::string& instance_id)
   {
     const uint32_t addend = get_32_bit_property(pt, "offset_in_bytes", true);
     const auto control_packet_patch_pt = pt.get_child_optional("control_packet_patch_locations");
     if (!control_packet_patch_pt)
       return;
     const auto patchs = control_packet_patch_pt.get();
+    std::string ctrldata_name = ctrl_data;
+    if (!instance_id.empty())
+      ctrldata_name += "." + instance_id;
     for (auto pat : patchs)
     {
       auto patch = pat.second;
-      uint32_t control_packet_size = m_data[".ctrldata"].size();
+      if (m_data.find(ctrldata_name) == m_data.end())
+        throw error(error::error_code::invalid_asm, "control packet for id " + instance_id + " not present");
+      uint32_t control_packet_size = m_data[ctrldata_name].size();
       uint32_t control_packet_offset = get_32_bit_property(patch, "offset");
       // Check if the control packet offset is within the control packet size
       validate_json(control_packet_offset, control_packet_size, arg_index, offset_type::CONTROL_PACKET);
       // move 8 bytes(header) up for unifying the patching scheme between DPU sequence and transaction-buffer
       uint32_t offset = control_packet_offset - 8;
-      add_symbol({name, offset, 0, 0, addend, 0, ctrlData, symbol::patch_schema::control_packet_48});
+      add_symbol({name, offset, 0, 0, addend, 0, ctrldata_name, symbol::patch_schema::control_packet_48});
     }
   }
 
   void
   aie2_blob_preprocessor_input::
-  aiecompiler_json_parser(const boost::property_tree::ptree& pt)
+  aiecompiler_json_parser(const boost::property_tree::ptree& pt, const std::string& instance_id)
   {
     const auto pt_external_buffers = pt.get_child_optional("external_buffers");
     if (!pt_external_buffers)
@@ -253,18 +261,18 @@ add_preemption_code(uint32_t col)
     for (auto& external_buffer : external_buffers)
     {
       const auto pt_coalesed_buffers = external_buffer.second.get_child_optional("coalesed_buffers");
-      // added ARG_OFFSET to argidx to match with kernel argument index in xclbin
+      // added arg_offset to argidx to match with kernel argument index in xclbin
       auto arg = get_32_bit_property(external_buffer.second, "xrt_id");
-      std::string name = std::to_string(arg + ARG_OFFSET);
+      std::string name = std::to_string(arg + arg_offset);
       if (external_buffer.second.get<bool>("ctrl_pkt_buffer", false))
         xrt_id_map.insert({arg, "control-packet"});
       else
         xrt_id_map.insert({arg, name});
 
       if (pt_coalesed_buffers)
-        extract_coalesed_buffers(name, external_buffer.second);
+        extract_coalesed_buffers(name, external_buffer.second, instance_id);
       else
-        extract_control_packet_patch(name, arg, external_buffer.second);
+        extract_control_packet_patch(name, arg, external_buffer.second, instance_id);
     }
   }
 
@@ -306,14 +314,14 @@ add_preemption_code(uint32_t col)
       // move 8 bytes(header) up for unifying the patching scheme between DPU sequence and transaction-buffer
       uint32_t offset = control_packet_offset - 8;
       const uint32_t addend = get_32_bit_property(patch, "bo_offset");
-      add_symbol({std::to_string(arg_index + ARG_OFFSET), offset, 0, 0, addend, 0, ctrlData, symbol::patch_schema::control_packet_48});
+      add_symbol({std::to_string(arg_index + arg_offset), offset, 0, 0, addend, 0, ctrl_data, symbol::patch_schema::control_packet_48});
     }
 
   }
 
   void
   aie2_blob_preprocessor_input::
-  readmetajson(std::istream& patch_json)
+  readmetajson(std::istream& patch_json, const std::string& instance_id)
   {
     boost::property_tree::ptree pt;
     boost::property_tree::read_json(patch_json, pt);
@@ -321,7 +329,7 @@ add_preemption_code(uint32_t col)
     const auto aiecompiler_json = pt.get_child_optional("external_buffers");
     if (aiecompiler_json)
     {
-      aiecompiler_json_parser(pt);
+      aiecompiler_json_parser(pt, instance_id);
       return;
     }
 
@@ -421,6 +429,16 @@ add_preemption_code(uint32_t col)
           ptr += bw_header->Size;
           break;
         }
+        case XAIE_IO_LOADPDI: {
+          auto lp_header = reinterpret_cast<const XAie_LoadPdiHdr *>(ptr);
+          std::string pdiname = get_pdi_name(lp_header->PdiId);
+          if (m_data.find(pdiname) == m_data.end())
+            throw error(error::error_code::invalid_asm, "pdi for id " + pdiname + " not present");
+          add_symbol({pdiname, static_cast<uint32_t>(reinterpret_cast<const char*>(&(lp_header->PdiAddress))-mc_code.data()),
+                      0, 0, 0, lp_header->PdiSize, section_name, symbol::patch_schema::address_64});
+          ptr += sizeof(XAie_LoadPdiHdr);
+          break;
+        }
         case XAIE_IO_MASKWRITE: {
           auto mw_header = reinterpret_cast<const XAie_MaskWrite32Hdr *>(ptr);
           ptr += mw_header->Size;
@@ -485,7 +503,7 @@ add_preemption_code(uint32_t col)
           uint32_t offset = blockWriteRegOffsetMap[reg].first;
           uint64_t buffer_length_in_bytes = blockWriteRegOffsetMap[reg].second;
           patch_helper_input input = {section_name, argname, static_cast<uint32_t>(GET_REG(op->regaddr)),
-                                      static_cast<uint32_t>(op->argidx + ARG_OFFSET), offset,
+                                      static_cast<uint32_t>(op->argidx + arg_offset), offset,
                                       buffer_length_in_bytes, op->argplus};
           patch_helper(mc_code, input);
           ptr += hdr->Size;
@@ -561,6 +579,16 @@ add_preemption_code(uint32_t col)
           ptr += bw_header->Size;
           break;
         }
+        case XAIE_IO_LOADPDI: {
+          auto lp_header = reinterpret_cast<const XAie_LoadPdiHdr *>(ptr);
+          std::string pdiname = get_pdi_name(lp_header->PdiId);
+          if (m_data.find(pdiname) == m_data.end())
+            throw error(error::error_code::invalid_asm, "pdi for id " + pdiname + " not present");
+          add_symbol({pdiname, static_cast<uint32_t>(reinterpret_cast<const char*>(&(lp_header->PdiAddress))-mc_code.data()),
+                      0, 0, 0, lp_header->PdiSize, section_name, symbol::patch_schema::address_64});
+          ptr += sizeof(XAie_LoadPdiHdr);
+          break;
+        }
         case XAIE_IO_MASKWRITE: {
           ptr += sizeof(XAie_MaskWrite32Hdr_opt);
           break;
@@ -618,7 +646,7 @@ add_preemption_code(uint32_t col)
           uint32_t offset = blockWriteRegOffsetMap[reg].first;
           uint64_t buffer_length_in_bytes = blockWriteRegOffsetMap[reg].second;
           patch_helper_input input = {section_name, argname, static_cast<uint32_t>(GET_REG(op->regaddr)),
-                                      static_cast<uint32_t>(op->argidx + ARG_OFFSET), offset,
+                                      static_cast<uint32_t>(op->argidx + arg_offset), offset,
                                       buffer_length_in_bytes, op->argplus};
           patch_helper(mc_code, input);
           ptr += hdr->Size;
@@ -652,6 +680,11 @@ add_preemption_code(uint32_t col)
                           const std::string& section_name,
                           const std::string& argname)
   {
+    if (!mc_code.size())
+    {
+      std::cout << "txn buffer is empty\n";
+      return 0;
+    }
     const char *ptr = (mc_code.data());
     auto txn_header = reinterpret_cast<const XAie_TxnHeader *>(ptr);
 
@@ -692,7 +725,7 @@ add_preemption_code(uint32_t col)
     }
     uint32_t addend = static_cast<uint32_t>(input.addend);
 
-    if (argidx > (MAX_ARG_INDEX + ARG_OFFSET))
+    if (argidx > (MAX_ARG_INDEX + arg_offset))
     {
       auto error_msg = boost::format("Arg index: %d in patch opcode > 32") % argidx;
       throw error(error::error_code::invalid_asm, error_msg.str());
@@ -749,14 +782,14 @@ add_preemption_code(uint32_t col)
           // in case of scratchpad
           add_symbol({argname, offset, 0, 0, addend, buffer_length_in_bytes, section_name, symbol::patch_schema::shim_dma_48});
         }
-        else if (xrt_id_map.find(argidx-ARG_OFFSET) != xrt_id_map.end())
+        else if (xrt_id_map.find(argidx-arg_offset) != xrt_id_map.end())
         {
           // incase external buffer json is provided with xrt_id
-          add_symbol({xrt_id_map[argidx-ARG_OFFSET], offset, 0, 0, addend, buffer_length_in_bytes, section_name, symbol::patch_schema::shim_dma_48});
+          add_symbol({xrt_id_map[argidx-arg_offset], offset, 0, 0, addend, buffer_length_in_bytes, section_name, symbol::patch_schema::shim_dma_48});
         }
         else
         {
-          // added ARG_OFFSET to argidx to match with kernel argument index in xclbin
+          // added arg_offset to argidx to match with kernel argument index in xclbin
           add_symbol({std::to_string(argidx), offset, 0, 0, addend, buffer_length_in_bytes, section_name, symbol::patch_schema::shim_dma_48});
         }
         return;
@@ -861,5 +894,87 @@ add_preemption_code(uint32_t col)
       }
     }
     return 0;
+  }
+
+
+
+  void
+  config_preprocessor_input::
+  add_pdi(const boost::property_tree::ptree& pdis)
+  {
+    for (const auto& [unused, pdi] : pdis)
+      m_data[std::string(".pdi.") + pdi.get<std::string>("id")] = std::move(readfile(pdi.get<std::string>("PDI_file")));
+  }
+
+  void
+  config_preprocessor_input::
+  add_instance(const boost::property_tree::ptree& pinstance)
+  {
+    for (const auto& [unused, pic] : pinstance)
+    {
+      std::string tname = get_ctrltext_name(pic.get<std::string>("id"));
+      m_data[tname] = std::move(readfile(pic.get<std::string>("TXN_ctrl_code_file")));
+      //std::cout << "TXN_ctrl_code_file id:" << pic.get<std::string>("id") << std::endl;
+      //std::cout << "TXN_ctrl_code_file:" << pic.get<std::string>("TXN_ctrl_code_file") << std::endl;
+      if (!pic.get<std::string>("ctrl_packet_file", "").empty())
+        m_data[get_ctrldata_name(pic.get<std::string>("id"))] = std::move(readfile(pic.get<std::string>("ctrl_packet_file")));
+
+      if (!pic.get<std::string>("patch_info_file", "").empty())
+      {
+        std::vector<char> jdata = readfile(pic.get<std::string>("patch_info_file"));
+        vector_streambuf vsb(jdata);
+        std::istream elf_stream(&vsb);
+        readmetajson(elf_stream, pic.get<std::string>("id"));
+      }
+      // col is used to add corrosponding save/restore control code
+      col = extractSymbolFromBuffer(m_data[tname], tname, "");
+      xrt_id_map.clear();
+    }
+  }
+
+  void
+  config_preprocessor_input::
+  readconfigjson(std::istream& patch_json)
+  {
+    boost::property_tree::ptree pt;
+    boost::property_tree::read_json(patch_json, pt);
+
+    const auto& pt_xrt_kernel_instance = pt.get_child_optional("xrt-kernels");
+    if (!pt_xrt_kernel_instance) {
+      std::cout << "xrt-kernels instance not found returning\n";
+      return;
+    }
+    const auto& p_xrt_kernel_instance = pt_xrt_kernel_instance.get();
+    for (const auto& [unused, ctrlcode] : p_xrt_kernel_instance)
+    {
+      //const auto& ctrlcode = pt_ctrlcode.second;
+      //get mangled kernel name
+      function func;
+      func.name = ctrlcode.get<std::string>("name");
+      for (const auto& item : ctrlcode.get_child("arguments")) {
+        func.arguments.emplace_back(item.second.get<std::string>("name"),
+                                    item.second.get<std::string>("type"),
+                                    item.second.get<std::string>("offset"));
+      }
+      std::string mangled_name = mangle_function_name(func);
+      //std::cout << "Mangled Function Name: " << mangled_name << std::endl;
+      add_metadata("kernel.signature", mangled_name);
+
+      const auto& pt_pdis = ctrlcode.get_child_optional("PDIs");
+      if (pt_pdis) {
+        const auto& pdis = pt_pdis.get();
+        add_pdi(pdis);
+      } else {
+        std::cout << "PDIs not found\n";
+      }
+
+      const auto& pt_instance = ctrlcode.get_child_optional("instance");
+      if (pt_instance) {
+        const auto& pinstance = pt_instance.get();
+        add_instance(pinstance);
+      } else {
+        std::cout << "instance not found\n";
+      }
+    }
   }
 }

--- a/src/cpp/preprocessor/aie2/aie2_blob_preprocessor_input.h
+++ b/src/cpp/preprocessor/aie2/aie2_blob_preprocessor_input.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
 #ifndef _AIEBU_PREPROCESSOR_AIE2_BLOB_PREPROCESSOR_INPUT_H_
 #define _AIEBU_PREPROCESSOR_AIE2_BLOB_PREPROCESSOR_INPUT_H_
@@ -7,6 +7,7 @@
 #include <map>
 #include "symbol.h"
 #include "utils.h"
+#include "file_utils.h"
 #include "preprocessor_input.h"
 #include <boost/format.hpp>
 #include <boost/property_tree/json_parser.hpp>
@@ -21,7 +22,7 @@ class aie2_blob_preprocessor_input : public preprocessor_input
 {
 protected:
   const std::string ctrlText = ".ctrltext";
-  const std::string ctrlData = ".ctrldata";
+  const std::string ctrl_data = ".ctrldata";
   const std::string preempt_save = ".preempt_save";
   const std::string preempt_restore = ".preempt_restore";
   const std::string preempt_lib = "preempt";
@@ -42,7 +43,7 @@ protected:
 
   // For transaction buffer flow. In Xclbin kernel argument, actual argument start from 3,
   // 0th is opcode, 1st is instruct buffer, 2nd is instruct buffer size.
-  constexpr static uint32_t ARG_OFFSET = 3;
+  uint32_t arg_offset = 3;
 
   enum class offset_type {
     CONTROL_PACKET,
@@ -65,15 +66,21 @@ protected:
   std::vector<uint32_t> pm_id_list;
   bool haspreempt = false;
   virtual uint32_t extractSymbolFromBuffer(std::vector<char>& mc_code, const std::string& section_name, const std::string& argname) = 0;
-  void aiecompiler_json_parser(const boost::property_tree::ptree& pt);
+  void aiecompiler_json_parser(const boost::property_tree::ptree& pt, const std::string& instance_id);
   void dmacompiler_json_parser(const boost::property_tree::ptree& pt);
-  void readmetajson(std::istream& patch_json);
-  void extract_control_packet_patch(const std::string& name, const uint32_t arg_index, const boost::property_tree::ptree& _pt);
-  void extract_coalesed_buffers(const std::string& name, const boost::property_tree::ptree& _pt);
+  void readmetajson(std::istream& patch_json, const std::string& instance_id);
+  void extract_control_packet_patch(const std::string& name, uint32_t arg_index,
+                                    const boost::property_tree::ptree& _pt, const std::string& instance_id);
+  void extract_coalesed_buffers(const std::string& name, const boost::property_tree::ptree& _pt, const std::string& instance_id);
   void clear_shimBD_address_bits(std::vector<char>& mc_code, uint32_t offset) const;
   void validate_json(uint32_t offset, uint32_t size, uint32_t arg_index, offset_type type) const;
   uint32_t get_32_bit_property(const boost::property_tree::ptree& pt, const std::string& property, bool defaultvalue = false) const;
   void add_preemption_code(uint32_t col);
+  std::string get_pdi_name(uint16_t pdi_id)
+  {
+    return ".pdi." + std::to_string(pdi_id);
+  }
+
 public:
   aie2_blob_preprocessor_input() = default;
   virtual void set_args(const std::vector<char>& mc_code,
@@ -98,7 +105,7 @@ public:
     {
       vector_streambuf vsb(patch_json);
       std::istream elf_stream(&vsb);
-      readmetajson(elf_stream);
+      readmetajson(elf_stream, "");
     }
 
     auto col = extractSymbolFromBuffer(m_data[".ctrltext"], ctrlText, "");
@@ -267,6 +274,81 @@ public:
   {
     const std::vector<char> mc_code = encode(mc_asm_code);
     aie2_blob_transaction_preprocessor_input::set_args(mc_code, patch_json, control_packet, libs, libpaths, ctrlpkt);
+  }
+};
+
+class config_preprocessor_input : public aie2_blob_transaction_preprocessor_input
+{
+  uint32_t col = 0;
+protected:
+  void readconfigjson(std::istream& patch_json);
+  void add_pdi(const boost::property_tree::ptree& pinstance);
+  void add_instance(const boost::property_tree::ptree& pinstance);
+  std::string get_ctrltext_name(std::string instance_id)
+  {
+    return ".ctrltext." + instance_id;
+  }
+  std::string get_ctrldata_name(std::string instance_id)
+  {
+    return ".ctrldata." + instance_id;
+  }
+  class argument {
+    public:
+    std::string name;
+    std::string type;
+    std::string offset;
+
+    argument(std::string na, std::string ty, std::string off):
+             name(std::move(na)),
+             type(std::move(ty)),
+             offset(std::move(off)) {}
+    argument(const argument& rhs) = default;
+    argument& operator=(const argument& rhs) = default;
+    argument(argument &&s) = default;
+    ~argument() = default;
+  };
+
+  struct function {
+    std::string name;
+    std::vector<argument> arguments;
+  };
+
+  std::string mangle_function_name(const function& func) {
+    std::string mangled_name = "_Z" + std::to_string(func.name.length()) + func.name;
+    for (const auto& arg : func.arguments) {
+        if (arg.type == "char *") {
+            mangled_name += "Pc"; // 'Pc' represents 'char *' in Itanium C++ ABI
+        } else if (arg.type == "void *") {
+            mangled_name += "Pv"; // 'Pv' represents 'void *' in Itanium C++ ABI
+        } else if (arg.type == "scalar") {
+            mangled_name += "i"; // 'i' represents 'int' in Itanium C++ ABI for scalar
+        } else if (arg.type == "int *") {
+            mangled_name += "Pi"; // 'Pi' represents 'int *' in Itanium C++ ABI
+        }
+    }
+    return mangled_name;
+  }
+public:
+  config_preprocessor_input() = default;
+  void set_args(const std::vector<char>& /*mc_code*/,
+                const std::vector<char>& patch_json,
+                const std::vector<char>& /*control_packet*/,
+                const std::vector<std::string>& /*libs*/,
+                const std::vector<std::string>& /*libpaths*/,
+                const std::map<uint32_t, std::vector<char> >& /*ctrlpkt*/) override
+  {
+    arg_offset = 0;
+    if (patch_json.size() !=0)
+    {
+      vector_streambuf vsb(patch_json);
+      std::istream elf_stream(&vsb);
+      readconfigjson(elf_stream);
+    }
+
+    add_metadata("configuration", std::to_string(col));
+
+    if (haspreempt)
+      add_preemption_code(col);
   }
 };
 }

--- a/src/cpp/preprocessor/aie2/config_preprocessor.h
+++ b/src/cpp/preprocessor/aie2/config_preprocessor.h
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+
+#ifndef AIEBU_PREPROCESSOR_CONFIG_PREPROCESSOR_H_
+#define AIEBU_PREPROCESSOR_CONFIG_PREPROCESSOR_H_
+
+#include "preprocessor.h"
+#include "aie2_blob_preprocessor_input.h"
+#include "aie2_blob_preprocessed_output.h"
+
+namespace aiebu {
+
+class config_preprocessor: public preprocessor
+{  
+
+public:
+  config_preprocessor() = default;
+
+  std::vector<uint8_t> transform(const std::vector<char>& in)
+  {
+    // transform vector<char> to vector<uint8_t>
+    std::vector<uint8_t> out;
+    out.resize(in.size());
+    std::transform(in.begin(), in.end(), out.begin(), [](char c) {return static_cast<uint8_t>(c);});
+    return out;
+  }
+
+  std::shared_ptr<preprocessed_output>
+  process(std::shared_ptr<preprocessor_input> input) override
+  {
+    // preporcess : nothing to be done.
+    auto rinput = std::static_pointer_cast<config_preprocessor_input>(input);
+    auto routput = std::make_shared<aie2_blob_preprocessed_output>();
+
+    for(const auto& key : rinput->get_keys())
+      routput->add_data(key, transform(rinput->get_data(key)));
+
+    routput->add_symbols(rinput->get_symbols());
+    routput->add_metadata(std::move(rinput->get_metadata()));
+    return routput;
+  }
+};
+
+}
+#endif //AIEBU_PREPROCESSOR_CONFIG_PREPROCESSOR_H_

--- a/src/cpp/preprocessor/preprocessor_input.h
+++ b/src/cpp/preprocessor/preprocessor_input.h
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <map>
 #include <vector>
+#include <unordered_map>
 #include <string>
 
 namespace aiebu {
@@ -18,6 +19,7 @@ class preprocessor_input
 protected:
   std::map<std::string, std::vector<char>> m_data;
   std::vector<symbol> m_sym;
+  std::unordered_map<std::string, std::string> m_metadata;
 public:
   preprocessor_input() {}
   virtual ~preprocessor_input() = default;
@@ -37,7 +39,7 @@ public:
     return keys;
   }
 
-  virtual std::vector<char>& get_data(std::string& key)
+  virtual std::vector<char>& get_data(const std::string& key)
   {
     auto it = m_data.find(key);
     if (it == m_data.end())
@@ -58,6 +60,17 @@ public:
   void add_symbols(const std::vector<symbol>& syms)
   {
     m_sym.insert( m_sym.end(), syms.begin(), syms.end());
+  }
+
+  void add_metadata(const std::string& key, std::string val)
+  {
+    m_metadata[key] = std::move(val);
+  }
+
+  std::unordered_map<std::string, std::string>&
+  get_metadata()
+  {
+    return m_metadata;
   }
 };
 

--- a/src/cpp/utils/asm/asm.cpp
+++ b/src/cpp/utils/asm/asm.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.
 
 #include <boost/format.hpp>
 #include <cxxopts.hpp>
@@ -28,7 +28,7 @@ void main_helper(int argc, char** argv,
       .allow_unrecognised_options()
       .add_options()
       ("h,help", "show help message and exit", cxxopts::value<bool>()->default_value("false"))
-      ("t,target", "supported targets aie2ps/aie2asm/aie2txn/aie2dpu", cxxopts::value<decltype(target_name)>())
+      ("t,target", "supported targets aie2ps/aie2asm/aie2txn/aie2dpu/config", cxxopts::value<decltype(target_name)>())
     ;
 
     auto result = global_options.parse(argc, argv);
@@ -82,6 +82,7 @@ int main( int argc, char** argv )
     targets.emplace_back(std::make_shared<aiebu::utilities::target_aie2>(executable));
     targets.emplace_back(std::make_shared<aiebu::utilities::target_aie2blob_transaction>(executable));
     targets.emplace_back(std::make_shared<aiebu::utilities::target_aie2blob_dpu>(executable));
+    targets.emplace_back(std::make_shared<aiebu::utilities::target_config>(executable));
   }
 
   // -- Program Description

--- a/src/cpp/utils/target/target.cpp
+++ b/src/cpp/utils/target/target.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.
 
 #include <iostream>
 #include <limits>
@@ -47,7 +47,7 @@ target_aie2blob::parse_pmctrlpkt(const std::vector<std::string> pm_key_value_pai
 
 bool
 aiebu::utilities::
-target_aie2blob::parseOption(const sub_cmd_options &_options)
+target_aie2blob::parseOption(const sub_cmd_options &options)
 {
   std::vector<std::string> pm_key_value_pairs;
   cxxopts::Options all_options("Target aie2blob Options", m_description);
@@ -65,7 +65,7 @@ target_aie2blob::parseOption(const sub_cmd_options &_options)
             ("h,help", "show help message and exit", cxxopts::value<bool>()->default_value("false"))
     ;
 
-    auto char_ver = aiebu::utilities::vector_of_string_to_vector_of_char(_options);
+    auto char_ver = aiebu::utilities::vector_of_string_to_vector_of_char(options);
 
     auto result = all_options.parse(char_ver.size(), char_ver.data());
 
@@ -107,7 +107,8 @@ target_aie2blob::parseOption(const sub_cmd_options &_options)
     throw std::runtime_error(errMsg.str());
   }
 
-  readfile(m_transaction_file, m_transaction_buffer);
+  if (!m_transaction_file.empty())
+    readfile(m_transaction_file, m_transaction_buffer);
 
   m_ctrlpkt = parse_pmctrlpkt(pm_key_value_pairs);
 
@@ -122,9 +123,9 @@ target_aie2blob::parseOption(const sub_cmd_options &_options)
 
 void
 aiebu::utilities::
-target_aie2blob_dpu::assemble(const sub_cmd_options &_options)
+target_aie2blob_dpu::assemble(const sub_cmd_options &options)
 {
-  if (!parseOption(_options))
+  if (!parseOption(options))
     return;
 
   try {
@@ -142,9 +143,9 @@ target_aie2blob_dpu::assemble(const sub_cmd_options &_options)
 
 void
 aiebu::utilities::
-target_aie2blob_transaction::assemble(const sub_cmd_options &_options)
+target_aie2blob_transaction::assemble(const sub_cmd_options &options)
 {
-  if (!parseOption(_options))
+  if (!parseOption(options))
     return;
 
   try {
@@ -167,9 +168,9 @@ target_aie2blob_transaction::assemble(const sub_cmd_options &_options)
 
 void
 aiebu::utilities::
-target_aie2::assemble(const sub_cmd_options &_options)
+target_aie2::assemble(const sub_cmd_options &options)
 {
-  if (!parseOption(_options))
+  if (!parseOption(options))
     return;
 
   try {
@@ -193,7 +194,7 @@ target_aie2::assemble(const sub_cmd_options &_options)
 
 void
 aiebu::utilities::
-target_aie2ps::assemble(const sub_cmd_options &_options)
+target_aie2ps::assemble(const sub_cmd_options &options)
 {
   std::string output_elffile;
   std::string input_file;
@@ -211,7 +212,7 @@ target_aie2ps::assemble(const sub_cmd_options &_options)
             ("help,h", "show help message and exit", cxxopts::value<bool>()->default_value("false"))
     ;
 
-    auto char_ver = aiebu::utilities::vector_of_string_to_vector_of_char(_options);
+    auto char_ver = aiebu::utilities::vector_of_string_to_vector_of_char(options);
     auto result = all_options.parse(char_ver.size(), char_ver.data());
 
     if (result.count("help")) {
@@ -258,6 +259,59 @@ target_aie2ps::assemble(const sub_cmd_options &_options)
     aiebu::aiebu_assembler as(aiebu::aiebu_assembler::buffer_type::asm_aie2ps, asmBuffer, {}, libpaths, patch_data_buffer);
     write_elf(as, output_elffile);
   } catch (aiebu::error &ex) {
+    auto errMsg = boost::format("Error: %s, code:%d\n") % ex.what() % ex.get_code() ;
+    throw std::runtime_error(errMsg.str());
+  }
+}
+
+void
+aiebu::utilities::
+target_config::assemble(const sub_cmd_options &options)
+{
+  std::string output_elffile;
+  std::string json_file;
+  cxxopts::Options all_options("Target config Options", m_description);
+
+  try {
+    all_options.add_options()
+            ("o,outputelf", "ELF output file name", cxxopts::value<decltype(output_elffile)>())
+            ("j,json", "control packet Patching json file", cxxopts::value<decltype(json_file)>())
+            ("h,help", "show help message and exit", cxxopts::value<bool>()->default_value("false"))
+    ;
+
+
+    auto char_ver = aiebu::utilities::vector_of_string_to_vector_of_char(options);
+
+    auto result = all_options.parse(static_cast<int>(char_ver.size()), char_ver.data());
+
+    if (result.count("help")) {
+      std::cout << all_options.help({"", "Target config Options"});
+      return;
+    }
+
+    if (result.count("outputelf"))
+      output_elffile = result["outputelf"].as<decltype(output_elffile)>();
+    else
+      throw std::runtime_error("the option '--outputelf' is required but missing\n");
+
+    if (result.count("json"))
+      json_file = result["json"].as<decltype(json_file)>();
+  }
+  catch (const cxxopts::exceptions::exception& e) {
+    std::cout << all_options.help({"", "Target config Options"});
+    auto errMsg = boost::format("Error parsing options: %s\n") % e.what() ;
+    throw std::runtime_error(errMsg.str());
+  }
+
+  std::vector<char> json_buffer;
+  if (!json_file.empty())
+    readfile(json_file, json_buffer);
+
+  try {
+    aiebu::aiebu_assembler as(aiebu::aiebu_assembler::buffer_type::config, {}, {}, {}, json_buffer);
+    write_elf(as, output_elffile);
+  }
+  catch (aiebu::error &ex) {
     auto errMsg = boost::format("Error: %s, code:%d\n") % ex.what() % ex.get_code() ;
     throw std::runtime_error(errMsg.str());
   }

--- a/src/cpp/utils/target/target.h
+++ b/src/cpp/utils/target/target.h
@@ -64,7 +64,7 @@ class target
 class target_aie2ps: public target
 {
   public:
-  virtual void assemble(const sub_cmd_options &_options);
+  void assemble(const sub_cmd_options &_options) override;
 
   target_aie2ps(const std::string& name): target(name, "aie2ps", "aie2ps asm assembler") {}
 };
@@ -97,13 +97,13 @@ class target_aie2blob_transaction: public target_aie2blob
   target_aie2blob_transaction(const std::string& exename, const std::string& name = "aie2txn",
                               const std::string& description = "aie2 txn blob assembler")
     : target_aie2blob(exename, name, description) {}
-  virtual void assemble(const sub_cmd_options &_options);
+  void assemble(const sub_cmd_options &_options) override;
 };
 
 class target_aie2: public target_aie2blob_transaction
 {
   public:
-  virtual void assemble(const sub_cmd_options &_options);
+  void assemble(const sub_cmd_options &_options) override;
   target_aie2(const std::string& exename): target_aie2blob_transaction(exename, "aie2asm", "aie2 asm assembler") {}
 };
 
@@ -112,9 +112,15 @@ class target_aie2blob_dpu: public target_aie2blob
   public:
   target_aie2blob_dpu(const std::string& exename)
     : target_aie2blob(exename, "aie2dpu", "aie2 dpu blob assembler") {}
-  virtual void assemble(const sub_cmd_options &_options);
+  void assemble(const sub_cmd_options &_options) override;
 };
 
+class target_config: public target
+{
+  public:
+  void assemble(const sub_cmd_options &_options) override;
+  explicit target_config(const std::string& name): target(name, "config", "generate config elf") {}
+};
 } //namespace aiebu::utilities
 
 #endif // AIEBU_UTILITIES_TARGET_H_


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This PR enables new flow where ELF file is input instead of xclbin.
spec - https://confluence.amd.com/display/AIE/AIE+Compiler+Artifacts#AIECompilerArtifacts-Flow2

This new Elf has partition size and kernel signature.
It has multiple .ctrltext and .ctrldata sections and multiple .pdi sections.
Each ctrltext section represents one control code and pdi addresses along with kernel args needs to be patched into the control code buffer.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)

#### config.json
```
{
  "xrt-kernels": [
    {
      "name" : "Resnet18",
      "arguments" : [
        {
          "name" : "arg0",
          "type" : "char *",
          "offset" : "0x00"
        },
        {
          "name" : "arg1",
          "type" : "char *",
          "offset" : "0x08"
        },
        {
          "name" : "arg2",
          "type" : "char *",
          "offset" : "0x10"
        },
        {
          "name" : "arg3",
          "type" : "char *",
          "offset" : "0x18"
        }
      ],
        "instance" : [
                 {
                   "id" : 0,
                   "TXN_ctrl_code_file" : "/path/to/ml_txn_lp.bin",
                   "ctrl_packet_file" : "/path/to/ctrl_pkt0.bin",
                   "patch_info_file" : "/path/to/external_buffer_id.json"
                 },
                 {
                   "id" : 1,
                   "TXN_ctrl_code_file" : "/path/to/ml_txn_lp.bin"
                 }
        ],
        "PDIs" : [
                {
                  "id" : 0,
                  "PDI_file" : "/path/to/pdi0.pdi"
                },
                {
                  "id" : 1,
                  "PDI_file" : "/path/to/pdi1.pdi"
                }
        ]
    }
  ]
}
```

```
> aiebu-asm -t config -j config.json -o config.elf
```

```

>readelf -a config.elf 
ELF Header:
  Magic:   7f 45 4c 46 01 01 01 46 02 00 00 00 00 00 00 00 
  Class:                             ELF32
  Data:                              2's complement, little endian
  Version:                           1 (current)
  OS/ABI:                            <unknown: 46>
  ABI Version:                       2
  Type:                              EXEC (Executable file)
  Machine:                           WE32100
  Version:                           0x1
  Entry point address:               0x0
  Start of program headers:          52 (bytes into file)
  Start of section headers:          338624 (bytes into file)
  Flags:                             0x0
  Size of this header:               52 (bytes)
  Size of program headers:           32 (bytes)
  Number of program headers:         7
  Size of section headers:           40 (bytes)
  Number of section headers:         15
  Section header string table index: 1

Section Headers:
  [Nr] Name              Type            Addr     Off    Size   ES Flg Lk Inf Al
  [ 0]                   NULL            00000000 000000 000000 00      0   0  0
  [ 1] .shstrtab         STRTAB          00000000 052750 000096 00      0   0  1
  [ 2] .ctrldata.0       PROGBITS        00000000 000120 0004e0 00  WA  0   0 16
  [ 3] .ctrltext.0       PROGBITS        00000000 000600 004620 00  WA  0   0 16
  [ 4] .ctrltext.1       PROGBITS        00000000 004c20 004620 00  WA  0   0 16
  [ 5] .pdi.0            PROGBITS        00000000 009240 024a80 00  WA  0   0 16
  [ 6] .pdi.1            PROGBITS        00000000 02dcc0 024a80 00  WA  0   0 16
  [ 7] .dynstr           STRTAB          00000000 0527e6 00002e 00      0   0  0
  [ 8] .dynsym           DYNSYM          00000000 052818 0000c0 10   A  7   1  8
  [ 9] .rela.dyn         RELA            00000000 0528d8 00015c 0c   A  8   0  8
  [10] .dynamic          DYNAMIC         00000000 052740 000010 08   A  7   0  8
  [11] .note.xrt.co[...] NOTE            00000000 052a34 000014 00      0   0  1
  [12] .strtab           STRTAB          00000000 052a48 000015 00      0   0  0
  [13] .symtab           SYMTAB          00000000 052a60 000020 10     12   1  4
  [14] .note.xrt.UID     NOTE            00000000 052a80 000030 00      0   0  1
Key to Flags:
  W (write), A (alloc), X (execute), M (merge), S (strings), I (info),
  L (link order), O (extra OS processing required), G (group), T (TLS),
  C (compressed), x (unknown), o (OS specific), E (exclude),
  p (processor specific)

There are no section groups in this file.

Program Headers:
  Type           Offset   VirtAddr   PhysAddr   FileSiz MemSiz  Flg Align
  PHDR           0x000034 0x00000000 0x00000000 0x000e0 0x000e0 R   0
readelf: Error: the PHDR segment is not covered by a LOAD segment
  LOAD           0x000120 0x00000000 0x00000000 0x004e0 0x004e0 RW  0x10
  LOAD           0x000600 0x00000000 0x00000000 0x04620 0x04620 RW  0x10
  LOAD           0x004c20 0x00000000 0x00000000 0x04620 0x04620 RW  0x10
  LOAD           0x009240 0x00000000 0x00000000 0x24a80 0x24a80 RW  0x10
  LOAD           0x02dcc0 0x00000000 0x00000000 0x24a80 0x24a80 RW  0x10
  DYNAMIC        0x052740 0x00000000 0x00000000 0x00010 0x00010 RW  0x8

 Section to Segment mapping:
  Segment Sections...
   00     
   01     .ctrldata.0 
   02     .ctrltext.0 
   03     .ctrltext.1 
   04     .pdi.0 
   05     .pdi.1 
   06     .dynamic 

Dynamic section at offset 0x52740 contains 2 entries:
  Tag        Type                         Name/Value
 0x00000007 (RELA)                       0x9
 0x00000008 (RELASZ)                     348 (bytes)

Relocation section '.rela.dyn' at offset 0x528d8 contains 29 entries:
 Offset     Info    Type            Sym.Value  Sym. Name + Addend
00000004  00000104 unrecognized: 4       00000000   2 + 0
00000144  00000204 unrecognized: 4       00000000   1 + 0
00000424  00000304 unrecognized: 4       00000000   3 + 0
00000018  00000408 unrecognized: 8       00000000   .pdi.0 + 0
00001c90  00000505 unrecognized: 5       00000000   1 + f0
00001ee8  00000605 unrecognized: 5       00000000   control-packet + 0
00002028  00000505 unrecognized: 5       00000000   1 + a0
000021c0  00000605 unrecognized: 5       00000000   control-packet + 0
00002300  00000505 unrecognized: 5       00000000   1 + 50
00002498  00000605 unrecognized: 5       00000000   control-packet + 0
000025d8  00000505 unrecognized: 5       00000000   1 + 0
00002770  00000605 unrecognized: 5       00000000   control-packet + 0
000042b0  00000705 unrecognized: 5       00000000   2 + f0
000043a8  00000705 unrecognized: 5       00000000   2 + a0
000044a0  00000705 unrecognized: 5       00000000   2 + 50
00004598  00000705 unrecognized: 5       00000000   2 + 0
00000018  00000808 unrecognized: 8       00000000   .pdi.0 + 0
00001c90  00000905 unrecognized: 5       00000000   1 + f0
00001ee8  00000a05 unrecognized: 5       00000000   0 + 0
00002028  00000905 unrecognized: 5       00000000   1 + a0
000021c0  00000a05 unrecognized: 5       00000000   0 + 0
00002300  00000905 unrecognized: 5       00000000   1 + 50
00002498  00000a05 unrecognized: 5       00000000   0 + 0
000025d8  00000905 unrecognized: 5       00000000   1 + 0
00002770  00000a05 unrecognized: 5       00000000   0 + 0
000042b0  00000b05 unrecognized: 5       00000000   2 + f0
000043a8  00000b05 unrecognized: 5       00000000   2 + a0
000044a0  00000b05 unrecognized: 5       00000000   2 + 50
00004598  00000b05 unrecognized: 5       00000000   2 + 0

The decoding of unwind sections for machine type WE32100 is not currently supported.

Symbol table '.dynsym' contains 12 entries:
   Num:    Value  Size Type    Bind   Vis      Ndx Name
     0: 00000000     0 NOTYPE  LOCAL  DEFAULT  UND 
     1: 00000000     0 OBJECT  GLOBAL DEFAULT    2 2
     2: 00000000     0 OBJECT  GLOBAL DEFAULT    2 1
     3: 00000000     0 OBJECT  GLOBAL DEFAULT    2 3
     4: 00000000 0x24a80 OBJECT  GLOBAL DEFAULT    3 .pdi.0
     5: 00000000 61440 OBJECT  GLOBAL DEFAULT    3 1
     6: 00000000  1536 OBJECT  GLOBAL DEFAULT    3 control-packet
     7: 00000000    80 OBJECT  GLOBAL DEFAULT    3 2
     8: 00000000 0x24a80 OBJECT  GLOBAL DEFAULT    4 .pdi.0
     9: 00000000 61440 OBJECT  GLOBAL DEFAULT    4 1
    10: 00000000  1536 OBJECT  GLOBAL DEFAULT    4 0
    11: 00000000    80 OBJECT  GLOBAL DEFAULT    4 2

Symbol table '.symtab' contains 2 entries:
   Num:    Value  Size Type    Bind   Vis      Ndx Name
     0: 00000000     0 NOTYPE  LOCAL  DEFAULT  UND 
     1: 00000000     0 FUNC    WEAK   DEFAULT  UND _Z8Resnet18PcPcPcPc

No version information found in this file.

Displaying notes found in: .note.xrt.configuration
  Owner                Data size 	Description
  XRT                  0x00000001	Unknown note type: (0x00000006)
   description data: 34 

Displaying notes found in: .note.xrt.UID
  Owner                Data size 	Description
  XRT                  0x00000020	GO BUILDID
   description data: 62 66 35 32 39 61 36 66 66 34 39 38 30 32 37 33 63 65 39 65 38 30 64 33 37 36 66 33 30 38 61 35 

```
