### PR TITLE
aie4 changes

### DIFF
--- a/src/cpp/assembler/aiebu_assembler.cpp
+++ b/src/cpp/assembler/aiebu_assembler.cpp
@@ -61,6 +61,11 @@ aiebu_assembler(buffer_type type,
     aiebu::assembler a(assembler::elf_type::config);
     elf_data = a.process(buffer1, libs, libpaths, patch_json, buffer2);
   }
+  else if (type == buffer_type::asm_aie4)
+  {
+    aiebu::assembler a(assembler::elf_type::aie4_asm);
+    elf_data = a.process(buffer1, libs, libpaths, patch_json);
+  }
   else {
     throw error(error::error_code::invalid_buffer_type, "Buffer_type not supported !!!");
   }

--- a/src/cpp/assembler/assembler.cpp
+++ b/src/cpp/assembler/assembler.cpp
@@ -9,6 +9,10 @@
 #include "aie2ps_elfwriter.h"
 #include "aie2ps_encoder.h"
 #include "aie2ps_preprocessor.h"
+#include "encoder/aie4/aie4_encoder.h"
+#include "preprocessor/aie4/aie4_preprocessor.h"
+#include "preprocessor/aie4/aie4_preprocessor_input.h"
+#include "elf/aie4/aie4_elfwriter.h"
 #include "elfwriter.h"
 #include "encoder.h"
 #include "preprocessor.h"
@@ -55,6 +59,13 @@ assembler(const elf_type type)
     m_enoder = std::make_unique<aie2_blob_encoder>();
     m_elfwriter = std::make_unique<config_elf_writer>();
     m_ppi = std::make_shared<config_preprocessor_input>();
+  }
+  else if (type == elf_type::aie4_asm)
+  {
+    m_preprocessor = std::make_unique<aie4_preprocessor>();
+    m_enoder = std::make_unique<aie4_encoder>();
+    m_elfwriter = std::make_unique<aie4_elf_writer>();
+    m_ppi = std::make_shared<aie4_preprocessor_input>();
   }
   else {
     throw error(error::error_code::invalid_buffer_type ,"Invalid elf type!!!");

--- a/src/cpp/assembler/assembler.h
+++ b/src/cpp/assembler/assembler.h
@@ -30,7 +30,8 @@ public:
     aie2_dpu_blob,
     aie2ps_asm,
     aie2_asm,
-    config
+    config,
+    aie4_asm
   };
 
   explicit assembler(const elf_type type);

--- a/src/cpp/common/assembler_state.cpp
+++ b/src/cpp/common/assembler_state.cpp
@@ -140,7 +140,7 @@ process(bool makeunique)
  * 4. If string is numeric string: it will convert to decimal
  */
 uint32_t assembler_state::parse_num_arg(const std::string& str) {
-  static const std::unordered_map<std::string, std::function<uint32_t(const std::string&)>> handlers = {
+  const std::unordered_map<std::string, std::function<uint32_t(const std::string&)>> handlers = {
     {"@", [this](const std::string& s) -> uint32_t {
           //If string start with '@': it can be either pad name or label name
           auto key = s.substr(1);
@@ -157,7 +157,8 @@ uint32_t assembler_state::parse_num_arg(const std::string& str) {
     {"shim_s2mm_", [this](const std::string& s) -> uint32_t { return get_actor("shim_s2mm", s); }},
     {"shim_mm2s_", [this](const std::string& s) -> uint32_t { return get_actor("shim_mm2s", s); }},
     {"tile_s2mm_", [this](const std::string& s) -> uint32_t { return get_actor("tile_s2mm", s); }},
-    {"tile_mm2s_", [this](const std::string& s) -> uint32_t { return get_actor("tile_mm2s", s); }}
+    {"tile_mm2s_", [this](const std::string& s) -> uint32_t { return get_actor("tile_mm2s", s); }},
+    {"shim_ctrl_mm2s_", [this](const std::string& s) -> uint32_t { return get_actor("shim_ctrl_mm2s", s); }}
   };
 
   // check if its pad/label/actor

--- a/src/cpp/common/assembler_state.cpp
+++ b/src/cpp/common/assembler_state.cpp
@@ -150,15 +150,15 @@ uint32_t assembler_state::parse_num_arg(const std::string& str) {
             return it->second->get_pos();
           throw error(error::error_code::invalid_asm, "Label " + key + " not present in label map\n");
     }},
-    {"s2mm_", [this](const std::string& s) -> uint32_t { return get_actor("s2mm", s); }},
-    {"mm2s_", [this](const std::string& s) -> uint32_t { return get_actor("mm2s", s); }},
-    {"mem_s2mm_", [this](const std::string& s) -> uint32_t { return get_actor("mem_s2mm", s); }},
-    {"mem_mm2s_", [this](const std::string& s) -> uint32_t { return get_actor("mem_mm2s", s); }},
-    {"shim_s2mm_", [this](const std::string& s) -> uint32_t { return get_actor("shim_s2mm", s); }},
-    {"shim_mm2s_", [this](const std::string& s) -> uint32_t { return get_actor("shim_mm2s", s); }},
-    {"tile_s2mm_", [this](const std::string& s) -> uint32_t { return get_actor("tile_s2mm", s); }},
-    {"tile_mm2s_", [this](const std::string& s) -> uint32_t { return get_actor("tile_mm2s", s); }},
-    {"shim_ctrl_mm2s_", [this](const std::string& s) -> uint32_t { return get_actor("shim_ctrl_mm2s", s); }}
+    {"s2mm_", [this](const std::string& s) -> uint32_t { return get_actor(s); }},
+    {"mm2s_", [this](const std::string& s) -> uint32_t { return get_actor(s); }},
+    {"mem_s2mm_", [this](const std::string& s) -> uint32_t { return get_actor(s); }},
+    {"mem_mm2s_", [this](const std::string& s) -> uint32_t { return get_actor(s); }},
+    {"shim_s2mm_", [this](const std::string& s) -> uint32_t { return get_actor(s); }},
+    {"shim_mm2s_", [this](const std::string& s) -> uint32_t { return get_actor(s); }},
+    {"tile_s2mm_", [this](const std::string& s) -> uint32_t { return get_actor(s); }},
+    {"tile_mm2s_", [this](const std::string& s) -> uint32_t { return get_actor(s); }},
+    {"shim_ctrl_mm2s_", [this](const std::string& s) -> uint32_t { return get_actor(s); }}
   };
 
   // check if its pad/label/actor

--- a/src/cpp/common/assembler_state.h
+++ b/src/cpp/common/assembler_state.h
@@ -130,12 +130,11 @@ protected:
 
   //std::unordered_map<std::string, ActionId> actor_id;
 
-  virtual std::unordered_map<std::string, ActionId>& get_actor_id_map() const = 0;
-  uint32_t get_actor(const std::string& prefix, const std::string& s) const
+  virtual std::unordered_map<std::string, uint32_t>& get_actor_id_map() const = 0;
+  uint32_t get_actor(const std::string& s) const
   {
-    std::unordered_map<std::string, ActionId>& actor_id = get_actor_id_map();
-    uint32_t actor = std::stoi(s.substr(actor_id.at(prefix).actor_start));
-    return actor_id.at(prefix).base_actor_offset + actor;
+    std::unordered_map<std::string, uint32_t>& actor_id = get_actor_id_map();
+    return actor_id.at(s);
   }
 
   assembler_state(std::shared_ptr<std::map<std::string, std::shared_ptr<isa_op>>> isa,
@@ -207,21 +206,45 @@ public:
 
 class assembler_state_aie2ps : public assembler_state
 {
-  std::unordered_map<std::string, ActionId>&
+  std::unordered_map<std::string, uint32_t>&
   get_actor_id_map() const override
   {
-    static std::unordered_map<std::string, ActionId> actor_id = {
-      {"mm2s", {5, 6}},          //NOLINT
-      {"s2mm", {5, 0}},          //NOLINT
-      {"tile_mm2s", {10, 6}},    //NOLINT
-      {"tile_s2mm", {10, 0}},    //NOLINT
-      {"shim_mm2s", {10, 6}},    //NOLINT
-      {"shim_s2mm", {10, 0}},    //NOLINT
-      {"mem_mm2s", {9, 6}},      //NOLINT
-      {"mem_s2mm", {9, 0}}       //NOLINT
+    static std::unordered_map<std::string, uint32_t> actor_id = {
+      //{"s2mm_0", 0},          //NOLINT
+      //{"s2mm_1", 1},          //NOLINT
+
+      //{"mm2s_0", 6},          //NOLINT
+      //{"mm2s_1", 7},          //NOLINT
+
+      {"shim_s2mm_0", 0},          //NOLINT
+      {"shim_s2mm_1", 1},          //NOLINT
+
+      {"shim_mm2s_0", 6},          //NOLINT
+      {"shim_mm2s_1", 7},          //NOLINT
+
+      {"mem_s2mm_0", 0},          //NOLINT
+      {"mem_s2mm_1", 1},          //NOLINT
+      {"mem_s2mm_2", 2},          //NOLINT
+      {"mem_s2mm_3", 3},          //NOLINT
+      {"mem_s2mm_4", 4},          //NOLINT
+      {"mem_s2mm_5", 5},          //NOLINT
+
+      {"mem_mm2s_0", 6},          //NOLINT
+      {"mem_mm2s_1", 7},          //NOLINT
+      {"mem_mm2s_2", 8},          //NOLINT
+      {"mem_mm2s_3", 9},          //NOLINT
+      {"mem_mm2s_4", 10},         //NOLINT
+      {"mem_mm2s_5", 11},         //NOLINT
+
+      {"tile_s2mm_0", 0},          //NOLINT
+      {"tile_s2mm_1", 1},          //NOLINT
+      {"tile_mm2s_0", 6},          //NOLINT
+      {"tile_mm2s_1", 7},          //NOLINT
+      {"tile_core", 15},           //NOLINT
     };
     return actor_id;
   }
+
   public:
   assembler_state_aie2ps(std::shared_ptr<std::map<std::string, std::shared_ptr<isa_op>>> isa,
                          std::vector<std::shared_ptr<asm_data>>& data,
@@ -239,19 +262,48 @@ class assembler_state_aie2ps : public assembler_state
 
 class assembler_state_aie4 : public assembler_state
 {
-  std::unordered_map<std::string, ActionId>&
+  std::unordered_map<std::string, uint32_t>&
   get_actor_id_map() const override
   {
-    static std::unordered_map<std::string, ActionId> actor_id = {
-      {"mm2s", {5, 6}},               //NOLINT
-      {"s2mm", {5, 0}},               //NOLINT
-      {"tile_mm2s", {10, 6}},         //NOLINT
-      {"tile_s2mm", {10, 0}},         //NOLINT
-      {"shim_mm2s", {10, 6}},         //NOLINT
-      {"shim_s2mm", {10, 0}},         //NOLINT
-      {"mem_mm2s", {9, 16}},          //NOLINT
-      {"mem_s2mm", {9, 0}},           //NOLINT
-      {"shim_ctrl_mm2s", {15, 16}}    //NOLINT
+    static std::unordered_map<std::string, uint32_t> actor_id = {
+      {"shim_s2mm_0", 0},          //NOLINT
+      {"shim_trace_s2mm", 1},     //NOLINT
+      {"shim_s2mm_1", 2},          //NOLINT
+
+      {"shim_mm2s_0", 6},          //NOLINT
+      {"shim_mm2s_1", 7},          //NOLINT
+      {"shim_mm2s_2", 8},          //NOLINT
+      {"shim_mm2s_3", 9},          //NOLINT
+
+      {"shim_ctrl_mm2s_0", 16},    //NOLINT
+      {"shim_ctrl_mm2s_1", 17},    //NOLINT
+
+      {"mem_s2mm_0", 0},          //NOLINT
+      {"mem_s2mm_1", 1},          //NOLINT
+      {"mem_s2mm_2", 2},          //NOLINT
+      {"mem_s2mm_3", 3},          //NOLINT
+      {"mem_s2mm_4", 4},          //NOLINT
+      {"mem_s2mm_5", 5},          //NOLINT
+      {"mem_s2mm_6", 6},          //NOLINT
+      {"mem_s2mm_7", 7},          //NOLINT
+
+      {"mem_mm2s_0", 16},          //NOLINT
+      {"mem_mm2s_1", 17},          //NOLINT
+      {"mem_mm2s_2", 18},          //NOLINT
+      {"mem_mm2s_3", 19},          //NOLINT
+      {"mem_mm2s_4", 20},          //NOLINT
+      {"mem_mm2s_5", 22},          //NOLINT
+      {"mem_mm2s_6", 23},          //NOLINT
+      {"mem_mm2s_7", 24},          //NOLINT
+      {"mem_mm2s_8", 25},          //NOLINT
+      {"mem_mm2s_9", 26},          //NOLINT
+
+      {"tile_s2mm_0", 0},          //NOLINT
+      {"tile_s2mm_1", 1},          //NOLINT
+
+      {"tile_mm2s_0", 6},          //NOLINT
+
+      {"tile_core", 15},          //NOLINT
     };
     return actor_id;
   }

--- a/src/cpp/common/assembler_state.h
+++ b/src/cpp/common/assembler_state.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
 #ifndef _AIEBU_COMMON_ASSEMBLER_STATE_H_
 #define _AIEBU_COMMON_ASSEMBLER_STATE_H_
@@ -103,9 +103,11 @@ public:
   }
 };
 
-class assembler_state
+class assembler_state : public std::enable_shared_from_this<assembler_state>
 {
+protected:
   offset_type m_pos = 0;
+
   inline std::string gen_label_name(bool makeunique, const std::shared_ptr<asm_data> data)
   {
     return makeunique ? data->get_file() + ":" + data->get_operation()->get_name() : data->get_operation()->get_name();
@@ -126,22 +128,23 @@ class assembler_state
     uint32_t base_actor_offset; //base channel
   };
 
-  const std::unordered_map<std::string, ActionId> actor_id = {
-    {"mm2s", {5, 6}},
-    {"s2mm", {5, 0}},
-    {"tile_mm2s", {10, 6}},
-    {"tile_s2mm", {10, 0}},
-    {"shim_mm2s", {10, 6}},
-    {"shim_s2mm", {10, 0}},
-    {"mem_mm2s", {9, 6}},
-    {"mem_s2mm", {9, 0}}
-  };
+  //std::unordered_map<std::string, ActionId> actor_id;
 
+  virtual std::unordered_map<std::string, ActionId>& get_actor_id_map() const = 0;
   uint32_t get_actor(const std::string& prefix, const std::string& s) const
   {
+    std::unordered_map<std::string, ActionId>& actor_id = get_actor_id_map();
     uint32_t actor = std::stoi(s.substr(actor_id.at(prefix).actor_start));
     return actor_id.at(prefix).base_actor_offset + actor;
   }
+
+  assembler_state(std::shared_ptr<std::map<std::string, std::shared_ptr<isa_op>>> isa,
+                  std::vector<std::shared_ptr<asm_data>>& data,
+                  std::map<std::string, std::shared_ptr<scratchpad_info>>& scratchpad,
+                  std::map<std::string, uint32_t>& labelpageindex, uint32_t control_packet_index, bool makeunique);
+  assembler_state(const assembler_state& rhs) = default;
+  assembler_state& operator=(const assembler_state& rhs) = default;
+  assembler_state(assembler_state &&s) = default;
 public:
   std::shared_ptr<std::map<std::string, std::shared_ptr<isa_op>>> m_isa;
   std::vector<std::shared_ptr<asm_data>>& m_data;
@@ -155,11 +158,6 @@ public:
   std::map<std::string, uint32_t>& m_labelpageindex;
   uint32_t m_control_packet_index;
   std::string m_controlpacket_padname;
-
-  assembler_state(std::shared_ptr<std::map<std::string, std::shared_ptr<isa_op>>> isa,
-                  std::vector<std::shared_ptr<asm_data>>& data,
-                  std::map<std::string, std::shared_ptr<scratchpad_info>>& scratchpad,
-                  std::map<std::string, uint32_t>& labelpageindex, uint32_t control_packet_index, bool makeunique);
 
   HEADER_ACCESS_GET_SET(offset_type, pos);
 
@@ -200,7 +198,77 @@ public:
       [](const std::map<std::string, std::shared_ptr<label>>::value_type &pair){return pair.first;});
     return keys;
   }
+
+  virtual symbol::patch_schema get_shim_dma_patching() const = 0;
+  virtual symbol::patch_schema get_control_packet_patching() const = 0;
+  virtual ~assembler_state() = default;
 };
 
+
+class assembler_state_aie2ps : public assembler_state
+{
+  std::unordered_map<std::string, ActionId>&
+  get_actor_id_map() const override
+  {
+    static std::unordered_map<std::string, ActionId> actor_id = {
+      {"mm2s", {5, 6}},          //NOLINT
+      {"s2mm", {5, 0}},          //NOLINT
+      {"tile_mm2s", {10, 6}},    //NOLINT
+      {"tile_s2mm", {10, 0}},    //NOLINT
+      {"shim_mm2s", {10, 6}},    //NOLINT
+      {"shim_s2mm", {10, 0}},    //NOLINT
+      {"mem_mm2s", {9, 6}},      //NOLINT
+      {"mem_s2mm", {9, 0}}       //NOLINT
+    };
+    return actor_id;
+  }
+  public:
+  assembler_state_aie2ps(std::shared_ptr<std::map<std::string, std::shared_ptr<isa_op>>> isa,
+                         std::vector<std::shared_ptr<asm_data>>& data,
+                         std::map<std::string, std::shared_ptr<scratchpad_info>>& scratchpad,
+                         std::map<std::string, uint32_t>& labelpageindex, uint32_t control_packet_index, bool makeunique)
+                  : assembler_state(isa, data, scratchpad, labelpageindex, control_packet_index, makeunique)
+  {
+    //shim_dma_patching = symbol::patch_schema::shim_dma_57;
+    //control_packet_patching = symbol::patch_schema::control_packet_57;
+  }
+
+  symbol::patch_schema get_shim_dma_patching() const override { return symbol::patch_schema::shim_dma_57; }
+  symbol::patch_schema get_control_packet_patching() const override { return symbol::patch_schema::control_packet_57; }
+};
+
+class assembler_state_aie4 : public assembler_state
+{
+  std::unordered_map<std::string, ActionId>&
+  get_actor_id_map() const override
+  {
+    static std::unordered_map<std::string, ActionId> actor_id = {
+      {"mm2s", {5, 6}},               //NOLINT
+      {"s2mm", {5, 0}},               //NOLINT
+      {"tile_mm2s", {10, 6}},         //NOLINT
+      {"tile_s2mm", {10, 0}},         //NOLINT
+      {"shim_mm2s", {10, 6}},         //NOLINT
+      {"shim_s2mm", {10, 0}},         //NOLINT
+      {"mem_mm2s", {9, 16}},          //NOLINT
+      {"mem_s2mm", {9, 0}},           //NOLINT
+      {"shim_ctrl_mm2s", {15, 16}}    //NOLINT
+    };
+    return actor_id;
+  }
+
+  public:
+  assembler_state_aie4(std::shared_ptr<std::map<std::string, std::shared_ptr<isa_op>>> isa,
+                       std::vector<std::shared_ptr<asm_data>>& data,
+                       std::map<std::string, std::shared_ptr<scratchpad_info>>& scratchpad,
+                       std::map<std::string, uint32_t>& labelpageindex, uint32_t control_packet_index, bool makeunique)
+                  : assembler_state(isa, data, scratchpad, labelpageindex, control_packet_index, makeunique)
+  {
+    //shim_dma_patching = symbol::patch_schema::shim_dma_57_aie4;
+    //control_packet_patching = symbol::patch_schema::control_packet_57_aie4;
+  }
+
+  symbol::patch_schema get_shim_dma_patching() const override { return symbol::patch_schema::shim_dma_57_aie4; }
+  symbol::patch_schema get_control_packet_patching() const override { return symbol::patch_schema::control_packet_57_aie4; }
+};
 }
 #endif //_AIEBU_COMMON_ASSEMBLER_STATE_H_

--- a/src/cpp/common/symbol.h
+++ b/src/cpp/common/symbol.h
@@ -23,7 +23,8 @@ public:
     shim_dma_57_aie4 = 6,
     control_packet_57 = 7,
     address_64 = 8,
-    unknown = 9,
+    control_packet_57_aie4 = 9,
+    unknown = 10,
   };
 
 private:

--- a/src/cpp/elf/aie4/aie4_elfwriter.h
+++ b/src/cpp/elf/aie4/aie4_elfwriter.h
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+
+#ifndef AIEBU_ELF_AIE4_ELF_WRITER_H_
+#define AIEBU_ELF_AIE4_ELF_WRITER_H_
+
+#include <aie2ps_elfwriter.h>
+
+namespace aiebu {
+
+class aie4_elf_writer: public aie2ps_elf_writer
+{
+public:
+  aie4_elf_writer(): aie2ps_elf_writer()
+  { }
+};
+
+}
+#endif //AIEBU_ELF_AIE4_ELF_WRITER_H_

--- a/src/cpp/encoder/aie2ps/aie2ps_encoder.cpp
+++ b/src/cpp/encoder/aie2ps/aie2ps_encoder.cpp
@@ -128,7 +128,7 @@ page_writer(page& lpage, std::map<std::string, std::shared_ptr<scratchpad_info>>
   std::vector<std::shared_ptr<asm_data>> all;
   all.insert(all.end(), lpage.m_text.begin(), lpage.m_text.end());
   all.insert(all.end(), lpage.m_data.begin(), lpage.m_data.end());
-  assembler_state page_state = assembler_state(m_isa, all, scratchpad, labelpageindex, control_packet_index, false);
+  std::shared_ptr<assembler_state> page_state = create_assembler_state(m_isa, all, scratchpad, labelpageindex, control_packet_index, false);
 
   writer textwriter(get_TextSectionName(colnum, pagenum), code_section::text);
   writer datawriter(get_DataSectionName(colnum, pagenum), code_section::data);
@@ -145,7 +145,7 @@ page_writer(page& lpage, std::map<std::string, std::shared_ptr<scratchpad_info>>
     std::string name = text->get_operation()->get_name();
     if (text->isOpcode())
     {
-      page_state.set_pos(textwriter.tell() - offset);
+      page_state->set_pos(textwriter.tell() - offset);
       std::vector<uint8_t> ret = (*m_isa)[name]->serializer(text->get_operation()->get_args())
                                                ->serialize(page_state, tsym, colnum, pagenum);
       for (uint8_t byte : ret) {
@@ -159,7 +159,7 @@ page_writer(page& lpage, std::map<std::string, std::shared_ptr<scratchpad_info>>
   // encode data section
   for (auto data : lpage.m_data)
   {
-    page_state.set_pos(datawriter.tell() + textwriter.tell() - offset);
+    page_state->set_pos(datawriter.tell() + textwriter.tell() - offset);
     std::string name = data->get_operation()->get_name();
     if (!name.compare("eof"))
       continue;
@@ -178,13 +178,13 @@ page_writer(page& lpage, std::map<std::string, std::shared_ptr<scratchpad_info>>
       throw error(error::error_code::internal_error, "Invalid operation: " + name + " in DATA section !!!");
   }
 
-  for (auto &spad : page_state.m_patch)
+  for (auto &spad : page_state->m_patch)
   {
     for (auto& arg : spad.second)
     {
-      offset = page_state.parse_num_arg(arg);
+      offset = page_state->parse_num_arg(arg);
       patch57(textwriter, datawriter, offset + page_header.size(),
-              page_state.m_scratchpad[spad.first.substr(1)]->get_base() + page_state.m_scratchpad[spad.first.substr(1)]->get_offset());
+              page_state->m_scratchpad[spad.first.substr(1)]->get_base() + page_state->m_scratchpad[spad.first.substr(1)]->get_offset());
     }
   }
 
@@ -195,7 +195,7 @@ page_writer(page& lpage, std::map<std::string, std::shared_ptr<scratchpad_info>>
   twriter.push_back(textwriter);
   twriter.push_back(datawriter);
 
-  return page_state.m_controlpacket_padname;
+  return page_state->m_controlpacket_padname;
   // TODO add size and generate report
 }
 

--- a/src/cpp/encoder/aie2ps/aie2ps_encoder.h
+++ b/src/cpp/encoder/aie2ps/aie2ps_encoder.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
 #ifndef _AIEBU_ENCODER_AIE2PS_ENCODER_H_
 #define _AIEBU_ENCODER_AIE2PS_ENCODER_H_
@@ -30,10 +30,20 @@ public:
   std::string get_DataSectionName(uint32_t colnum, pageid_type pagenum) {return ".ctrldata." + std::to_string(colnum) + "." + std::to_string(pagenum); }
   std::string get_PadSectionName(uint32_t colnum) {return ".pad." + std::to_string(colnum); }
   std::string page_writer(page& lpage, std::map<std::string, std::shared_ptr<scratchpad_info>>& scratchpad, std::map<std::string, uint32_t>& labelpageindex, uint32_t control_packet_index);
-  void patch57(const writer& textwriter, writer& datawriter, offset_type offset, uint64_t patch);
+  virtual void patch57(const writer& textwriter, writer& datawriter, offset_type offset, uint64_t patch);
   void fill_scratchpad(writer& padwriter,const std::map<std::string, std::shared_ptr<scratchpad_info>>& scratchpads);
   void fill_control_packet_symbols(writer& padwriter,const uint32_t col, const std::string& controlpacket_padname, std::vector<symbol>& syms, const std::map<std::string, std::shared_ptr<scratchpad_info>>& scratchpads);
   std::string findKey(const std::map<std::string, std::vector<std::string>>& myMap, const std::string& value);
+
+  virtual std::shared_ptr<assembler_state>
+  create_assembler_state(std::shared_ptr<std::map<std::string, std::shared_ptr<isa_op>>> isa,
+                         std::vector<std::shared_ptr<asm_data>>& data,
+                         std::map<std::string, std::shared_ptr<scratchpad_info>>& scratchpad,
+                         std::map<std::string, uint32_t>& labelpageindex,
+                         uint32_t control_packet_index, bool makeunique)
+  {
+    return std::make_shared<assembler_state_aie2ps>(isa, data, scratchpad, labelpageindex, control_packet_index, makeunique);
+  }
 };
 
 }

--- a/src/cpp/encoder/aie4/aie4_encoder.h
+++ b/src/cpp/encoder/aie4/aie4_encoder.h
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+
+#ifndef AIEBU_ENCODER_AIE4_ENCODER_H_
+#define AIEBU_ENCODER_AIE4_ENCODER_H_
+
+#include <memory>
+
+#include "aie2ps_encoder.h"
+#include "writer.h"
+#include "aie2ps_preprocessed_output.h"
+#include "ops.h"
+#include "specification/aie2ps/isa.h"
+
+namespace aiebu {
+
+class aie4_encoder : public aie2ps_encoder
+{
+protected:
+  
+public:
+  aie4_encoder(): aie2ps_encoder() {}
+
+  std::shared_ptr<assembler_state>
+  create_assembler_state(std::shared_ptr<std::map<std::string, std::shared_ptr<isa_op>>> isa,
+                         std::vector<std::shared_ptr<asm_data>>& data,
+                         std::map<std::string, std::shared_ptr<scratchpad_info>>& scratchpad,
+                         std::map<std::string, uint32_t>& labelpageindex,
+                         uint32_t control_packet_index, bool makeunique) override
+  {
+    return std::make_shared<assembler_state_aie4>(isa, data, scratchpad, labelpageindex, control_packet_index, makeunique);
+  }
+
+  void
+  patch57(const writer& textwriter, writer& datawriter, offset_type offset, uint64_t patch) override
+  {
+    offset = offset - textwriter.tell();
+    uint64_t bd0 = datawriter.read_word(offset);
+    uint64_t bd1 = datawriter.read_word(offset + 1*4);             // NOLINT
+
+    uint64_t arg = (bd1 & 0xFFFFFFFF) + ((bd0 & 0x1FFFFFF) << 32); // NOLINT
+    patch = arg + patch;
+    datawriter.write_word_at(offset + 1*4, patch & 0xFFFFFFFF);    // NOLINT
+    datawriter.write_word_at(offset, (((patch >> 32) & 0x1FFFFFF) | (bd0 & 0xFE000000)));  // NOLINT
+  }
+
+};
+
+}
+#endif //AIEBU_ENCODER_AIE4_ENCODER_H_

--- a/src/cpp/include/aiebu/aiebu.h
+++ b/src/cpp/include/aiebu/aiebu.h
@@ -25,7 +25,8 @@ enum aiebu_assembler_buffer_type {
   aiebu_assembler_buffer_type_blob_instr_transaction,
   aiebu_assembler_buffer_type_blob_control_packet,
   aiebu_assembler_buffer_type_asm_aie2ps,
-  aiebu_assembler_buffer_type_config
+  aiebu_assembler_buffer_type_config,
+  aiebu_assembler_buffer_type_asm_aie4
 };
 
 struct pm_ctrlpkt {

--- a/src/cpp/include/aiebu/aiebu_assembler.h
+++ b/src/cpp/include/aiebu/aiebu_assembler.h
@@ -24,6 +24,7 @@ class aiebu_assembler
       blob_control_packet,
       asm_aie2ps,
       asm_aie2,
+      asm_aie4,
       config,
       elf_aie2,
       elf_aie2ps,

--- a/src/cpp/ops/ops.cpp
+++ b/src/cpp/ops/ops.cpp
@@ -28,7 +28,7 @@ align_op_serializer::size(assembler_state& state)
 
 std::vector<uint8_t>
 isa_op_serializer::
-serialize(assembler_state& state, std::vector<symbol>& symbols,
+serialize(std::shared_ptr<assembler_state> state, std::vector<symbol>& symbols,
           uint32_t colnum, pageid_type pagenum)
 {
   //encode isa_op
@@ -49,13 +49,13 @@ serialize(assembler_state& state, std::vector<symbol>& symbols,
     } else if (arg.m_type == opArg::optype::JOBSIZE)
     {
       jobid_type jobid = m_args[0];
-      sval = std::to_string(state.m_jobmap[jobid]->get_size());
+      sval = std::to_string(state->m_jobmap[jobid]->get_size());
       atype = opArg::optype::CONST;
     } else if (arg.m_type == opArg::optype::PAGE_ID)
     {
-      if (state.m_labelpageindex.find(m_args[arg_index].substr(1)) == state.m_labelpageindex.end())
+      if (state->m_labelpageindex.find(m_args[arg_index].substr(1)) == state->m_labelpageindex.end())
         throw error(error::error_code::invalid_asm, "Label " + m_args[arg_index].substr(1) + "not present in label list\n");
-      sval = std::to_string(state.m_labelpageindex[m_args[arg_index].substr(1)]);
+      sval = std::to_string(state->m_labelpageindex[m_args[arg_index].substr(1)]);
       atype = opArg::optype::CONST;
       ++arg_index;
     } else
@@ -72,9 +72,9 @@ serialize(assembler_state& state, std::vector<symbol>& symbols,
     else if (atype == opArg::optype::CONST)
     {
       try {
-        val = state.parse_num_arg(sval);
+        val = state->parse_num_arg(sval);
       } catch (symbol_exception &s) {
-        symbols.emplace_back(sval, state.get_pos()+(uint32_t)ret.size(),
+        symbols.emplace_back(sval, state->get_pos()+(uint32_t)ret.size(),
                              colnum, pagenum, 0, 0, ".ctrltext." + std::to_string(colnum)
                              + "." + std::to_string(pagenum),
                              symbol::patch_schema::scaler_32);
@@ -92,26 +92,26 @@ serialize(assembler_state& state, std::vector<symbol>& symbols,
         // For opcode is 'apply_offset_57' and arg is 'offset',
         // if val is 0xFFFF means we need to patch the host address of 1st page of controlcode
         // and we can patch in host and firmware, we send "control-code-X" as symbol name and 0xFFFF in apply_offset_57
-        // if val == self.state.control_packet_index, we add "control-code-X" as symbol name and 0xFFFF in apply_offset_57
-        // if val is not 0xFFFF or self.state.control_packet_index, we can do patching in cert or host so add symbol info in elf
+        // if val == self.state->control_packet_index, we add "control-code-X" as symbol name and 0xFFFF in apply_offset_57
+        // if val is not 0xFFFF or self.state->control_packet_index, we can do patching in cert or host so add symbol info in elf
         //    we send "arg index" as symbol name and arg offset in apply_offset_57
         if (!m_opcode->get_code_name().compare("apply_offset_57") && !arg.get_name().compare("offset"))
         {
-          if (val == state.m_control_packet_index || val == 0xFFFF)
+          if (val == state->m_control_packet_index || val == 0xFFFF)       // NOLINT
             sval = "control-code-" + std::to_string(colnum);
-          symbols.emplace_back(sval, state.parse_num_arg(m_args[0]),
+          symbols.emplace_back(sval, state->parse_num_arg(m_args[0]),
                                colnum, pagenum, 0, 0, ".ctrltext." + std::to_string(colnum)
                                + "." + std::to_string(pagenum),
-                               symbol::patch_schema::shim_dma_57);
+                               state->get_shim_dma_patching());
 
-          if (val == state.m_control_packet_index && !arg.get_name().compare("offset") && m_args.size() == 4)
-            state.m_controlpacket_padname = m_args[3];
+          if (val == state->m_control_packet_index && !arg.get_name().compare("offset") && m_args.size() == 4)
+            state->m_controlpacket_padname = m_args[3];
 
           // arg 0 to 6 and be patched in CERT.
           // Beyond that its elfloader/host responsibility to patch mandatorily
           if (val > 6 && val != 0xFFFF)
             std::cout <<"WARNING: Apply_offset_57 has arg index " << val << " > 6, Should be mandatorily patched in host!!!\n";
-          if (val == state.m_control_packet_index)
+          if (val == state->m_control_packet_index)
             val = 0xFFFF;
           else if (val != 0xFFFF)
           {
@@ -122,9 +122,9 @@ serialize(assembler_state& state, std::vector<symbol>& symbols,
           if (!arg.get_name().compare("offset") && m_args.size() == 4)
           {
             auto usymbo = m_args[3].substr(1);
-            if (state.m_scratchpad.find(usymbo) != state.m_scratchpad.end())
+            if (state->m_scratchpad.find(usymbo) != state->m_scratchpad.end())
             {
-              state.m_patch[m_args[3]].emplace_back(m_args[0]);
+              state->m_patch[m_args[3]].emplace_back(m_args[0]);
             }
           }
 
@@ -150,22 +150,22 @@ serialize(assembler_state& state, std::vector<symbol>& symbols,
 
 std::vector<uint8_t>
 ucDmaBd_op_serializer::
-serialize(assembler_state& state,
+serialize(std::shared_ptr<assembler_state> state,
           std::vector<symbol>& /*symbols*/,
           uint32_t /*colnum*/, pageid_type /*pagenum*/)
 {
   //encode ucDmaBd
   std::vector<uint8_t> ret;
-  uint32_t remote_ptr_high = state.parse_num_arg(m_args[0]);
-  uint32_t remote_ptr_low  = state.parse_num_arg(m_args[1]);
-  uint32_t local_ptr_absolute  = state.parse_num_arg(m_args[2]);
-  uint32_t size  = state.parse_num_arg(m_args[3]);
-  bool ctrl_external  = state.parse_num_arg(m_args[4]) != 0;
-  bool ctrl_next_BD  = state.parse_num_arg(m_args[5]) != 0;
+  uint32_t remote_ptr_high = state->parse_num_arg(m_args[0]);
+  uint32_t remote_ptr_low  = state->parse_num_arg(m_args[1]);
+  uint32_t local_ptr_absolute  = state->parse_num_arg(m_args[2]);
+  uint32_t size  = state->parse_num_arg(m_args[3]);
+  bool ctrl_external  = state->parse_num_arg(m_args[4]) != 0;
+  bool ctrl_next_BD  = state->parse_num_arg(m_args[5]) != 0;        //NOLINT
   bool ctrl_local_relative = true;
 
   // TODO assert
-  uint32_t local_ptr = local_ptr_absolute - state.get_pos();
+  uint32_t local_ptr = local_ptr_absolute - state->get_pos();
 
   //TODO assert
   ret.push_back(size & BYTE_MASK);
@@ -197,14 +197,14 @@ serialize(assembler_state& state,
 
 std::vector<uint8_t>
 long_op_serializer::
-serialize(assembler_state& state,
+serialize(std::shared_ptr<assembler_state> state,
           std::vector<symbol>& /*symbols*/,
           uint32_t /*colnum*/,
           pageid_type /*pagenum*/)
 {
   //encode long
   std::vector<uint8_t> ret;
-  uint32_t val = state.parse_num_arg(m_args[0]);
+  uint32_t val = state->parse_num_arg(m_args[0]);
   ret.push_back((val >> FIRST_BYTE_SHIFT) & BYTE_MASK);
   ret.push_back((val >> SECOND_BYTE_SHIFT) & BYTE_MASK);
   ret.push_back((val >> THIRD_BYTE_SHIFT) & BYTE_MASK);
@@ -215,13 +215,13 @@ serialize(assembler_state& state,
 
 std::vector<uint8_t>
 align_op_serializer::
-serialize(assembler_state& state,
+serialize(std::shared_ptr<assembler_state> state,
           std::vector<symbol>& /*symbols*/,
           uint32_t /*colnum*/, pageid_type /*pagenum*/)
 {
   //encode align
   std::vector<uint8_t> ret;
-  for (uint32_t i=0;i < size(state); ++i)
+  for (uint32_t i=0;i < size(*state); ++i)
     ret.push_back(m_opcode->get_code());
 
   return ret;

--- a/src/cpp/ops/ops.h
+++ b/src/cpp/ops/ops.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
 #ifndef _ADSM_OPS_ISA_OP_H_
 #define _ADSM_OPS_ISA_OP_H_
@@ -36,7 +36,7 @@ public:
 
   virtual offset_type size(assembler_state& ) { return 0;}
   virtual offset_type align() {return 0;}
-  virtual std::vector<uint8_t> serialize(assembler_state& /*state*/, std::vector<symbol>& /*symbols*/, uint32_t /*colnum*/, pageid_type /*pagenum*/)
+  virtual std::vector<uint8_t> serialize(std::shared_ptr<assembler_state> /*state*/, std::vector<symbol>& /*symbols*/, uint32_t /*colnum*/, pageid_type /*pagenum*/)
   { std::vector<uint8_t> v; return v;}
 };
 
@@ -49,7 +49,7 @@ public:
   offset_type size(assembler_state& state) override;
 
   offset_type align() override { return 0; }
-  std::vector<uint8_t> serialize(assembler_state& state, std::vector<symbol>& symbols, uint32_t colnum, pageid_type pagenum) override;
+  std::vector<uint8_t> serialize(std::shared_ptr<assembler_state> state, std::vector<symbol>& symbols, uint32_t colnum, pageid_type pagenum) override;
 };
 
 class long_op_serializer: public op_serializer
@@ -60,7 +60,7 @@ public:
   offset_type size(assembler_state& /*state*/) override { return 4; }
 
   offset_type align() override { return 4; }
-  std::vector<uint8_t> serialize(assembler_state& state, std::vector<symbol>& symbols, uint32_t colnum, pageid_type pagenum) override;
+  std::vector<uint8_t> serialize(std::shared_ptr<assembler_state> state, std::vector<symbol>& symbols, uint32_t colnum, pageid_type pagenum) override;
 };
 
 class align_op_serializer: public op_serializer
@@ -71,7 +71,7 @@ public:
   offset_type size(assembler_state& state) override;
 
   offset_type align() override { return 0; }
-  std::vector<uint8_t> serialize(assembler_state& state, std::vector<symbol>& symbols, uint32_t colnum, pageid_type pagenum) override;
+  std::vector<uint8_t> serialize(std::shared_ptr<assembler_state> state, std::vector<symbol>& symbols, uint32_t colnum, pageid_type pagenum) override;
 };
 
 class ucDmaBd_op_serializer: public op_serializer
@@ -82,7 +82,7 @@ public:
   offset_type size(assembler_state& /*state*/) override { return 16; }
 
   offset_type align() override { return 16; }
-  std::vector<uint8_t> serialize(assembler_state& state, std::vector<symbol>& symbols, uint32_t colnum, pageid_type pagenum) override;
+  std::vector<uint8_t> serialize(std::shared_ptr<assembler_state> state, std::vector<symbol>& symbols, uint32_t colnum, pageid_type pagenum) override;
 };
 
 class isa_op : public std::enable_shared_from_this<isa_op>

--- a/src/cpp/preprocessor/aie2ps/aie2ps_preprocessor.h
+++ b/src/cpp/preprocessor/aie2ps/aie2ps_preprocessor.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
 #ifndef _AIEBU_PREPROCESSOR_AIE2PS_PREPROCESSOR_H_
 #define _AIEBU_PREPROCESSOR_AIE2PS_PREPROCESSOR_H_
@@ -20,6 +20,14 @@ class aie2ps_preprocessor: public preprocessor
   std::shared_ptr<std::map<std::string, std::shared_ptr<isa_op>>> m_isa;
 public:
   aie2ps_preprocessor() {}
+  virtual std::shared_ptr<assembler_state> create_assembler_state(std::shared_ptr<std::map<std::string, std::shared_ptr<isa_op>>> isa,
+                                                 std::vector<std::shared_ptr<asm_data>>& data,
+                                                 std::map<std::string, std::shared_ptr<scratchpad_info>>& scratchpad,
+                                                 std::map<std::string, uint32_t>& labelpageindex,
+                                                 uint32_t control_packet_index, bool makeunique)
+  {
+    return std::make_shared<assembler_state_aie2ps>(isa, data, scratchpad, labelpageindex, control_packet_index, makeunique);
+  }
 
   virtual std::shared_ptr<preprocessed_output>
   process(std::shared_ptr<preprocessor_input> input) override
@@ -27,7 +35,12 @@ public:
     // do preprocessing,
     // separate out asm data colnum wise
     // create pages
-    auto tinput = std::static_pointer_cast<aie2ps_preprocessor_input>(input);
+    return process_internal(std::dynamic_pointer_cast<aie2ps_preprocessor_input>(input));
+  }
+
+  std::shared_ptr<preprocessed_output>
+  process_internal(std::shared_ptr<asm_preprocessor_input> tinput)
+  {
     auto toutput = std::make_shared<aie2ps_preprocessed_output>();
     //auto keys = tinput->get_keys();
     std::shared_ptr<asm_parser> parser(new asm_parser(tinput->get_data(), tinput->get_include_paths()));
@@ -48,9 +61,9 @@ public:
       {
         // create state
         std::vector<std::shared_ptr<asm_data>> data = coldata.get_label_asmdata(label);
-        assembler_state state = assembler_state(m_isa, data, scratchpad, label_page_index, 0, true);
+        std::shared_ptr<assembler_state> state = create_assembler_state(m_isa, data, scratchpad, label_page_index, 0, true);
         // create pages
-        pager(PAGE_SIZE).pagify(state, col, pages, relative_page_index);
+        pager(PAGE_SIZE).pagify(*state, col, pages, relative_page_index);
         label_page_index[get_pagelabel(label)] = relative_page_index;
         relative_page_index = pages.size();
       }

--- a/src/cpp/preprocessor/aie2ps/aie2ps_preprocessor_input.cpp
+++ b/src/cpp/preprocessor/aie2ps/aie2ps_preprocessor_input.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
 #include "aie2ps_preprocessor_input.h"
 
@@ -7,7 +7,7 @@ namespace aiebu {
 
   //TODO: this these functions are custom copy from aie2_preprocessor_input.cpp, todo we mode both in common place
   void
-  aie2ps_preprocessor_input::
+  asm_preprocessor_input::
   validate_json(uint32_t /*offset*/, uint32_t /*size*/, uint32_t /*arg_index*/, offset_type /*type*/) const {
     // Return if the offset and arg_index are within their respective sizes.
     // TODO enable checks
@@ -39,7 +39,7 @@ namespace aiebu {
   }
 
   void
-  aie2ps_preprocessor_input::
+  asm_preprocessor_input::
   extract_coalesed_buffers(const std::string& name,
                            const boost::property_tree::ptree& pt)
   {
@@ -60,7 +60,7 @@ namespace aiebu {
   }
 
   void
-  aie2ps_preprocessor_input::
+  asm_preprocessor_input::
   extract_control_packet_patch(const std::string& name,
                                const uint32_t arg_index,
                                const boost::property_tree::ptree& pt)
@@ -82,12 +82,12 @@ namespace aiebu {
 
       // TODO added symbols name hardcoded to ".pad.0" and col 0
       // this will change once compiler decide on how to generate multi col control packet design
-      add_symbol({name, offset, 0, 0, addend, 0, ".pad.0", symbol::patch_schema::control_packet_57});
+      add_symbol({name, offset, 0, 0, addend, 0, ".pad.0", control_packet_patching});
     }
   }
 
   void
-  aie2ps_preprocessor_input::
+  asm_preprocessor_input::
   aiecompiler_json_parser(const boost::property_tree::ptree& pt)
   {
     const auto pt_external_buffers = pt.get_child_optional("external_buffers");
@@ -112,7 +112,7 @@ namespace aiebu {
   }
 
   void
-  aie2ps_preprocessor_input::
+  asm_preprocessor_input::
   dmacompiler_json_parser(const boost::property_tree::ptree& pt)
   {
     const auto pt_ctrl_xrt_arg_idx = pt.get_optional<uint32_t>("ctrl_pkt_xrt_arg_idx");
@@ -144,13 +144,13 @@ namespace aiebu {
 
       // TODO added symbols name hardcoded to ".pad.0" and col 0
       // this will change once compiler decide on how to generate multi col control packet design
-      add_symbol({std::to_string(arg_index + ARG_OFFSET), offset, 0, 0, addend, 0, ".ctrltext.0.0", symbol::patch_schema::control_packet_57});
+      add_symbol({std::to_string(arg_index + ARG_OFFSET), offset, 0, 0, addend, 0, ".ctrltext.0.0", control_packet_patching});
     }
 
   }
 
   void
-  aie2ps_preprocessor_input::
+  asm_preprocessor_input::
   readmetajson(std::istream& patch_json)
   {
     boost::property_tree::ptree pt;
@@ -173,7 +173,7 @@ namespace aiebu {
 
 
   uint32_t
-  aie2ps_preprocessor_input::
+  asm_preprocessor_input::
   get_32_bit_property(const boost::property_tree::ptree& pt, const std::string& property, bool defaultvalue) const
   {
     uint64_t value = 0;

--- a/src/cpp/preprocessor/aie2ps/aie2ps_preprocessor_input.h
+++ b/src/cpp/preprocessor/aie2ps/aie2ps_preprocessor_input.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
 #ifndef _AIEBU_PREPROCESSOR_AIE2PS_PREPROCESSOR_INPUT_H_
 #define _AIEBU_PREPROCESSOR_AIE2PS_PREPROCESSOR_INPUT_H_
@@ -13,8 +13,9 @@
 
 namespace aiebu {
 
-class aie2ps_preprocessor_input : public preprocessor_input
+class asm_preprocessor_input : public preprocessor_input
 {
+protected:
   constexpr static uint32_t MAX_ARG_INDEX = 512; // approximated value 512 to limit the number of arguments in XRT kernel call
 
   constexpr static uint64_t RANGE_32BIT = 0xFFFFFFFF; // Max value supported in 32bit elf supported
@@ -29,6 +30,8 @@ class aie2ps_preprocessor_input : public preprocessor_input
     COALESED_BUFFER
   };
 
+  symbol::patch_schema control_packet_patching = symbol::patch_schema::control_packet_57;
+
   void aiecompiler_json_parser(const boost::property_tree::ptree& pt);
   void dmacompiler_json_parser(const boost::property_tree::ptree& pt);
   void readmetajson(std::istream& patch_json);
@@ -38,7 +41,7 @@ class aie2ps_preprocessor_input : public preprocessor_input
   uint32_t get_32_bit_property(const boost::property_tree::ptree& pt, const std::string& property, bool defaultvalue = false) const;
 
 public:
-  aie2ps_preprocessor_input() {}
+  asm_preprocessor_input() = default;
 
   const std::vector<std::string>& get_include_paths() const { return m_libpaths; }
   uint32_t get_control_packet_index() const { return m_control_packet_index; }
@@ -72,6 +75,14 @@ public:
   {
     return m_data["control_code"];
   }
+};
+
+
+class aie2ps_preprocessor_input : public asm_preprocessor_input
+{
+public:
+  aie2ps_preprocessor_input() { control_packet_patching = symbol::patch_schema::control_packet_57;}
+
 };
 
 }

--- a/src/cpp/preprocessor/aie4/aie4_preprocessor.h
+++ b/src/cpp/preprocessor/aie4/aie4_preprocessor.h
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+
+#ifndef AIEBU_PREPROCESSOR_AIE4_PREPROCESSOR_H_
+#define AIEBU_PREPROCESSOR_AIE4_PREPROCESSOR_H_
+
+#include <string>
+#include "aie2ps_preprocessor.h"
+#include "preprocessor/aie4/aie4_preprocessor_input.h"
+
+namespace aiebu {
+
+class aie4_preprocessor: public aie2ps_preprocessor
+{
+public:
+  aie4_preprocessor(): aie2ps_preprocessor() {}
+  
+  std::shared_ptr<preprocessed_output>
+  process(std::shared_ptr<preprocessor_input> input) override
+  {
+    // do preprocessing,
+    // separate out asm data colnum wise
+    // create pages
+    return process_internal(std::dynamic_pointer_cast<aie4_preprocessor_input>(input));
+  }
+  std::shared_ptr<assembler_state> create_assembler_state(std::shared_ptr<std::map<std::string, std::shared_ptr<isa_op>>> isa,
+                                         std::vector<std::shared_ptr<asm_data>>& data,
+                                         std::map<std::string, std::shared_ptr<scratchpad_info>>& scratchpad,
+                                         std::map<std::string, uint32_t>& labelpageindex,
+                                         uint32_t control_packet_index, bool makeunique) override
+  {
+    return std::make_shared<assembler_state_aie4>(isa, data, scratchpad, labelpageindex, control_packet_index, makeunique);
+  }
+};
+
+}
+#endif //AIEBU_PREPROCESSOR_AIE4_PREPROCESSOR_H_

--- a/src/cpp/preprocessor/aie4/aie4_preprocessor_input.h
+++ b/src/cpp/preprocessor/aie4/aie4_preprocessor_input.h
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+
+#ifndef AIEBU_PREPROCESSOR_AIE4_PREPROCESSOR_INPUT_H_
+#define AIEBU_PREPROCESSOR_AIE4_PREPROCESSOR_INPUT_H_
+
+#include "aie2ps_preprocessor_input.h"
+namespace aiebu {
+
+class aie4_preprocessor_input : public asm_preprocessor_input
+{
+public:
+  aie4_preprocessor_input() { control_packet_patching = symbol::patch_schema::control_packet_57_aie4;}
+
+};
+
+}
+#endif //AIEBU_PREPROCESSOR_AIE4_PREPROCESSOR_INPUT_H_

--- a/src/cpp/utils/asm/asm.cpp
+++ b/src/cpp/utils/asm/asm.cpp
@@ -29,7 +29,7 @@ void main_helper(int argc, char** argv,
       .allow_unrecognised_options()
       .add_options()
       ("h,help", "show help message and exit", cxxopts::value<bool>()->default_value("false"))
-      ("t,target", "supported targets aie2ps/aie2asm/aie2txn/aie2dpu/config", cxxopts::value<decltype(target_name)>())
+      ("t,target", "supported targets aie2ps/aie2asm/aie2txn/aie2dpu/config/aie4", cxxopts::value<decltype(target_name)>())
       ("v,version", "show version and exit", cxxopts::value<bool>()->default_value("false"))
       ;
 
@@ -90,6 +90,7 @@ int main( int argc, char** argv )
     targets.emplace_back(std::make_shared<aiebu::utilities::target_aie2blob_transaction>(executable));
     targets.emplace_back(std::make_shared<aiebu::utilities::target_aie2blob_dpu>(executable));
     targets.emplace_back(std::make_shared<aiebu::utilities::target_config>(executable));
+    targets.emplace_back(std::make_shared<aiebu::utilities::target_aie4>(executable));
   }
 
   // -- Program Description

--- a/src/cpp/utils/target/target.cpp
+++ b/src/cpp/utils/target/target.cpp
@@ -316,3 +316,75 @@ target_config::assemble(const sub_cmd_options &options)
     throw std::runtime_error(errMsg.str());
   }
 }
+
+void
+aiebu::utilities::
+target_aie4::assemble(const sub_cmd_options &_options)
+{
+  std::string output_elffile;
+  std::string input_file;
+  std::string external_buffers_file;
+  std::vector<std::string> libpaths;
+
+  cxxopts::Options all_options("Target aie4 Options", m_description);
+
+  try {
+    all_options.add_options()
+            ("outputelf,o", "ELF output file name", cxxopts::value<decltype(output_elffile)>())
+            ("asm,c", "ASM File", cxxopts::value<decltype(input_file)>())
+            ("j,json", "control packet Patching json file", cxxopts::value<decltype(external_buffers_file)>())
+            ("L,libpath", "libs path", cxxopts::value<decltype(libpaths)>())
+            ("help,h", "show help message and exit", cxxopts::value<bool>()->default_value("false"))
+    ;
+
+    auto char_ver = aiebu::utilities::vector_of_string_to_vector_of_char(_options);
+    auto result = all_options.parse(static_cast<int>(char_ver.size()), char_ver.data());
+
+    if (result.count("help")) {
+      std::cout << all_options.help({"", "Target aie4 Options"});
+      return;
+    }
+
+    if (result.count("outputelf"))
+      output_elffile = result["outputelf"].as<decltype(output_elffile)>();
+    else
+    {
+      throw std::runtime_error("the option '--outputelf' is required but missing\n");
+    }
+
+    if (result.count("asm"))
+      input_file = result["asm"].as<decltype(input_file)>();
+    else
+    {
+      throw std::runtime_error("the option '--asm' is required but missing\n");
+    }
+
+    if (result.count("libpath"))
+      libpaths = result["libpath"].as<decltype(libpaths)>();
+
+    if (result.count("json"))
+      external_buffers_file = result["json"].as<decltype(external_buffers_file)>();
+
+  }
+  catch (const cxxopts::exceptions::exception& e) {
+    std::cout << all_options.help({"", "Target aie4 Options"});
+    auto errMsg = boost::format("Error parsing options: %s\n") % e.what() ;
+    throw std::runtime_error(errMsg.str());
+  }
+
+  std::vector<char> asmBuffer;
+  readfile(input_file, asmBuffer);
+
+
+  std::vector<char> patch_data_buffer;
+  if (!external_buffers_file.empty())
+    readfile(external_buffers_file, patch_data_buffer);
+
+  try {
+    aiebu::aiebu_assembler as(aiebu::aiebu_assembler::buffer_type::asm_aie4, asmBuffer, {}, libpaths, patch_data_buffer);
+    write_elf(as, output_elffile);
+  } catch (aiebu::error &ex) {
+    auto errMsg = boost::format("Error: %s, code:%d\n") % ex.what() % ex.get_code() ;
+    throw std::runtime_error(errMsg.str());
+  }
+}

--- a/src/cpp/utils/target/target.h
+++ b/src/cpp/utils/target/target.h
@@ -121,6 +121,14 @@ class target_config: public target
   void assemble(const sub_cmd_options &_options) override;
   explicit target_config(const std::string& name): target(name, "config", "generate config elf") {}
 };
+
+class target_aie4: public target
+{
+  public:
+  void assemble(const sub_cmd_options &_options) override;
+  explicit target_aie4(const std::string& name): target(name, "aie4", "aie4 asm assembler") {}
+};
+
 } //namespace aiebu::utilities
 
 #endif // AIEBU_UTILITIES_TARGET_H_


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Aiebu change to support aie4 target
1. added new target asm_aie4
2. aie2ps and aie4 have 2 things different
     a. patch57 schema and control packet schema
     b. actor_id's for tiles/mm2s/s2mm
3. created assembler_state base class and aie2ps and aie4 derived class. We have create_assembler_state virtual function which will return aie4 or aie2ps assembler_state shared ptr.
4. created aie4 encoder class from aie2ps encoder as only patch57 and assember_state is different.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA

#### How problem was solved, alternative solutions (if any) and why they were rejected
NA

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)

#### USAGE
```
> aiebu-asm -t aie2ps -c ..\test\cpp_test\aie2ps\eff_net_coal\ml_asm\merged_control.asm -L ..\test\cpp_test\aie2ps\eff_net_coal\ml_asm -L ..\test\cpp_test\aie2ps\eff_net_coal\asm\ -o controlcode.elf

```