### PR TITLE
Add support for AIE2 & AIE2P ctrlpkt dump from ctrlpkt binary file

### DIFF
--- a/src/cpp/analyzer/packets.cpp
+++ b/src/cpp/analyzer/packets.cpp
@@ -9,6 +9,11 @@
 
 namespace aiebu {
 
+// Size of word in bytes
+constexpr unsigned int word_size = 4;
+// For AIE2 control packets are 8 words (8words * 4bytes/word = 32bytes) aligned
+constexpr unsigned int ctrlpkt_offset_aie2 = 8 * word_size;
+
 char control_packet_operations_map(uint32_t op)
 {
   static const std::array<char, 4> optable = {'P', 'R', 'W', 'U'};

--- a/src/cpp/analyzer/packets.cpp
+++ b/src/cpp/analyzer/packets.cpp
@@ -43,20 +43,20 @@ packets::get_dump() const
 {
   std::stringstream stream;
   size_t offset = 0;
-  while (offset < m_size) {
-    offset = serialize(stream, offset);
-  }
-  return stream.str();
-}
-
-std::string
-packets::get_dump_aie2() const
-{
-  std::stringstream stream;
-  size_t offset = 0;
-  while (offset < m_size) {
-    serialize(stream, offset);
-    offset += ctrlpkt_offset_aie2;
+  // check control packet type
+  if (m_buffer_type == aiebu::aiebu_assembler::buffer_type::blob_control_packet) {
+    // AIE2P control packet
+    while (offset < m_size) {
+      offset = serialize(stream, offset);
+    }
+  } else if (m_buffer_type == aiebu::aiebu_assembler::buffer_type::blob_control_packet_aie2) {
+    // AIE2 control packet
+    while (offset < m_size) {
+      serialize(stream, offset);
+      offset += ctrlpkt_offset_aie2;
+    }
+  } else {
+    stream << "Unknown buffer type for control packet dump.\n";
   }
   return stream.str();
 }

--- a/src/cpp/analyzer/packets.cpp
+++ b/src/cpp/analyzer/packets.cpp
@@ -49,4 +49,16 @@ packets::get_dump() const
   return stream.str();
 }
 
+std::string
+packets::get_dump_aie2() const
+{
+  std::stringstream stream;
+  size_t offset = 0;
+  while (offset < m_size) {
+    serialize(stream, offset);
+    offset += ctrlpkt_offset_aie2;
+  }
+  return stream.str();
+}
+
 }

--- a/src/cpp/analyzer/packets.h
+++ b/src/cpp/analyzer/packets.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <cstdint>
 #include <iostream>
+#include "aiebu/aiebu_assembler.h"
 
 namespace aiebu {
 
@@ -11,14 +12,16 @@ class packets {
 private:
   const char *m_buffer;
   uint64_t m_size;
+  aiebu::aiebu_assembler::buffer_type m_buffer_type;
 
 private:
   size_t serialize(std::ostream &stream, size_t offset) const;
 
 public:
-  packets(const char *buffer, uint64_t size) : m_buffer(buffer), m_size(size) {}
+  packets(const char *buffer, uint64_t size, aiebu::aiebu_assembler::buffer_type buffer_type)
+    : m_buffer(buffer), m_size(size), m_buffer_type(buffer_type) {}
+
   std::string get_dump() const;
-  std::string get_dump_aie2() const;
 };
 
 }

--- a/src/cpp/analyzer/packets.h
+++ b/src/cpp/analyzer/packets.h
@@ -18,6 +18,7 @@ private:
 public:
   packets(const char *buffer, uint64_t size) : m_buffer(buffer), m_size(size) {}
   std::string get_dump() const;
+  std::string get_dump_aie2() const;
 };
 
 }

--- a/src/cpp/analyzer/packets.h
+++ b/src/cpp/analyzer/packets.h
@@ -12,7 +12,7 @@ class packets {
 private:
   const char *m_buffer;
   uint64_t m_size;
-  aiebu::aiebu_assembler::buffer_type m_buffer_type;
+  const aiebu::aiebu_assembler::buffer_type m_buffer_type;
 
 private:
   size_t serialize(std::ostream &stream, size_t offset) const;

--- a/src/cpp/analyzer/reporter.cpp
+++ b/src/cpp/analyzer/reporter.cpp
@@ -4,6 +4,8 @@
 #include "packets.h"
 #include "transaction.hpp"
 #include "transaction.hpp"
+#include "common/file_utils.h"
+
 
 #include "aiebu/aiebu_error.h"
 
@@ -63,9 +65,21 @@ namespace aiebu {
                     std::ofstream stream(file);
                     stream << ";  [" << i << "] " << psec->get_name() << "\t"
                            << psec->get_size() << 'B' << std::endl;
-
                     packets pprint(psec->get_data(), psec->get_size());
-                    stream << pprint.get_dump();
+                    if (is_pm_ctrlpkt(psec->get_name())) {
+                        stream << pprint.get_dump();
+                    } else if (is_ctrldata(psec->get_name())) {
+                        // Check type of control packet
+                        aiebu::aiebu_assembler::buffer_type packet_type =
+                        check_control_packet(psec->get_data(), psec->get_size());
+                        if (packet_type == aiebu::aiebu_assembler::buffer_type::blob_control_packet) {
+                            stream << pprint.get_dump();
+                        } else if (packet_type == aiebu::aiebu_assembler::buffer_type::blob_control_packet_aie2) {
+                            stream << pprint.get_dump_aie2();
+                        } else {
+                            stream << "\nInvalid control packet type" << std::endl;
+                        }
+                    }
                 }
                 continue;
             }
@@ -97,7 +111,20 @@ namespace aiebu {
                     stream << "Section[" << i << "]: " << psec->get_name()
                            << "\tSize: " << psec->get_size() << 'B' << std::endl;
                     packets pprint(psec->get_data(), psec->get_size());
-                    stream << "\n" << pprint.get_dump();
+                    if (is_pm_ctrlpkt(psec->get_name())) {
+                        stream << "\n" << pprint.get_dump();
+                    } else if (is_ctrldata(psec->get_name())) {
+                        // Check type of control packet
+                        aiebu::aiebu_assembler::buffer_type packet_type =
+                        check_control_packet(psec->get_data(), psec->get_size());
+                        if (packet_type == aiebu::aiebu_assembler::buffer_type::blob_control_packet) {
+                            stream << "\n" << pprint.get_dump();
+                        } else if (packet_type == aiebu::aiebu_assembler::buffer_type::blob_control_packet_aie2) {
+                            stream << "\n" << pprint.get_dump_aie2();
+                        } else {
+                            stream << "\nInvalid control packet type" << std::endl;
+                        }
+                    }
                 }
                 continue;
             }

--- a/src/cpp/analyzer/reporter.cpp
+++ b/src/cpp/analyzer/reporter.cpp
@@ -65,21 +65,11 @@ namespace aiebu {
                     std::ofstream stream(file);
                     stream << ";  [" << i << "] " << psec->get_name() << "\t"
                            << psec->get_size() << 'B' << std::endl;
-                    packets pprint(psec->get_data(), psec->get_size());
-                    if (is_pm_ctrlpkt(psec->get_name())) {
-                        stream << pprint.get_dump();
-                    } else if (is_ctrldata(psec->get_name())) {
-                        // Check type of control packet
-                        aiebu::aiebu_assembler::buffer_type packet_type =
-                        check_control_packet(psec->get_data(), psec->get_size());
-                        if (packet_type == aiebu::aiebu_assembler::buffer_type::blob_control_packet) {
-                            stream << pprint.get_dump();
-                        } else if (packet_type == aiebu::aiebu_assembler::buffer_type::blob_control_packet_aie2) {
-                            stream << pprint.get_dump_aie2();
-                        } else {
-                            stream << "\nInvalid control packet type" << std::endl;
-                        }
-                    }
+                    // Check type of control packet
+                    aiebu::aiebu_assembler::buffer_type packet_type =
+                    check_control_packet(psec->get_data(), psec->get_size());
+                    packets pprint(psec->get_data(), psec->get_size(), packet_type);
+                    stream << pprint.get_dump();
                 }
                 continue;
             }
@@ -110,21 +100,12 @@ namespace aiebu {
                     stream << "\n";
                     stream << "Section[" << i << "]: " << psec->get_name()
                            << "\tSize: " << psec->get_size() << 'B' << std::endl;
-                    packets pprint(psec->get_data(), psec->get_size());
-                    if (is_pm_ctrlpkt(psec->get_name())) {
-                        stream << "\n" << pprint.get_dump();
-                    } else if (is_ctrldata(psec->get_name())) {
-                        // Check type of control packet
-                        aiebu::aiebu_assembler::buffer_type packet_type =
-                        check_control_packet(psec->get_data(), psec->get_size());
-                        if (packet_type == aiebu::aiebu_assembler::buffer_type::blob_control_packet) {
-                            stream << "\n" << pprint.get_dump();
-                        } else if (packet_type == aiebu::aiebu_assembler::buffer_type::blob_control_packet_aie2) {
-                            stream << "\n" << pprint.get_dump_aie2();
-                        } else {
-                            stream << "\nInvalid control packet type" << std::endl;
-                        }
-                    }
+
+                    // Check type of control packet
+                    aiebu::aiebu_assembler::buffer_type packet_type =
+                    check_control_packet(psec->get_data(), psec->get_size());
+                    packets pprint(psec->get_data(), psec->get_size(), packet_type);
+                    stream << "\n" << pprint.get_dump();
                 }
                 continue;
             }

--- a/src/cpp/analyzer/reporter.cpp
+++ b/src/cpp/analyzer/reporter.cpp
@@ -67,7 +67,7 @@ namespace aiebu {
                            << psec->get_size() << 'B' << std::endl;
                     // Check type of control packet
                     aiebu::aiebu_assembler::buffer_type packet_type =
-                    check_control_packet(psec->get_data(), psec->get_size());
+                    identify_control_packet(psec->get_data(), psec->get_size());
                     packets pprint(psec->get_data(), psec->get_size(), packet_type);
                     stream << pprint.get_dump();
                 }
@@ -103,7 +103,7 @@ namespace aiebu {
 
                     // Check type of control packet
                     aiebu::aiebu_assembler::buffer_type packet_type =
-                    check_control_packet(psec->get_data(), psec->get_size());
+                    identify_control_packet(psec->get_data(), psec->get_size());
                     packets pprint(psec->get_data(), psec->get_size(), packet_type);
                     stream << "\n" << pprint.get_dump();
                 }

--- a/src/cpp/common/file_utils.cpp
+++ b/src/cpp/common/file_utils.cpp
@@ -50,7 +50,6 @@ check_control_packet(const char* buffer, uint64_t size)
     return aiebu_assembler::buffer_type::unspecified;
 
   auto control_packet = reinterpret_cast<const unsigned int *>(buffer);
-  uint64_t offset = 0;
   uint64_t count = 0;
 
   // Check if the input buffer is control packet for aie2p
@@ -61,7 +60,7 @@ check_control_packet(const char* buffer, uint64_t size)
     if ((cphdr->reserved_a_0 == 0x0) && (cphdr->reserved_b_0 == 0x0) &&
         (cphdr->reserved_c_000 == 0x0) && (cp->reserved_00 == 0x0) &&
         odd_parity_check(*control_packet) && odd_parity_check(*(control_packet + 1))) {
-      offset = ((sizeof(*cphdr) + sizeof(*cp)) / word_size) + (cp->num_data_beat + 1);
+      uint64_t offset = ((sizeof(*cphdr) + sizeof(*cp)) / word_size) + (cp->num_data_beat + 1);
       control_packet += offset;
       count += offset * word_size;
     } else {

--- a/src/cpp/common/file_utils.cpp
+++ b/src/cpp/common/file_utils.cpp
@@ -69,7 +69,7 @@ check_control_packet(const char* buffer, uint64_t size)
     }
   }
 
-  if (count >= size)
+  if (count == size)
     return aiebu_assembler::buffer_type::blob_control_packet;
 
   // Check if the input buffer is control packet for aie2

--- a/src/cpp/common/file_utils.cpp
+++ b/src/cpp/common/file_utils.cpp
@@ -40,51 +40,50 @@ identify_buffer_type(const std::vector<char>& buffer)
 
   // TODO: Put the reference to Packet Header and Control Packet here
   // ctrlpkt identification is WIP
-  return check_control_packet(buffer);
+  return check_control_packet(buffer.data(), buffer.size());
 }
 
-
 aiebu_assembler::buffer_type
-check_control_packet(const std::vector<char>& buffer)
+check_control_packet(const char* buffer, uint64_t size)
 {
-  if (buffer.size() < magic_length)
+  if (size < magic_length)
     return aiebu_assembler::buffer_type::unspecified;
 
-  const unsigned int* control_packet = reinterpret_cast<const unsigned int *>(buffer.data());
-  size_t offset = 0;
-  size_t count = 0;
+  auto control_packet = reinterpret_cast<const unsigned int *>(buffer);
+  uint64_t offset = 0;
+  uint64_t count = 0;
 
   // Check if the input buffer is control packet for aie2p
-  while (count < buffer.size()) {
+  while (count < size) {
     const auto cphdr = reinterpret_cast<const cp_pktheader_aie2p *>(control_packet);
     const auto cp = reinterpret_cast<const cp_ctrlinfo_aie2p *>(control_packet + 1);
 
     if ((cphdr->reserved_a_0 == 0x0) && (cphdr->reserved_b_0 == 0x0) &&
         (cphdr->reserved_c_000 == 0x0) && (cp->reserved_00 == 0x0) &&
-        odd_parity_check(control_packet[0]) && odd_parity_check(control_packet[1])) {
-      offset = sizeof(*cphdr) + sizeof(*cp) + ((cp->num_data_beat + 1) * sizeof(unsigned int));
-      control_packet += offset / sizeof(*control_packet);
-      count += offset;
+        odd_parity_check(*control_packet) && odd_parity_check(*(control_packet + 1))) {
+      offset = ((sizeof(*cphdr) + sizeof(*cp)) / word_size) + (cp->num_data_beat + 1);
+      control_packet += offset;
+      count += offset * word_size;
     } else {
       break;
     }
   }
 
-  if (count >= buffer.size())
+  if (count >= size)
     return aiebu_assembler::buffer_type::blob_control_packet;
 
   // Check if the input buffer is control packet for aie2
-  control_packet = reinterpret_cast<const unsigned int *>(buffer.data());
+  control_packet = reinterpret_cast<const unsigned int *>(buffer);
   count = 0;
 
-  while (count < buffer.size()) {
+  while (count < size) {
     const auto cphdr_aie2 = reinterpret_cast<const cp_pktheader_aie2p *>(control_packet);
     const auto cp_aie2 = reinterpret_cast<const cp_ctrlinfo_aie2p *>(control_packet + 1);
 
     if ((cphdr_aie2->reserved_a_0 == 0x0) && (cphdr_aie2->reserved_b_0 == 0x0) &&
         (cphdr_aie2->reserved_c_000 == 0x0) && (cp_aie2->reserved_00 == 0x0) &&
-        odd_parity_check(control_packet[0]) && odd_parity_check(control_packet[1])) {
-      control_packet += ctrlpkt_offset_aie2 / sizeof(*control_packet);
+        odd_parity_check(*control_packet) && odd_parity_check(*(control_packet + 1))) {
+      control_packet += ctrlpkt_offset_aie2 / word_size;
       count += ctrlpkt_offset_aie2;
     } else {
       return aiebu_assembler::buffer_type::unspecified;

--- a/src/cpp/common/file_utils.cpp
+++ b/src/cpp/common/file_utils.cpp
@@ -4,6 +4,7 @@
 #include "file_utils.h"
 #include "aiebu/aiebu_assembler.h"
 #include "utils.h"
+#include <iostream>
 
 namespace aiebu {
 
@@ -28,7 +29,6 @@ identify_buffer_type(const std::vector<char>& buffer)
   // TODO: add additional check to distinguish between aie2 and aie2ps
   if (data[0] == elf_magic)
     return aiebu_assembler::buffer_type::elf_aie2;
-
   // Transaction ctrlcode header
   if (data[0] == ctrlcode_magic_aie2)
     return aiebu_assembler::buffer_type::blob_instr_transaction;
@@ -40,18 +40,58 @@ identify_buffer_type(const std::vector<char>& buffer)
 
   // TODO: Put the reference to Packet Header and Control Packet here
   // ctrlpkt identification is WIP
-  const auto cphdr = reinterpret_cast<const cp_pktheader_aie2p *>(data);
-  const auto cp = reinterpret_cast<const cp_ctrlinfo_aie2p *>(data + 1);
+  return check_control_packet(buffer);
+}
 
-  if ((cphdr->reserved_a_0 == 0x0) && (cphdr->reserved_b_0 == 0x0) &&
-      (cphdr->reserved_c_000 == 0x0) && (cp->reserved_00 == 0x0)) {
-    if (odd_parity_check(data[0]) && odd_parity_check(data[1]))
-      return aiebu_assembler::buffer_type::blob_control_packet;
-    else
-      return aiebu_assembler::buffer_type::unspecified;
+
+aiebu_assembler::buffer_type
+check_control_packet(const std::vector<char>& buffer)
+{
+  if (buffer.size() < magic_length)
+    return aiebu_assembler::buffer_type::unspecified;
+
+  const unsigned int* control_packet = reinterpret_cast<const unsigned int *>(buffer.data());
+  size_t offset = 0;
+  size_t count = 0;
+
+  // Check if the input buffer is control packet for aie2p
+  while (count < buffer.size()) {
+    const auto cphdr = reinterpret_cast<const cp_pktheader_aie2p *>(control_packet);
+    const auto cp = reinterpret_cast<const cp_ctrlinfo_aie2p *>(control_packet + 1);
+
+    if ((cphdr->reserved_a_0 == 0x0) && (cphdr->reserved_b_0 == 0x0) &&
+        (cphdr->reserved_c_000 == 0x0) && (cp->reserved_00 == 0x0) &&
+        odd_parity_check(control_packet[0]) && odd_parity_check(control_packet[1])) {
+      offset = sizeof(*cphdr) + sizeof(*cp) + ((cp->num_data_beat + 1) * sizeof(unsigned int));
+      control_packet += offset / sizeof(*control_packet);
+      count += offset;
+    } else {
+      break;
+    }
   }
 
-  return aiebu_assembler::buffer_type::unspecified;
+  if (count >= buffer.size())
+    return aiebu_assembler::buffer_type::blob_control_packet;
+
+  // Check if the input buffer is control packet for aie2
+  control_packet = reinterpret_cast<const unsigned int *>(buffer.data());
+  count = 0;
+
+  while (count < buffer.size()) {
+    const auto cphdr_aie2 = reinterpret_cast<const cp_pktheader_aie2p *>(control_packet);
+    const auto cp_aie2 = reinterpret_cast<const cp_ctrlinfo_aie2p *>(control_packet + 1);
+
+    if ((cphdr_aie2->reserved_a_0 == 0x0) && (cphdr_aie2->reserved_b_0 == 0x0) &&
+        (cphdr_aie2->reserved_c_000 == 0x0) && (cp_aie2->reserved_00 == 0x0) &&
+        odd_parity_check(control_packet[0]) && odd_parity_check(control_packet[1])) {
+      control_packet += ctrlpkt_offset_aie2 / sizeof(*control_packet);
+      count += ctrlpkt_offset_aie2;
+    } else {
+      return aiebu_assembler::buffer_type::unspecified;
+    }
+  }
+
+  return aiebu_assembler::buffer_type::blob_control_packet_aie2;
 }
 
 }

--- a/src/cpp/common/file_utils.cpp
+++ b/src/cpp/common/file_utils.cpp
@@ -18,6 +18,11 @@ constexpr unsigned int ctrlcode_magic_aie2 = 0x06040100;
 constexpr unsigned int pdi_magic0 = 0x000000dd;
 constexpr unsigned int pdi_magic1 = 0x11223344;
 
+// Size of word in bytes
+constexpr unsigned int word_size = 4;
+// For AIE2 control packets are 8 words (8words * 4bytes/word = 32bytes) aligned
+constexpr unsigned int ctrlpkt_offset_aie2 = 8 * word_size;
+
 aiebu_assembler::buffer_type
 identify_buffer_type(const std::vector<char>& buffer)
 {
@@ -40,11 +45,11 @@ identify_buffer_type(const std::vector<char>& buffer)
 
   // TODO: Put the reference to Packet Header and Control Packet here
   // ctrlpkt identification is WIP
-  return check_control_packet(buffer.data(), buffer.size());
+  return identify_control_packet(buffer.data(), buffer.size());
 }
 
 aiebu_assembler::buffer_type
-check_control_packet(const char* buffer, uint64_t size)
+identify_control_packet(const char* buffer, uint64_t size)
 {
   if (size < magic_length)
     return aiebu_assembler::buffer_type::unspecified;

--- a/src/cpp/common/file_utils.h
+++ b/src/cpp/common/file_utils.h
@@ -39,12 +39,6 @@ struct cp_ctrlinfo_aie2p
   uint32_t parity : 1;
 };
 
-// Size of word in bytes
-constexpr unsigned int word_size = 4;
-
-// For AIE2 control packets are 8 words (8words * 4bytes/word = 32bytes) aligned
-constexpr unsigned int ctrlpkt_offset_aie2 = 8 * word_size;
-
 inline std::vector<char>
 readfile(const std::string& filename)
 {
@@ -78,7 +72,7 @@ aiebu_assembler::buffer_type
 identify_buffer_type(const std::vector<char> &buffer);
 
 aiebu_assembler::buffer_type
-check_control_packet(const char* buffer, uint64_t size);
+identify_control_packet(const char* buffer, uint64_t size);
 
 }
 

--- a/src/cpp/common/file_utils.h
+++ b/src/cpp/common/file_utils.h
@@ -39,6 +39,9 @@ struct cp_ctrlinfo_aie2p
   uint32_t parity : 1;
 };
 
+// For AIE2 control packets are 8 words aligned
+constexpr unsigned int ctrlpkt_offset_aie2 = 8 * sizeof(unsigned int);
+
 inline std::vector<char>
 readfile(const std::string& filename)
 {
@@ -70,6 +73,9 @@ findFilePath(const std::string& filename, const std::vector<std::string>& libpat
 
 aiebu_assembler::buffer_type
 identify_buffer_type(const std::vector<char> &buffer);
+
+aiebu_assembler::buffer_type
+check_control_packet(const std::vector<char>& buffer);
 
 }
 

--- a/src/cpp/common/file_utils.h
+++ b/src/cpp/common/file_utils.h
@@ -39,8 +39,11 @@ struct cp_ctrlinfo_aie2p
   uint32_t parity : 1;
 };
 
-// For AIE2 control packets are 8 words aligned
-constexpr unsigned int ctrlpkt_offset_aie2 = 8 * sizeof(unsigned int);
+// Size of word in bytes
+constexpr unsigned int word_size = 4;
+
+// For AIE2 control packets are 8 words (8words * 4bytes/word = 32bytes) aligned
+constexpr unsigned int ctrlpkt_offset_aie2 = 8 * word_size;
 
 inline std::vector<char>
 readfile(const std::string& filename)
@@ -75,7 +78,7 @@ aiebu_assembler::buffer_type
 identify_buffer_type(const std::vector<char> &buffer);
 
 aiebu_assembler::buffer_type
-check_control_packet(const std::vector<char>& buffer);
+check_control_packet(const char* buffer, uint64_t size);
 
 }
 

--- a/src/cpp/include/aiebu/aiebu_assembler.h
+++ b/src/cpp/include/aiebu/aiebu_assembler.h
@@ -30,6 +30,7 @@ class aiebu_assembler
       elf_aie2ps,
       pdi_aie2,
       pdi_aie2ps,
+      blob_control_packet_aie2,
       unspecified,
     };
 

--- a/src/cpp/utils/dump/dump.cpp
+++ b/src/cpp/utils/dump/dump.cpp
@@ -54,7 +54,8 @@ cxxopts::ParseResult main_helper(int argc, const char* const *argv,
       ("a,archive-headers", "Display archive header information", cxxopts::value<bool>()->default_value("false"))
       ("f,file-headers", "Display the contents of the overall file header", cxxopts::value<bool>()->default_value("false"))
       ("x,all-headers", "Display contents of all elf headers", cxxopts::value<bool>()->default_value("false"))
-      ("d,disassemble", "Display assembler contents of ctrltext sections", cxxopts::value<bool>()->default_value("false"))
+      ("d,disassemble", "Display assembler contents of ctrltext sections if elf file is provided or display control packet \
+        in assembled format if control packet binary file is provided", cxxopts::value<bool>()->default_value("false"))
       ("H,help", "show help message and exit", cxxopts::value<bool>()->default_value("false"))
       ("m,architecture", "Specify the target architecture as MACHINE (aie2ps/aie2asm/aie2txn/aie2dpu)", cxxopts::value<std::string>()->default_value("unspecified"))
       ("D,disassemble-all", "Display assembler contents of all sections", cxxopts::value<bool>()->default_value("false"))
@@ -132,13 +133,16 @@ int main(int argc, char* argv[])
     }
   }
   else if (type == aiebu::aiebu_assembler::buffer_type::blob_control_packet) {
-    aiebu::packets packetprint(buffer.data(), static_cast<uint64_t>(buffer.size()));
-    std::cout <<  packetprint.get_dump() << std::endl;
-
+    if (result["disassemble"].as<bool>()) {
+      aiebu::packets packetprint(buffer.data(), static_cast<uint64_t>(buffer.size()));
+      std::cout <<  packetprint.get_dump() << std::endl;
+    }
   }
   else if (type == aiebu::aiebu_assembler::buffer_type::blob_control_packet_aie2) {
-        aiebu::packets packetprint(buffer.data(), static_cast<uint64_t>(buffer.size()));
-        std::cout <<  packetprint.get_dump_aie2() << std::endl;
+    if (result["disassemble"].as<bool>()) {
+      aiebu::packets packetprint(buffer.data(), static_cast<uint64_t>(buffer.size()));
+      std::cout <<  packetprint.get_dump_aie2() << std::endl;
+    }
   }
   return 0;
 }

--- a/src/cpp/utils/dump/dump.cpp
+++ b/src/cpp/utils/dump/dump.cpp
@@ -9,6 +9,7 @@
 #include <map>
 
 #include "analyzer/reporter.h"
+#include "analyzer/packets.h"
 #include "common/file_utils.h"
 #include "common/utils.h"
 
@@ -28,7 +29,8 @@ buffer_type_table = { // NOLINT
   {aiebu::aiebu_assembler::buffer_type::blob_instr_dpu, "aie2-dpu-ctrlcode"},
   {aiebu::aiebu_assembler::buffer_type::blob_instr_prepost, "aie2-ctrlpkt"},
   {aiebu::aiebu_assembler::buffer_type::blob_instr_transaction, "aie2-ctrlcode"},
-  {aiebu::aiebu_assembler::buffer_type::blob_control_packet, "aie2-ctrlpkt"},
+  {aiebu::aiebu_assembler::buffer_type::blob_control_packet, "aie2p-ctrlpkt"},
+  {aiebu::aiebu_assembler::buffer_type::blob_control_packet_aie2, "aie2-ctrlpkt"},
   {aiebu::aiebu_assembler::buffer_type::asm_aie2ps, "aie2ps-ctrlcode-asm"},
   {aiebu::aiebu_assembler::buffer_type::asm_aie2, "aie2-ctrlcode-asm"},
   {aiebu::aiebu_assembler::buffer_type::elf_aie2, "aie2-elf"},
@@ -129,6 +131,14 @@ int main(int argc, char* argv[])
       rep.disassemble(std::cout, true);
     }
   }
+  else if (type == aiebu::aiebu_assembler::buffer_type::blob_control_packet) {
+    aiebu::packets packetprint(buffer.data(), static_cast<uint64_t>(buffer.size()));
+    std::cout <<  packetprint.get_dump() << std::endl;
 
+  }
+  else if (type == aiebu::aiebu_assembler::buffer_type::blob_control_packet_aie2) {
+        aiebu::packets packetprint(buffer.data(), static_cast<uint64_t>(buffer.size()));
+        std::cout <<  packetprint.get_dump_aie2() << std::endl;
+  }
   return 0;
 }

--- a/src/cpp/utils/dump/dump.cpp
+++ b/src/cpp/utils/dump/dump.cpp
@@ -132,16 +132,11 @@ int main(int argc, char* argv[])
       rep.disassemble(std::cout, true);
     }
   }
-  else if (type == aiebu::aiebu_assembler::buffer_type::blob_control_packet) {
+  else if (type == aiebu::aiebu_assembler::buffer_type::blob_control_packet || 
+           type == aiebu::aiebu_assembler::buffer_type::blob_control_packet_aie2) {
     if (result["disassemble"].as<bool>()) {
-      aiebu::packets packetprint(buffer.data(), static_cast<uint64_t>(buffer.size()));
+      aiebu::packets packetprint(buffer.data(), static_cast<uint64_t>(buffer.size()), type);
       std::cout <<  packetprint.get_dump() << std::endl;
-    }
-  }
-  else if (type == aiebu::aiebu_assembler::buffer_type::blob_control_packet_aie2) {
-    if (result["disassemble"].as<bool>()) {
-      aiebu::packets packetprint(buffer.data(), static_cast<uint64_t>(buffer.size()));
-      std::cout <<  packetprint.get_dump_aie2() << std::endl;
     }
   }
   return 0;


### PR DESCRIPTION
#### Problem solved by the commit
AIE2 and AIE2P control packet binaries are packaged differently.
1. For AIE2 - Each control packet entry in the control packet binary is 8 words aligned. That is, every control packet starts after 8 words from the start address of the previous control packet.
Example - control_packet_2 = Address of control_packet_1 + 8 words.

2. For AIE2P - Control packets are contiguous. That is each control packet entry in the control packet binary starts right after the previous control packet entry ends. 
Example - Start address of control_packet_2 = Start address of control_packet_1 + size of control_packet_1

Feature - Added support to display control packets for AIE2 and AIE2P using above specs when a control packet binary is provided.

Bug Fix - The existing control packet dump from ELF file doesn't follow above architecture specific rule but treats all control packets as per rule 2 above. This has been fixed.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://github.com/Xilinx/aiebu/pull/90

#### How problem was solved, alternative solutions (if any) and why they were rejected
1> Added additional buffer type "aiebu_assembler::buffer_type::blob_control_packet_aie2" for AIE2 specific control packet as this is a distinct category of control packet specific to AIE architecture without changing the existing one ("aiebu_assembler::buffer_type::blob_control_packet" ) to maintain backward compatibility.
But I think to further enhance nomenclature and clarity we can add "aiebu_assembler::buffer_type::blob_control_packet_aie2p" to have same functionality as existing "aiebu_assembler::buffer_type::blob_control_packet" and eventually deprecate "aiebu_assembler::buffer_type::blob_control_packet".
2> Added changes to detect control packet type from given ELF or from given control packet binary and accordingly display the control packet
3> "-d" option of aiebu-dump is extended to support both ELF input and control packet binary input.

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
1> All the build time tests have passed.
100% tests passed, 0 tests failed out of 88

2> Tested AIE2 and AIE2P control packet binaries and compared them with the transparser tool output which has the arch specific dumping enabled.

2.1 - Input is AIE2 Control packet Binary-
 **./aiebu-dump <path_to_ctrl_pkt0.bin>/ctrl_pkt0.bin -d**

aie2-ctrlpkt
PH {#4, R[0?], C[0?]}
CH {@0x1d000, [4], P}
   [0] 0x800
   [1] 0x0
   [2] 0x0
   [3] 0x0
PH {#4, R[0?], C[0?]}
CH {@0x1d010, [4], P}
   [0] 0x80000000
   [1] 0x2000000
   [2] 0x0
   [3] 0x2001001
PH {#2, R[0?], C[0?]}
CH {@0xa0000, [4], P}
   [0] 0x800
   [1] 0x20000
   [2] 0x0
   [3] 0x0
PH {#2, R[0?], C[0?]}
...

2.2 - Input is AIE2P Control packet Binary-
**./aiebu-dump <path_to_ctrl_pkt0.bin>/ctrl_pkt0.bin -d**

aie2p-ctrlpkt
PH {#8, R[0?], C[0?]}
CH {@0x32000, [1], P}
   [0] 0x0
PH {#8, R[0?], C[0?]}
CH {@0xef00, [4], P}
   [0] 0x0
   [1] 0x0
   [2] 0x0
   [3] 0x0
PH {#8, R[0?], C[0?]}
CH {@0xef10, [4], P}
   [0] 0x0
   [1] 0x0
   [2] 0x0
   [3] 0x0
PH {#8, R[0?], C[0?]}
CH {@0xef20, [4], P}
   [0] 0x0
   [1] 0x0
   [2] 0x0
   [3] 0x0
...

3> Input is ELF for AIE2
**./aiebu-dump <output.elf>/output.elf -D**

aie2-elf

Section[2]: .ctrltext   Size: 1232B

    .attach_to_group 0
    .attach_to_group 1
    .attach_to_group 2
    .attach_to_group 3
    .attach_to_group 4

XAIE_IO_BLOCKWRITE              @0x201d000, [8]
XAIE_IO_BLOCKWRITE.0            0x6
XAIE_IO_BLOCKWRITE.1            0x0
XAIE_IO_BLOCKWRITE.2            0x0
XAIE_IO_BLOCKWRITE.3            0x0
XAIE_IO_BLOCKWRITE.4            0x80000000
XAIE_IO_BLOCKWRITE.5            0x2000000
XAIE_IO_BLOCKWRITE.6            0x300007
XAIE_IO_BLOCKWRITE.7            0x2000000
XAIE_IO_CUSTOM_OP_DDR_PATCH     @0x201d004, #3, +0x0
XAIE_IO_WRITE                   @0x201d214, 0x30000
XAIE_IO_BLOCKWRITE              @0x201d020, [8]
XAIE_IO_BLOCKWRITE.0            0x3
XAIE_IO_BLOCKWRITE.1            0x0
...

Section[3]: .ctrldata   Size: 1248B

PH {#4, R[0?], C[0?]}
CH {@0x1d000, [4], P}
   [0] 0x800
   [1] 0x0
   [2] 0x0
   [3] 0x0
PH {#4, R[0?], C[0?]}
CH {@0x1d010, [4], P}
   [0] 0x80000000
   [1] 0x2000000
   [2] 0x0
   [3] 0x2001001
PH {#2, R[0?], C[0?]}
CH {@0xa0000, [4], P}
   [0] 0x800
   [1] 0x20000
   [2] 0x0
   [3] 0x0
PH {#2, R[0?], C[0?]}
CH {@0xa0010, [4], P}
   [0] 0x0
   [1] 0x0
   [2] 0x0
   [3] 0x81418040
PH {#4, R[0?], C[0?]}
CH {@0x14000, [1], P}
   [0] 0x0
...
