### PR TITLE
xrt integration fix, check boost else uid mismatch

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -24,6 +24,12 @@ add_library(aiebu_library_objects OBJECT
   ops/ops.cpp
   )
 
+# Remove globle includes in case of submodule XRT as there are conflicts
+# in version.h and utils.h
+set_target_properties(aiebu_library_objects PROPERTIES
+  INCLUDE_DIRECTORIES ""  # Clear inherited dirs
+  )
+
 target_include_directories(aiebu_library_objects
   PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}

--- a/src/cpp/utils/asm/CMakeLists.txt
+++ b/src/cpp/utils/asm/CMakeLists.txt
@@ -5,6 +5,12 @@ add_library(aiebu_asm_objects OBJECT
   ${AIEBU_SOURCE_DIR}/src/cpp/utils/target/target.cpp
   )
 
+# Remove globle includes in case of submodule XRT as there are conflicts
+# in version.h and utils.h
+set_target_properties(aiebu_asm_objects PROPERTIES
+  INCLUDE_DIRECTORIES ""  # Clear inherited dirs
+  )
+
 target_include_directories(aiebu_asm_objects
   PRIVATE
   ${AIEBU_SOURCE_DIR}/src/cpp

--- a/src/cpp/utils/dump/CMakeLists.txt
+++ b/src/cpp/utils/dump/CMakeLists.txt
@@ -5,6 +5,12 @@ add_library(aiebu_dump_objects OBJECT
   dump.cpp
   )
 
+# Remove globle includes in case of submodule XRT as there are conflicts
+# in version.h and utils.h
+set_target_properties(aiebu_dump_objects PROPERTIES
+  INCLUDE_DIRECTORIES ""  # Clear inherited dirs
+  )
+
 target_include_directories(aiebu_dump_objects
   PRIVATE
   ${AIEBU_SOURCE_DIR}/src/cpp/include

--- a/test/cpp_test/cpp_api/CMakeLists.txt
+++ b/test/cpp_test/cpp_api/CMakeLists.txt
@@ -41,13 +41,18 @@ add_test(NAME "aie2ps_cpp_eff_net_coal"
 #   COMMAND ${AIE2PS_TESTNAME} "eff_net_ctrlpacket" "${AIEBU_SOURCE_DIR}/test/cpp_test/aie2ps/eff_net_ctrlpacket/"
 #   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
-add_test(NAME "aie2ps_cpp_eff_net_coal_md5sum"
-  COMMAND cmake -P "${AIEBU_SOURCE_DIR}/cmake/md5sum-compare.cmake" "${CMAKE_CURRENT_BINARY_DIR}/eff_net_coal.elf" "${AIEBU_SOURCE_DIR}/test/cpp_test/aie2ps/eff_net_coal/gold.md5"
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+# Check checksum only then boost > 1.70 else there is mismatch in uid because of endianness issue
+# https://github.com/boostorg/uuid/pull/109
+# https://github.com/boostorg/uuid/issues/111
+if(Boost_VERSION VERSION_GREATER 1.70)
+  add_test(NAME "aie2ps_cpp_eff_net_coal_md5sum"
+    COMMAND cmake -P "${AIEBU_SOURCE_DIR}/cmake/md5sum-compare.cmake" "${CMAKE_CURRENT_BINARY_DIR}/eff_net_coal.elf" "${AIEBU_SOURCE_DIR}/test/cpp_test/aie2ps/eff_net_coal/gold.md5"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
 # add_test(NAME "aie2ps_cpp_eff_net_ctrlpacket_md5sum"
 #   COMMAND cmake -P "${AIEBU_SOURCE_DIR}/cmake/md5sum-compare.cmake" "${CMAKE_CURRENT_BINARY_DIR}/eff_net_ctrlpacket.elf" "${AIEBU_SOURCE_DIR}/test/cpp_test/aie2ps/eff_net_ctrlpacket/gold.md5"
 #   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+endif()
 
 add_test(NAME "aie2_cpp_4x4"
   COMMAND ${AIE2_TESTNAME} "${AIEBU_BINARY_DIR}/lib/gen/preempt_restore_stx_4x4.bin"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
XRT integration issue fix
1. XRT add include_dir globally https://github.com/Xilinx/XRT/blob/master/src/CMakeLists.txt#L15
   when aiebu is submodule it cause conflict in herderfiles like version.h/utils.h
2. boost:md5 is used for uid creation, there is a endianness fix done from boost 1.71. it cause md5 mismatch for boost below 1.71
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
