### PR TITLE
Support pmctrlpkt support in xclbin2elf

### DIFF
--- a/src/cpp/preprocessor/aie2/aie2_blob_preprocessor_input.cpp
+++ b/src/cpp/preprocessor/aie2/aie2_blob_preprocessor_input.cpp
@@ -912,12 +912,12 @@ add_preemption_code(uint32_t col)
     {
       uint32_t id = pdi.get<uint32_t>("id");
       auto type = pdi.get_optional<std::string>("type");
-      if (type && !type.get().compare("pm"))
+      if (type && !type.get().compare(pm_ctrlpkt_type))
       {
-        m_data[".ctrlpkt.pm." + std::to_string(id)] = std::move(readfile(pdi.get<std::string>("PDI_file")));
+        m_data[".ctrlpkt.pm." + std::to_string(id)] = readfile(pdi.get<std::string>("PDI_file"));
         pm_id_list.push_back(id);
       } else {
-        m_data[".pdi." + std::to_string(id)] = std::move(readfile(pdi.get<std::string>("PDI_file")));
+        m_data[".pdi." + std::to_string(id)] = readfile(pdi.get<std::string>("PDI_file"));
       }
     }
   }
@@ -929,11 +929,11 @@ add_preemption_code(uint32_t col)
     for (const auto& [unused, pic] : pinstance)
     {
       std::string tname = get_ctrltext_name(pic.get<std::string>("id"));
-      m_data[tname] = std::move(readfile(pic.get<std::string>("TXN_ctrl_code_file")));
+      m_data[tname] = readfile(pic.get<std::string>("TXN_ctrl_code_file"));
       //std::cout << "TXN_ctrl_code_file id:" << pic.get<std::string>("id") << std::endl;
       //std::cout << "TXN_ctrl_code_file:" << pic.get<std::string>("TXN_ctrl_code_file") << std::endl;
       if (!pic.get<std::string>("ctrl_packet_file", "").empty())
-        m_data[get_ctrldata_name(pic.get<std::string>("id"))] = std::move(readfile(pic.get<std::string>("ctrl_packet_file")));
+        m_data[get_ctrldata_name(pic.get<std::string>("id"))] = readfile(pic.get<std::string>("ctrl_packet_file"));
 
       if (!pic.get<std::string>("patch_info_file", "").empty())
       {

--- a/src/cpp/preprocessor/aie2/aie2_blob_preprocessor_input.cpp
+++ b/src/cpp/preprocessor/aie2/aie2_blob_preprocessor_input.cpp
@@ -909,7 +909,17 @@ add_preemption_code(uint32_t col)
   add_pdi(const boost::property_tree::ptree& pdis)
   {
     for (const auto& [unused, pdi] : pdis)
-      m_data[std::string(".pdi.") + pdi.get<std::string>("id")] = std::move(readfile(pdi.get<std::string>("PDI_file")));
+    {
+      uint32_t id = pdi.get<uint32_t>("id");
+      auto type = pdi.get_optional<std::string>("type");
+      if (type && !type.get().compare("pm"))
+      {
+        m_data[".ctrlpkt.pm." + std::to_string(id)] = std::move(readfile(pdi.get<std::string>("PDI_file")));
+        pm_id_list.push_back(id);
+      } else {
+        m_data[".pdi." + std::to_string(id)] = std::move(readfile(pdi.get<std::string>("PDI_file")));
+      }
+    }
   }
 
   void

--- a/src/cpp/preprocessor/aie2/aie2_blob_preprocessor_input.h
+++ b/src/cpp/preprocessor/aie2/aie2_blob_preprocessor_input.h
@@ -28,6 +28,7 @@ protected:
   const std::string preempt_lib = "preempt";
   const std::string scratch_pad = "scratch-pad-mem";
   const std::string ctrlpkt_pm = "ctrlpkt-pm-";
+  const std::string pm_ctrlpkt_type = "pmctrlpkt";
 
   constexpr static uint32_t SHIM_DMA_BD0_0 = 0x0001D000;
   constexpr static uint32_t SHIM_DMA_BD_NUM = 16;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Support pmctrlpkt support in xclbin2elf
pmctrlpkt part of **PDIs** section in json also should have **"type = pm"** 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)

### Config.json
```
{
  "xrt-kernels": [
    {
      "name" : "Resnet18",
      "arguments" : [
        {
          "name" : "arg0",
          "type" : "char *",
          "offset" : "0x00"
        },
        {
          "name" : "arg1",
          "type" : "char *",
          "offset" : "0x08"
        },
        {
          "name" : "arg2",
          "type" : "char *",
          "offset" : "0x10"
        },
        {
          "name" : "arg3",
          "type" : "char *",
          "offset" : "0x18"
        }
      ],
        "instance" : [
                 {
                   "id" : "inst_1",
                   "TXN_ctrl_code_file" : "path/to/ml_txn_lp.bin"
                 },
                 {
                   "id" : "inst_2",
                   "TXN_ctrl_code_file" : "/path/to/ml_txn_lp.bin",
                   "ctrl_packet_file" : "/path/to/ctrl_pkt0.bin",
                   "patch_info_file" : "/path/to/external_buffer_id.json"
                 },
                 {
                   "id" : "inst_pmctrl",
                   "TXN_ctrl_code_file" : "/path/to/mc_code_txn.bin"
                 }
        ],
        "PDIs" : [
                {
                  "id" : 0,
                  "PDI_file" : "/path/to/pdi.pdi"
                },
                {
                  "id" : 1,
                  "PDI_file" : "/path/to/pdi.pdi"
                },
                {
                  "id" : 0,
                  "type" : "pmctrlpkt",
                  "PDI_file" : "/path/to/pm_ctrlpkt_0.bin"
                }
        ]
    }
  ]
}
```

### ELF Output
```
>readelf -a tt.elf | more
readelf: Error: the PHDR segment is not covered by a LOAD segment
ELF Header:
  Magic:   7f 45 4c 46 01 01 01 46 02 00 00 00 00 00 00 00 
  Class:                             ELF32
  Data:                              2's complement, little endian
  Version:                           1 (current)
  OS/ABI:                            <unknown: 46>
  ABI Version:                       2
  Type:                              EXEC (Executable file)
  Machine:                           WE32100
  Version:                           0x1
  Entry point address:               0x0
  Start of program headers:          52 (bytes into file)
  Start of section headers:          10928096 (bytes into file)
  Flags:                             0x0
  Size of this header:               52 (bytes)
  Size of program headers:           32 (bytes)
  Number of program headers:         11
  Size of section headers:           40 (bytes)
  Number of section headers:         19
  Section header string table index: 1

Section Headers:
  [Nr] Name              Type            Addr     Off    Size   ES Flg Lk Inf Al
  [ 0]                   NULL            00000000 000000 000000 00      0   0  0
  [ 1] .shstrtab         STRTAB          00000000 a3efd0 0000d8 00      0   0  1
  [ 2] .ctrldata.inst_2  PROGBITS        00000000 0001a0 0004e0 00  WA  0   0 16
  [ 3] .ctrlpkt.pm.0     PROGBITS        00000000 000680 0051ec 00  WA  0   0 16
  [ 4] .ctrltext.inst_pmctrl  PROGBITS        00000000 005870 9e6344 00  WA  0   0 16
  [ 5] .ctrltext.inst_1  PROGBITS        00000000 9ebbc0 004620 00  WA  0   0 16
  [ 6] .ctrltext.inst_2  PROGBITS        00000000 9f01e0 004620 00  WA  0   0 16
  [ 7] .pdi.0            PROGBITS        00000000 9f4800 024a80 00  WA  0   0 16
  [ 8] .pdi.1            PROGBITS        00000000 a19280 024a80 00  WA  0   0 16
  [ 9] .preempt_restore  PROGBITS        00000000 a3dd00 0009bc 00  WA  0   0 16
  [10] .preempt_save     PROGBITS        00000000 a3e6c0 0008fc 00  WA  0   0 16
  [11] .dynstr           STRTAB          00000000 a3f0a8 0000a9 00      0   0  0
  [12] .dynsym           DYNSYM          00000000 a3f158 000360 10   A 11   1  8
  [13] .rela.dyn         RELA            00000000 a3f4b8 02cab4 0c   A 12   0  8
  [14] .dynamic          DYNAMIC         00000000 a3efc0 000010 08   A 11   0  8
  [15] .note.xrt.co[...] NOTE            00000000 a6bf6c 000014 00      0   0  1
  [16] .strtab           STRTAB          00000000 a6bf80 000015 00      0   0  0
  [17] .symtab           SYMTAB          00000000 a6bf98 000020 10     16   1  4
  [18] .note.xrt.UID     NOTE            00000000 a6bfb8 000020 00      0   0  1
Key to Flags:
  W (write), A (alloc), X (execute), M (merge), S (strings), I (info),
  L (link order), O (extra OS processing required), G (group), T (TLS),
  C (compressed), x (unknown), o (OS specific), E (exclude),
  p (processor specific)

There are no section groups in this file.

Program Headers:
  Type           Offset   VirtAddr   PhysAddr   FileSiz MemSiz  Flg Align
  PHDR           0x000034 0x00000000 0x00000000 0x00160 0x00160 R   0
  LOAD           0x0001a0 0x00000000 0x00000000 0x004e0 0x004e0 RW  0x10
  LOAD           0x000680 0x00000000 0x00000000 0x051ec 0x051ec RW  0x10
  LOAD           0x005870 0x00000000 0x00000000 0x9e6344 0x9e6344 RW  0x10
  LOAD           0x9ebbc0 0x00000000 0x00000000 0x04620 0x04620 RW  0x10
  LOAD           0x9f01e0 0x00000000 0x00000000 0x04620 0x04620 RW  0x10
  LOAD           0x9f4800 0x00000000 0x00000000 0x24a80 0x24a80 RW  0x10
  LOAD           0xa19280 0x00000000 0x00000000 0x24a80 0x24a80 RW  0x10
  LOAD           0xa3dd00 0x00000000 0x00000000 0x009bc 0x009bc RW  0x10
  LOAD           0xa3e6c0 0x00000000 0x00000000 0x008fc 0x008fc RW  0x10
  DYNAMIC        0xa3efc0 0x00000000 0x00000000 0x00010 0x00010 RW  0x8

 Section to Segment mapping:
  Segment Sections...
   00     
   01     .ctrldata.inst_2
   02     .ctrlpkt.pm.0 
   03     .ctrltext.inst_pmctrl  
   04     .ctrltext.inst_1
   05     .ctrltext.inst_2
   06     .pdi.0 
   07     .pdi.1 
   08     .preempt_restore 
   09     .preempt_save 
   10     .dynamic 

Dynamic section at offset 0xa3efc0 contains 2 entries:
  Tag        Type                         Name/Value
 0x00000007 (RELA)                       0xd
 0x00000008 (RELASZ)                     182964 (bytes)

Relocation section '.rela.dyn' at offset 0xa3f4b8 contains 15247 entries:
 Offset     Info    Type            Sym.Value  Sym. Name + Addend
00000018  00000108 unrecognized: 8       00000000   .pdi.0 + 0
00001c90  00000205 unrecognized: 5       00000000   1 + f0
00001ee8  00000305 unrecognized: 5       00000000   0 + 0
00002028  00000205 unrecognized: 5       00000000   1 + a0
000021c0  00000305 unrecognized: 5       00000000   0 + 0
00002300  00000205 unrecognized: 5       00000000   1 + 50
00002498  00000305 unrecognized: 5       00000000   0 + 0
000025d8  00000205 unrecognized: 5       00000000   1 + 0
00002770  00000305 unrecognized: 5       00000000   0 + 0
000042b0  00000405 unrecognized: 5       00000000   2 + f0
000043a8  00000405 unrecognized: 5       00000000   2 + a0
000044a0  00000405 unrecognized: 5       00000000   2 + 50
00004598  00000405 unrecognized: 5       00000000   2 + 0
00000004  00000504 unrecognized: 4       00000000   2 + 0
00000144  00000604 unrecognized: 4       00000000   1 + 0
00000424  00000704 unrecognized: 4       00000000   3 + 0
00000018  00000808 unrecognized: 8       00000000   .pdi.0 + 0
00001c90  00000905 unrecognized: 5       00000000   1 + f0
00001ee8  00000a05 unrecognized: 5       00000000   control-packet + 0
00002028  00000905 unrecognized: 5       00000000   1 + a0
000021c0  00000a05 unrecognized: 5       00000000   control-packet + 0
00002300  00000905 unrecognized: 5       00000000   1 + 50
00002498  00000a05 unrecognized: 5       00000000   control-packet + 0
000025d8  00000905 unrecognized: 5       00000000   1 + 0
00002770  00000a05 unrecognized: 5       00000000   control-packet + 0
000042b0  00000b05 unrecognized: 5       00000000   2 + f0
000696dc  00001705 unrecognized: 5       00000000   ctrlpkt-pm-0 + 0
00069724  00001705 unrecognized: 5       00000000   ctrlpkt-pm-0 + 0
0006976c  00001705 unrecognized: 5       00000000   ctrlpkt-pm-0 + 0
000697b4  00001705 unrecognized: 5       00000000   ctrlpkt-pm-0 + 0
009e62cc  00001d05 unrecognized: 5       00000000   4 + 10c794
000000a0  00003405 unrecognized: 5       00000000   scratch-pad-mem + 0
000001bc  00003405 unrecognized: 5       00000000   scratch-pad-mem + 40000
000002d8  00003405 unrecognized: 5       00000000   scratch-pad-mem + 80000
000003f4  00003405 unrecognized: 5       00000000   scratch-pad-mem + c0000
00000510  00003405 unrecognized: 5       00000000   scratch-pad-mem + 100000
0000062c  00003405 unrecognized: 5       00000000   scratch-pad-mem + 140000
00000748  00003405 unrecognized: 5       00000000   scratch-pad-mem + 180000
00000864  00003405 unrecognized: 5       00000000   scratch-pad-mem + 1c0000
0000008c  00003505 unrecognized: 5       00000000   scratch-pad-mem + 0
000001c0  00003505 unrecognized: 5       00000000   scratch-pad-mem + 40000
000002f4  00003505 unrecognized: 5       00000000   scratch-pad-mem + 80000
00000428  00003505 unrecognized: 5       00000000   scratch-pad-mem + c0000
0000055c  00003505 unrecognized: 5       00000000   scratch-pad-mem + 100000
00000690  00003505 unrecognized: 5       00000000   scratch-pad-mem + 140000
000007c4  00003505 unrecognized: 5       00000000   scratch-pad-mem + 180000
000008f8  00003505 unrecognized: 5       00000000   scratch-pad-mem + 1c0000

The decoding of unwind sections for machine type WE32100 is not currently supported.

Symbol table '.dynsym' contains 54 entries:
   Num:    Value  Size Type    Bind   Vis      Ndx Name
     0: 00000000     0 NOTYPE  LOCAL  DEFAULT  UND 
     1: 00000000 0x24a80 OBJECT  GLOBAL DEFAULT    5 .pdi.0
     2: 00000000 61440 OBJECT  GLOBAL DEFAULT    5 1
     3: 00000000  1536 OBJECT  GLOBAL DEFAULT    5 0
     4: 00000000    80 OBJECT  GLOBAL DEFAULT    5 2
     5: 00000000     0 OBJECT  GLOBAL DEFAULT    2 2
     6: 00000000     0 OBJECT  GLOBAL DEFAULT    2 1
     7: 00000000     0 OBJECT  GLOBAL DEFAULT    2 3
     8: 00000000 0x24a80 OBJECT  GLOBAL DEFAULT    6 .pdi.0
     9: 00000000 61440 OBJECT  GLOBAL DEFAULT    6 1
    10: 00000000  1536 OBJECT  GLOBAL DEFAULT    6 control-packet
    11: 00000000    80 OBJECT  GLOBAL DEFAULT    6 2
    12: 00000000   696 OBJECT  GLOBAL DEFAULT    4 4
    13: 00000000   120 OBJECT  GLOBAL DEFAULT    4 4
    14: 00000000   288 OBJECT  GLOBAL DEFAULT    4 4
    15: 00000000  2064 OBJECT  GLOBAL DEFAULT    4 4
    16: 00000000   360 OBJECT  GLOBAL DEFAULT    4 4
    17: 00000000  2016 OBJECT  GLOBAL DEFAULT    4 4
    18: 00000000 50688 OBJECT  GLOBAL DEFAULT    4 3
    19: 00000000 49152 OBJECT  GLOBAL DEFAULT    4 3
    20: 00000000 74112 OBJECT  GLOBAL DEFAULT    4 1
    21: 00000000   576 OBJECT  GLOBAL DEFAULT    4 4
    22: 00000000   168 OBJECT  GLOBAL DEFAULT    4 4
    23: 00000000 20972 OBJECT  GLOBAL DEFAULT    4 ctrlpkt-pm-0
    24: 00000000  2772 OBJECT  GLOBAL DEFAULT    4 4
    25: 00000000   240 OBJECT  GLOBAL DEFAULT    4 4
    26: 00000000   552 OBJECT  GLOBAL DEFAULT    4 4
    27: 00000000    60 OBJECT  GLOBAL DEFAULT    4 4
    28: 00000000   792 OBJECT  GLOBAL DEFAULT    4 4
    29: 00000000   180 OBJECT  GLOBAL DEFAULT    4 4
    30: 00000000  2136 OBJECT  GLOBAL DEFAULT    4 4
    31: 00000000   132 OBJECT  GLOBAL DEFAULT    4 4
    32: 00000000   648 OBJECT  GLOBAL DEFAULT    4 4
    33: 00000000 0x19000 OBJECT  GLOBAL DEFAULT    4 3
    34: 00000000 12288 OBJECT  GLOBAL DEFAULT    4 3
    35: 00000000   816 OBJECT  GLOBAL DEFAULT    4 4
    36: 00000000   480 OBJECT  GLOBAL DEFAULT    4 4
    37: 00000000  2688 OBJECT  GLOBAL DEFAULT    4 4
    38: 00000000 83200 OBJECT  GLOBAL DEFAULT    4 3
    39: 00000000  6144 OBJECT  GLOBAL DEFAULT    4 3
    40: 00000000 76480 OBJECT  GLOBAL DEFAULT    4 1
    41: 00000000 40960 OBJECT  GLOBAL DEFAULT    4 3
    42: 00000000 24576 OBJECT  GLOBAL DEFAULT    4 3
    43: 00000000 0x25400 OBJECT  GLOBAL DEFAULT    4 1
    44: 00000000  2184 OBJECT  GLOBAL DEFAULT    4 4
    45: 00000000  2712 OBJECT  GLOBAL DEFAULT    4 4
    46: 00000000  2700 OBJECT  GLOBAL DEFAULT    4 4
    47: 00000000 36864 OBJECT  GLOBAL DEFAULT    4 3
    48: 00000000  2196 OBJECT  GLOBAL DEFAULT    4 4
    49: 00000000 53248 OBJECT  GLOBAL DEFAULT    4 3
    50: 00000000 82944 OBJECT  GLOBAL DEFAULT    4 3
    51: 00000000  2052 OBJECT  GLOBAL DEFAULT    4 4
    52: 00000000 0x40000 OBJECT  GLOBAL DEFAULT   10 scratch-pad-mem
    53: 00000000 0x40000 OBJECT  GLOBAL DEFAULT    9 scratch-pad-mem

Symbol table '.symtab' contains 2 entries:
   Num:    Value  Size Type    Bind   Vis      Ndx Name
     0: 00000000     0 NOTYPE  LOCAL  DEFAULT  UND 
     1: 00000000     0 FUNC    WEAK   DEFAULT  UND _Z8Resnet18PcPcPcPc

No version information found in this file.

Displaying notes found in: .note.xrt.configuration
  Owner                Data size 	Description
  XRT                  0x00000001	Unknown note type: (0x00000006)
   description data: 34 

Displaying notes found in: .note.xrt.UID
  Owner                Data size 	Description
  XRT                  0x00000010	GO BUILDID
   description data: ed 86 28 c2 81 73 34 db eb 88 dc 8a f6 b1 6a 74 
```