### PR TITLE
Bd

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -9,6 +9,7 @@ endif()
 add_library(aiebu_library_objects OBJECT
   analyzer/reporter.cpp
   analyzer/transaction.cpp
+  analyzer/packets.cpp
   assembler/aiebu_assembler.cpp
   assembler/assembler.cpp
   common/aiebu_error.cpp

--- a/src/cpp/analyzer/packets.cpp
+++ b/src/cpp/analyzer/packets.cpp
@@ -2,6 +2,7 @@
 // Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
 #include <array>
+#include <sstream>
 
 #include "file_utils.h"
 #include "packets.h"

--- a/src/cpp/analyzer/packets.cpp
+++ b/src/cpp/analyzer/packets.cpp
@@ -32,7 +32,7 @@ size_t packets::serialize(std::ostream &stream, size_t offset) const
   stream << "CTRL-PKT {@0x" << std::hex << info->local_byte_addr << std::dec << ", ["
          << info->num_data_beat << "], " << control_packet_operations_map(info->operation) << "}\n";
   for (uint32_t i = 0; i < info->num_data_beat; i++) {
-    stream << "         [" << i << "] " << std::hex
+    stream << "         [" << i << "] 0x" << std::hex
            << *(reinterpret_cast<const unsigned int *>(m_buffer + offset))
            << std::dec << "\n";
     offset += sizeof(unsigned int);

--- a/src/cpp/analyzer/packets.cpp
+++ b/src/cpp/analyzer/packets.cpp
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+
+#include <array>
+
+#include "file_utils.h"
+#include "packets.h"
+
+namespace aiebu {
+
+char control_packet_operations_map(uint32_t op)
+{
+  static const std::array<char, 4> optable = {'P', 'R', 'W', 'U'};
+  if (op >= 4)
+    return 'U';
+  return optable[op];
+}
+
+size_t packets::serialize(std::ostream &stream, size_t offset) const
+{
+  const auto header = reinterpret_cast<const cp_pktheader_aie2p *>(m_buffer + offset);
+  offset += sizeof(*header);
+  const auto info = reinterpret_cast<const cp_ctrlinfo_aie2p *>(m_buffer + offset);
+  offset += sizeof(*info);
+
+  if (info->num_data_beat == 0)
+    return offset;
+
+  stream << "PKT-HDR  {#" << header->stream_packet_ID << ", R[" << header->source_row
+         << "?], C[" << header->source_col << "?]}\n";
+
+  stream << "CTRL-PKT {@0x" << std::hex << info->local_byte_addr << std::dec << ", ["
+         << info->num_data_beat << "], " << control_packet_operations_map(info->operation) << "}\n";
+  for (uint32_t i = 0; i < info->num_data_beat; i++) {
+    stream << "         [" << i << "] " << std::hex
+           << *(reinterpret_cast<const unsigned int *>(m_buffer + offset))
+           << std::dec << "\n";
+    offset += sizeof(unsigned int);
+  }
+  return offset;
+}
+
+std::string
+packets::get_dump() const
+{
+  std::stringstream stream;
+  size_t offset = 0;
+  while (offset < m_size) {
+    offset = serialize(stream, offset);
+  }
+  return stream.str();
+}
+
+}

--- a/src/cpp/analyzer/packets.cpp
+++ b/src/cpp/analyzer/packets.cpp
@@ -23,16 +23,13 @@ size_t packets::serialize(std::ostream &stream, size_t offset) const
   const auto info = reinterpret_cast<const cp_ctrlinfo_aie2p *>(m_buffer + offset);
   offset += sizeof(*info);
 
-  if (info->num_data_beat == 0)
-    return offset;
-
-  stream << "PKT-HDR  {#" << header->stream_packet_ID << ", R[" << header->source_row
+  stream << "PH {#" << header->stream_packet_ID << ", R[" << header->source_row
          << "?], C[" << header->source_col << "?]}\n";
 
-  stream << "CTRL-PKT {@0x" << std::hex << info->local_byte_addr << std::dec << ", ["
-         << info->num_data_beat << "], " << control_packet_operations_map(info->operation) << "}\n";
-  for (uint32_t i = 0; i < info->num_data_beat; i++) {
-    stream << "         [" << i << "] 0x" << std::hex
+  stream << "CH {@0x" << std::hex << info->local_byte_addr << std::dec << ", ["
+         << info->num_data_beat + 1 << "], " << control_packet_operations_map(info->operation) << "}\n";
+  for (uint32_t i = 0; i <= info->num_data_beat; i++) {
+    stream << "   [" << i << "] 0x" << std::hex
            << *(reinterpret_cast<const unsigned int *>(m_buffer + offset))
            << std::dec << "\n";
     offset += sizeof(unsigned int);

--- a/src/cpp/analyzer/packets.h
+++ b/src/cpp/analyzer/packets.h
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <cstdint>
+#include <iostream>
 
 namespace aiebu {
 

--- a/src/cpp/analyzer/packets.h
+++ b/src/cpp/analyzer/packets.h
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+
+#include <string>
+#include <cstdint>
+
+namespace aiebu {
+
+class packets {
+private:
+  const char *m_buffer;
+  uint64_t m_size;
+
+private:
+  size_t serialize(std::ostream &stream, size_t offset) const;
+
+public:
+  packets(const char *buffer, uint64_t size) : m_buffer(buffer), m_size(size) {}
+  std::string get_dump() const;
+};
+
+}

--- a/src/cpp/analyzer/reporter.cpp
+++ b/src/cpp/analyzer/reporter.cpp
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 #include "reporter.h"
+#include "packets.h"
+#include "transaction.hpp"
 #include "transaction.hpp"
 
 #include "aiebu/aiebu_error.h"
@@ -77,12 +79,25 @@ namespace aiebu {
         for ( int i = 0; i < sec_num; ++i ) {
             const ELFIO::section* psec = my_elf_reader.sections[i];
 
+            if (psec->get_type() != ELFIO::SHT_PROGBITS)
+                continue;
             // Decoding not supported for ".ctrldata" section
-            // for aie2 ".ctrldata" contain control packet and ".ctrlpkt-pm-N" contain
-            // pm control packet which cannot be decoded
-            if (psec->get_type() != ELFIO::SHT_PROGBITS || is_ctrldata(psec->get_name())
-               || is_pm_ctrlpkt(psec->get_name()))
+            // for aie2 ".ctrldata" contain control packet and ".ctrlpkt-pm-N"
+            // contain pm control packet which cannot be decoded
+
+            if (is_pm_ctrlpkt(psec->get_name()))
+                continue;
+
+            if (is_ctrldata(psec->get_name())) {
+              stream << "\n";
+              stream << "Section[" << i << "]: " << psec->get_name()
+                     << "\tSize: " << psec->get_size() << 'B' << std::endl;
+              packets pprint(psec->get_data(), psec->get_size());
+              stream << "\n" << pprint.get_dump();
               continue;
+            }
+
+            stream << "\n";
             stream << "Section[" << i << "]: " << psec->get_name() << "\tSize: "
                    << psec->get_size() << 'B' << std::endl;
             transaction tprint(psec->get_data(), psec->get_size());

--- a/src/cpp/analyzer/reporter.cpp
+++ b/src/cpp/analyzer/reporter.cpp
@@ -47,7 +47,7 @@ namespace aiebu {
         }
     }
 
-    void reporter::ctrlcode_detail_summary(const std::filesystem::path &root) const
+    void reporter::disassemble(const std::filesystem::path &root) const
     {
         ELFIO::Elf_Half sec_num = my_elf_reader.sections.size();
         for ( int i = 0; i < sec_num; ++i ) {
@@ -73,7 +73,7 @@ namespace aiebu {
         }
     }
 
-    void reporter::ctrlcode_detail_summary(std::ostream &stream) const
+    void reporter::disassemble(std::ostream &stream, bool all) const
     {
         ELFIO::Elf_Half sec_num = my_elf_reader.sections.size();
         for ( int i = 0; i < sec_num; ++i ) {
@@ -89,12 +89,14 @@ namespace aiebu {
                 continue;
 
             if (is_ctrldata(psec->get_name())) {
-              stream << "\n";
-              stream << "Section[" << i << "]: " << psec->get_name()
-                     << "\tSize: " << psec->get_size() << 'B' << std::endl;
-              packets pprint(psec->get_data(), psec->get_size());
-              stream << "\n" << pprint.get_dump();
-              continue;
+                if (all) {
+                    stream << "\n";
+                    stream << "Section[" << i << "]: " << psec->get_name()
+                           << "\tSize: " << psec->get_size() << 'B' << std::endl;
+                    packets pprint(psec->get_data(), psec->get_size());
+                    stream << "\n" << pprint.get_dump();
+                }
+                continue;
             }
 
             stream << "\n";

--- a/src/cpp/analyzer/reporter.h
+++ b/src/cpp/analyzer/reporter.h
@@ -26,8 +26,8 @@ namespace aiebu {
         reporter(aiebu::aiebu_assembler::buffer_type type, const std::vector<char>& elf_data);
         void elf_summary(std::ostream &stream) const;
         void ctrlcode_summary(std::ostream &stream) const;
-        void ctrlcode_detail_summary(const std::filesystem::path &root) const;
-        void ctrlcode_detail_summary(std::ostream &stream) const;
+        void disassemble(const std::filesystem::path &root) const;
+        void disassemble(std::ostream &stream, bool all = false) const;
     };
 }
 

--- a/src/cpp/assembler/aiebu_assembler.cpp
+++ b/src/cpp/assembler/aiebu_assembler.cpp
@@ -93,7 +93,7 @@ aiebu_assembler::
 disassemble(const std::filesystem::path &root) const
 {
     reporter rep(m_type, elf_data);
-    rep.ctrlcode_detail_summary(root);
+    rep.disassemble(root);
 }
 }
 

--- a/src/cpp/common/file_utils.cpp
+++ b/src/cpp/common/file_utils.cpp
@@ -7,30 +7,6 @@
 
 namespace aiebu {
 
-struct cp_pktheader_aie2p
-{
-  uint32_t stream_packet_ID : 5;
-  uint32_t out_of_order_bd_idx : 6;
-  uint32_t reserved_a_0 : 1;
-  uint32_t stream_id_rtn : 3;
-  uint32_t reserved_b_0 : 1;
-  uint32_t source_row : 5;
-  uint32_t source_col : 7;
-  uint32_t reserved_c_000 : 3;
-  uint32_t odd_parity : 1;
-};
-
-struct cp_ctrlinfo_aie2p
-{
-  uint32_t local_byte_addr : 20;
-  uint32_t num_data_beat : 2;
-  uint32_t operation : 2;
-  uint32_t stream_id_rtn : 5;
-  uint32_t reserved_00 : 2;
-  uint32_t parity : 1;
-};
-
-
 constexpr unsigned int magic_length = 16;
 constexpr unsigned int elf_magic = 0x464c457f;
 

--- a/src/cpp/common/file_utils.h
+++ b/src/cpp/common/file_utils.h
@@ -14,6 +14,31 @@
 
 namespace aiebu {
 
+// Defined in AIE2p Architecture Specification v1.4
+struct cp_pktheader_aie2p
+{
+  uint32_t stream_packet_ID : 5;
+  uint32_t out_of_order_bd_idx : 6;
+  uint32_t reserved_a_0 : 1;
+  uint32_t stream_id_rtn : 3;
+  uint32_t reserved_b_0 : 1;
+  uint32_t source_row : 5;
+  uint32_t source_col : 7;
+  uint32_t reserved_c_000 : 3;
+  uint32_t odd_parity : 1;
+};
+
+// Defined in AIE2p Architecture Specification v1.4
+struct cp_ctrlinfo_aie2p
+{
+  uint32_t local_byte_addr : 20;
+  uint32_t num_data_beat : 2;
+  uint32_t operation : 2;
+  uint32_t stream_id_rtn : 5;
+  uint32_t reserved_00 : 2;
+  uint32_t parity : 1;
+};
+
 inline std::vector<char>
 readfile(const std::string& filename)
 {

--- a/src/cpp/common/utils.h
+++ b/src/cpp/common/utils.h
@@ -159,6 +159,7 @@ std::regex get_regex(const std::vector<fragment>& pattern);
 
 constexpr unsigned hexbase = 0x10;
 
+// Convert a string representation of a sized unsigned integer to the target integral value
 template <typename UIntType>
 UIntType
 to_uinteger(const std::string& token) {
@@ -171,10 +172,12 @@ to_uinteger(const std::string& token) {
   return static_cast<UIntType>(result);
 }
 
+// Extract a specific byte from a 32-bit unsigned integer
 template <unsigned int N>
 uint8_t
 get_byte(uint32_t data) {
   uint32_t mask = BYTE_MASK;
+  static_assert((N >= 0) && (N <= 3));
   const unsigned int shift = N * 8;
   mask <<= shift;
   data = data & mask;
@@ -182,10 +185,11 @@ get_byte(uint32_t data) {
   return static_cast<uint8_t>(data);
 }
 
+// Perform odd parity check for a 32-bit unsigned integer
 inline bool
 odd_parity_check(uint32_t data) {
   const std::bitset<32> parity(data);
-  return (parity.count() & 0x0) ? false : true;
+  return (parity.count() & 0x1) ? true : false;
 }
 
 inline bool

--- a/src/cpp/utils/dump/dump.cpp
+++ b/src/cpp/utils/dump/dump.cpp
@@ -123,10 +123,10 @@ int main(int argc, char* argv[])
       rep.ctrlcode_summary(std::cout);
     }
     else if (result["disassemble"].as<bool>()) {
-      rep.ctrlcode_detail_summary(std::cout);
+      rep.disassemble(std::cout);
     }
     else if (result["disassemble-all"].as<bool>()) {
-      rep.ctrlcode_detail_summary(std::cout);
+      rep.disassemble(std::cout, true);
     }
   }
 

--- a/src/cpp/utils/dump/dump.cpp
+++ b/src/cpp/utils/dump/dump.cpp
@@ -122,7 +122,10 @@ int main(int argc, char* argv[])
       rep.elf_summary(std::cout);
       rep.ctrlcode_summary(std::cout);
     }
-    if (result["disassemble"].as<bool>()) {
+    else if (result["disassemble"].as<bool>()) {
+      rep.ctrlcode_detail_summary(std::cout);
+    }
+    else if (result["disassemble-all"].as<bool>()) {
       rep.ctrlcode_detail_summary(std::cout);
     }
   }

--- a/test/aie2-ctrlcode/dump/CMakeLists.txt
+++ b/test/aie2-ctrlcode/dump/CMakeLists.txt
@@ -10,6 +10,10 @@ add_test(NAME "aie2_pmctrlpkt_elf_dump"
   COMMAND aiebu-dump -d ../pmctrlpkt/mc_code_txn.elf
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
+add_test(NAME "aie2_pmctrlpkt_elf_dump_all"
+  COMMAND aiebu-dump -D ../pmctrlpkt/mc_code_txn.elf
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
 add_test(NAME "aie2_pmctrlpkt_ctrlpkt_dump0"
   COMMAND aiebu-dump ../pmctrlpkt/ctrl_pkt.bin
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Add support for dumping aie2p control packets. This feature is tied to -D switch of aiebu-dump.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added new code to parse packet header and control header and write them out in a human readable format.

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Compile and ctest validated

#### Documentation impact (if any)
NA