### PR TITLE
Add Support for Txn Ctrlcode binary to asm conversion to Dump tool

### DIFF
--- a/src/cpp/analyzer/reporter.cpp
+++ b/src/cpp/analyzer/reporter.cpp
@@ -6,8 +6,6 @@
 #include "transaction.hpp"
 #include "common/file_utils.h"
 
-
-
 #include "aiebu/aiebu_error.h"
 
 #include <boost/interprocess/streams/bufferstream.hpp>

--- a/src/cpp/analyzer/reporter.cpp
+++ b/src/cpp/analyzer/reporter.cpp
@@ -203,8 +203,7 @@ namespace aiebu {
     void reporter::disassemble_blob(const std::filesystem::path &root) const
     {
         std::filesystem::path file(root);
-        file += "disassemble_";
-        file += "blob.asm";
+        file += "_disassemble.asm";
         std::ofstream stream(file);
         if (!stream) {
             throw error(error::error_code::internal_error, "Failed to open file for writing");

--- a/src/cpp/analyzer/reporter.cpp
+++ b/src/cpp/analyzer/reporter.cpp
@@ -15,15 +15,13 @@
 
 namespace aiebu {
 
-reporter::reporter(aiebu::aiebu_assembler::buffer_type type, const std::vector<char>& buffer)
-: m_buffer_type(type), m_buffer(buffer)
+reporter::reporter(aiebu::aiebu_assembler::buffer_type type, const std::vector<char>& elf_data) 
+    : m_buffer_type(type), m_buffer(elf_data.data()), m_buffer_size(elf_data.size())
 {
-    boost::interprocess::ibufferstream istr(buffer.data(), buffer.size());
-    if (type == aiebu::aiebu_assembler::buffer_type::elf_aie2) {
-        bool result = my_elf_reader.load(istr);
-        if (!result) {
-            throw error(error::error_code::invalid_buffer_type, "Invalid ELF buffer");
-        }
+    boost::interprocess::ibufferstream istr(elf_data.data(), elf_data.size());
+    bool result = my_elf_reader.load(istr);
+    if (!result) {
+        throw error(error::error_code::invalid_buffer_type, "Invalid ELF buffer");
     }
 }
 
@@ -126,13 +124,13 @@ void reporter::disassemble(std::ostream &stream, bool all) const
 
 void reporter::ctrlcode_blob_summary(std::ostream &stream) const
 {
-    transaction tprint(m_buffer.data(), m_buffer.size());
+    transaction tprint(m_buffer, m_buffer_size);
     stream << tprint.get_txn_summary() << std::endl;
 }
 
 void reporter::disassemble_blob(std::ostream &stream) const
 {
-    transaction tprint(m_buffer.data(), m_buffer.size());
+    transaction tprint(m_buffer, m_buffer_size);
     stream << tprint.get_all_ops() << std::endl;
 }
 

--- a/src/cpp/analyzer/reporter.cpp
+++ b/src/cpp/analyzer/reporter.cpp
@@ -6,130 +6,172 @@
 #include "transaction.hpp"
 #include "common/file_utils.h"
 
+
 #include "aiebu/aiebu_error.h"
 
 #include <boost/interprocess/streams/bufferstream.hpp>
 #include <elfio/elfio_dump.hpp>
-
 namespace aiebu {
 
-reporter::reporter(aiebu::aiebu_assembler::buffer_type type, const std::vector<char>& elf_data) 
-    : m_buffer_type(type), m_buffer(elf_data.data()), m_buffer_size(elf_data.size())
-{
-    boost::interprocess::ibufferstream istr(elf_data.data(), elf_data.size());
-    bool result = my_elf_reader.load(istr);
-    if (!result) {
-        throw error(error::error_code::invalid_buffer_type, "Invalid ELF buffer");
+    reporter::reporter(aiebu::aiebu_assembler::buffer_type type, const std::vector<char>& buffer) :
+        m_buffer_type(type), m_buffer(buffer)
+    {
+        if (type == aiebu::aiebu_assembler::buffer_type::elf_aie2) {
+            boost::interprocess::ibufferstream istr(buffer.data(), buffer.size());
+            bool result = my_elf_reader.load(istr);
+            if (!result)
+                throw error(error::error_code::invalid_buffer_type, "Invalid ELF buffer");
+        }
     }
-}
 
-void reporter::elf_summary(std::ostream &stream) const
-{
-    ELFIO::dump::header(stream, my_elf_reader);
-    ELFIO::dump::section_headers(stream, my_elf_reader);
-    ELFIO::dump::segment_headers(stream, my_elf_reader);
-}
-
-void reporter::ctrlcode_summary(std::ostream &stream) const
-{
-    ELFIO::Elf_Half sec_num = my_elf_reader.sections.size();
-    for (int i = 0; i < sec_num; ++i) {
-        const ELFIO::section* psec = my_elf_reader.sections[i];
-
-        // Decoding not supported for ".ctrldata" section
-        // for aie2 ".ctrldata" contain control packet and ".ctrlpkt-pm-N" contain
-        // pm control packet which cannot be decoded
-        if (psec->get_type() != ELFIO::SHT_PROGBITS || is_ctrldata(psec->get_name())
-           || is_pm_ctrlpkt(psec->get_name()))
-            continue;
-
-        stream << "  [" << i << "] " << psec->get_name() << "\t"
-               << psec->get_size() << std::endl;
-
-        transaction tprint(psec->get_data(), psec->get_size());
-        stream << tprint.get_txn_summary() << std::endl;
+    void reporter::elf_summary(std::ostream &stream) const
+    {
+        if (m_buffer_type != aiebu::aiebu_assembler::buffer_type::elf_aie2) {
+            throw error(error::error_code::invalid_buffer_type, "Invalid buffer type for ELF summary");
+        }
+        ELFIO::dump::header(stream, my_elf_reader );
+        ELFIO::dump::section_headers( stream, my_elf_reader);
+        ELFIO::dump::segment_headers( stream, my_elf_reader);
     }
-}
 
-void reporter::disassemble(const std::filesystem::path &root, bool all) const
-{
-    ELFIO::Elf_Half sec_num = my_elf_reader.sections.size();
-    for (int i = 0; i < sec_num; ++i) {
-        const ELFIO::section* psec = my_elf_reader.sections[i];
+    void reporter::ctrlcode_summary(std::ostream &stream) const
+    {
+        if (m_buffer_type == aiebu::aiebu_assembler::buffer_type::elf_aie2) {
+            ELFIO::Elf_Half sec_num = my_elf_reader.sections.size();
+            for ( int i = 0; i < sec_num; ++i ) {
+                const ELFIO::section* psec = my_elf_reader.sections[i];
 
-        if (psec->get_type() != ELFIO::SHT_PROGBITS)
-            continue;
-        if (is_pm_ctrlpkt(psec->get_name()) || is_ctrldata(psec->get_name())) {
-            if (all) {
+                // Decoding not supported for ".ctrldata" section
+                // for aie2 ".ctrldata" contain control packet and ".ctrlpkt-pm-N" contain
+                // pm control packet which cannot be decoded
+                if (psec->get_type() != ELFIO::SHT_PROGBITS || is_ctrldata(psec->get_name())
+                || is_pm_ctrlpkt(psec->get_name()))
+                    continue;
+
+                stream << "  [" << i << "] " << psec->get_name() << "\t"
+                    << psec->get_size() << std::endl;
+
+                transaction tprint(psec->get_data(), psec->get_size());
+                stream << tprint.get_txn_summary() << std::endl;
+            }
+        }
+        else if (m_buffer_type == aiebu::aiebu_assembler::buffer_type::blob_instr_transaction) {
+            ctrlcode_blob_summary(stream);
+        }
+        else {
+            throw error(error::error_code::invalid_buffer_type,
+                  "Invalid buffer type");
+        }
+    }
+
+    void reporter::disassemble(const std::filesystem::path &root, bool all) const
+    {
+        if (m_buffer_type == aiebu::aiebu_assembler::buffer_type::elf_aie2) {
+            ELFIO::Elf_Half sec_num = my_elf_reader.sections.size();
+            for ( int i = 0; i < sec_num; ++i ) {
+                const ELFIO::section* psec = my_elf_reader.sections[i];
+
+                if (psec->get_type() != ELFIO::SHT_PROGBITS)
+                    continue;
+                if (is_pm_ctrlpkt(psec->get_name()) || is_ctrldata(psec->get_name())) {
+                    if (all) {
+                        std::filesystem::path file(root);
+                        file += psec->get_name();
+                        file += ".ctrl";
+                        std::ofstream stream(file);
+                        stream << ";  [" << i << "] " << psec->get_name() << "\t"
+                            << psec->get_size() << 'B' << std::endl;
+                        // Check type of control packet
+                        aiebu::aiebu_assembler::buffer_type packet_type =
+                        identify_control_packet(psec->get_data(), psec->get_size());
+                        packets pprint(psec->get_data(), psec->get_size(), packet_type);
+                        stream << pprint.get_dump();
+                    }
+                    continue;
+                }
+
+                // Write out the ctrlcode in rudimentary ASM format
                 std::filesystem::path file(root);
                 file += psec->get_name();
-                file += ".ctrl";
+                file += ".asm";
                 std::ofstream stream(file);
                 stream << ";  [" << i << "] " << psec->get_name() << "\t"
-                       << psec->get_size() << 'B' << std::endl;
-                // Check type of control packet
-                aiebu::aiebu_assembler::buffer_type packet_type =
-                identify_control_packet(psec->get_data(), psec->get_size());
-                packets pprint(psec->get_data(), psec->get_size(), packet_type);
-                stream << pprint.get_dump();
+                    << psec->get_size() << 'B' << std::endl;
+
+                transaction tprint(psec->get_data(), psec->get_size());
+                stream << tprint.get_all_ops() << std::endl;
             }
-            continue;
         }
-
-        // Write out the ctrlcode in rudimentary ASM format
-        std::filesystem::path file(root);
-        file += psec->get_name();
-        file += ".asm";
-        std::ofstream stream(file);
-        stream << ";  [" << i << "] " << psec->get_name() << "\t"
-               << psec->get_size() << 'B' << std::endl;
-
-        transaction tprint(psec->get_data(), psec->get_size());
-        stream << tprint.get_all_ops() << std::endl;
+        else if (m_buffer_type == aiebu::aiebu_assembler::buffer_type::blob_instr_transaction) {
+            disassemble_blob(root);
+        }
+        else {
+            throw error(error::error_code::invalid_buffer_type,
+                  "Invalid buffer type");
+        }
     }
-}
 
-void reporter::disassemble(std::ostream &stream, bool all) const
-{
-    ELFIO::Elf_Half sec_num = my_elf_reader.sections.size();
-    for (int i = 0; i < sec_num; ++i) {
-        const ELFIO::section* psec = my_elf_reader.sections[i];
+    void reporter::disassemble(std::ostream &stream, bool all) const
+    {
+        if (m_buffer_type == aiebu::aiebu_assembler::buffer_type::elf_aie2) {
+            ELFIO::Elf_Half sec_num = my_elf_reader.sections.size();
+            for ( int i = 0; i < sec_num; ++i ) {
+                const ELFIO::section* psec = my_elf_reader.sections[i];
 
-        if (psec->get_type() != ELFIO::SHT_PROGBITS)
-            continue;
-        if (is_pm_ctrlpkt(psec->get_name()) || is_ctrldata(psec->get_name())) {
-            if (all) {
+                if (psec->get_type() != ELFIO::SHT_PROGBITS)
+                    continue;
+                if (is_pm_ctrlpkt(psec->get_name()) || is_ctrldata(psec->get_name())) {
+                    if (all) {
+                        stream << "\n";
+                        stream << "Section[" << i << "]: " << psec->get_name()
+                            << "\tSize: " << psec->get_size() << 'B' << std::endl;
+
+                        // Check type of control packet
+                        aiebu::aiebu_assembler::buffer_type packet_type =
+                        identify_control_packet(psec->get_data(), psec->get_size());
+                        packets pprint(psec->get_data(), psec->get_size(), packet_type);
+                        stream << "\n" << pprint.get_dump();
+                    }
+                    continue;
+                }
+
                 stream << "\n";
-                stream << "Section[" << i << "]: " << psec->get_name()
-                       << "\tSize: " << psec->get_size() << 'B' << std::endl;
-
-                // Check type of control packet
-                aiebu::aiebu_assembler::buffer_type packet_type =
-                identify_control_packet(psec->get_data(), psec->get_size());
-                packets pprint(psec->get_data(), psec->get_size(), packet_type);
-                stream << "\n" << pprint.get_dump();
+                stream << "Section[" << i << "]: " << psec->get_name() << "\tSize: "
+                    << psec->get_size() << 'B' << std::endl;
+                transaction tprint(psec->get_data(), psec->get_size());
+                stream << tprint.get_all_ops() << std::endl;
             }
-            continue;
         }
+        else if (m_buffer_type == aiebu::aiebu_assembler::buffer_type::blob_instr_transaction) {
+            disassemble_blob(stream);
+        }
+        else {
+            throw error(error::error_code::invalid_buffer_type,
+                  "Invalid buffer type");
+        }
+    }
 
-        stream << "\n";
-        stream << "Section[" << i << "]: " << psec->get_name() << "\tSize: "
-               << psec->get_size() << 'B' << std::endl;
-        transaction tprint(psec->get_data(), psec->get_size());
+    void reporter::ctrlcode_blob_summary(std::ostream &stream) const
+    {
+        transaction tprint(m_buffer.data(), m_buffer.size());
+        stream << tprint.get_txn_summary() << std::endl;
+    }
+
+    void reporter::disassemble_blob(std::ostream &stream) const
+    {
+        transaction tprint(m_buffer.data(), m_buffer.size());
         stream << tprint.get_all_ops() << std::endl;
     }
-}
 
-void reporter::ctrlcode_blob_summary(std::ostream &stream) const
-{
-    transaction tprint(m_buffer, m_buffer_size);
-    stream << tprint.get_txn_summary() << std::endl;
-}
-
-void reporter::disassemble_blob(std::ostream &stream) const
-{
-    transaction tprint(m_buffer, m_buffer_size);
-    stream << tprint.get_all_ops() << std::endl;
-}
-
+    void reporter::disassemble_blob(const std::filesystem::path &root) const
+    {
+        if (m_buffer_type != aiebu::aiebu_assembler::buffer_type::blob_instr_transaction) {
+            throw error(error::error_code::invalid_buffer_type,
+                  "Invalid buffer type for disassemble");
+        }
+        std::filesystem::path file(root);
+        file += "blob.asm";
+        std::ofstream stream(file);
+        disassemble_blob(stream);
+    }
 }

--- a/src/cpp/analyzer/reporter.cpp
+++ b/src/cpp/analyzer/reporter.cpp
@@ -7,114 +7,133 @@
 #include "common/file_utils.h"
 
 
+
 #include "aiebu/aiebu_error.h"
 
 #include <boost/interprocess/streams/bufferstream.hpp>
 #include <elfio/elfio_dump.hpp>
+
 namespace aiebu {
 
-    reporter::reporter(aiebu::aiebu_assembler::buffer_type /*type*/, const std::vector<char>& elf_data)
-    {
-        boost::interprocess::ibufferstream istr(elf_data.data(), elf_data.size());
+reporter::reporter(aiebu::aiebu_assembler::buffer_type type, const std::vector<char>& buffer)
+: m_buffer_type(type), m_buffer(buffer)
+{
+    boost::interprocess::ibufferstream istr(buffer.data(), buffer.size());
+    if (type == aiebu::aiebu_assembler::buffer_type::elf_aie2) {
         bool result = my_elf_reader.load(istr);
-        if (!result)
+        if (!result) {
             throw error(error::error_code::invalid_buffer_type, "Invalid ELF buffer");
-    }
-
-    void reporter::elf_summary(std::ostream &stream) const
-    {
-        ELFIO::dump::header(stream, my_elf_reader );
-        ELFIO::dump::section_headers( stream, my_elf_reader);
-        ELFIO::dump::segment_headers( stream, my_elf_reader);
-    }
-
-    void reporter::ctrlcode_summary(std::ostream &stream) const
-    {
-        ELFIO::Elf_Half sec_num = my_elf_reader.sections.size();
-        for ( int i = 0; i < sec_num; ++i ) {
-            const ELFIO::section* psec = my_elf_reader.sections[i];
-
-            // Decoding not supported for ".ctrldata" section
-            // for aie2 ".ctrldata" contain control packet and ".ctrlpkt-pm-N" contain
-            // pm control packet which cannot be decoded
-            if (psec->get_type() != ELFIO::SHT_PROGBITS || is_ctrldata(psec->get_name())
-               || is_pm_ctrlpkt(psec->get_name()))
-                continue;
-
-            stream << "  [" << i << "] " << psec->get_name() << "\t"
-                   << psec->get_size() << std::endl;
-
-            transaction tprint(psec->get_data(), psec->get_size());
-            stream << tprint.get_txn_summary() << std::endl;
         }
     }
+}
 
-    void reporter::disassemble(const std::filesystem::path &root, bool all) const
-    {
-        ELFIO::Elf_Half sec_num = my_elf_reader.sections.size();
-        for ( int i = 0; i < sec_num; ++i ) {
-            const ELFIO::section* psec = my_elf_reader.sections[i];
+void reporter::elf_summary(std::ostream &stream) const
+{
+    ELFIO::dump::header(stream, my_elf_reader);
+    ELFIO::dump::section_headers(stream, my_elf_reader);
+    ELFIO::dump::segment_headers(stream, my_elf_reader);
+}
 
-            if (psec->get_type() != ELFIO::SHT_PROGBITS)
-                continue;
-            if (is_pm_ctrlpkt(psec->get_name()) || is_ctrldata(psec->get_name())) {
-                if (all) {
-                    std::filesystem::path file(root);
-                    file += psec->get_name();
-                    file += ".ctrl";
-                    std::ofstream stream(file);
-                    stream << ";  [" << i << "] " << psec->get_name() << "\t"
-                           << psec->get_size() << 'B' << std::endl;
-                    // Check type of control packet
-                    aiebu::aiebu_assembler::buffer_type packet_type =
-                    identify_control_packet(psec->get_data(), psec->get_size());
-                    packets pprint(psec->get_data(), psec->get_size(), packet_type);
-                    stream << pprint.get_dump();
-                }
-                continue;
+void reporter::ctrlcode_summary(std::ostream &stream) const
+{
+    ELFIO::Elf_Half sec_num = my_elf_reader.sections.size();
+    for (int i = 0; i < sec_num; ++i) {
+        const ELFIO::section* psec = my_elf_reader.sections[i];
+
+        // Decoding not supported for ".ctrldata" section
+        // for aie2 ".ctrldata" contain control packet and ".ctrlpkt-pm-N" contain
+        // pm control packet which cannot be decoded
+        if (psec->get_type() != ELFIO::SHT_PROGBITS || is_ctrldata(psec->get_name())
+           || is_pm_ctrlpkt(psec->get_name()))
+            continue;
+
+        stream << "  [" << i << "] " << psec->get_name() << "\t"
+               << psec->get_size() << std::endl;
+
+        transaction tprint(psec->get_data(), psec->get_size());
+        stream << tprint.get_txn_summary() << std::endl;
+    }
+}
+
+void reporter::disassemble(const std::filesystem::path &root, bool all) const
+{
+    ELFIO::Elf_Half sec_num = my_elf_reader.sections.size();
+    for (int i = 0; i < sec_num; ++i) {
+        const ELFIO::section* psec = my_elf_reader.sections[i];
+
+        if (psec->get_type() != ELFIO::SHT_PROGBITS)
+            continue;
+        if (is_pm_ctrlpkt(psec->get_name()) || is_ctrldata(psec->get_name())) {
+            if (all) {
+                std::filesystem::path file(root);
+                file += psec->get_name();
+                file += ".ctrl";
+                std::ofstream stream(file);
+                stream << ";  [" << i << "] " << psec->get_name() << "\t"
+                       << psec->get_size() << 'B' << std::endl;
+                // Check type of control packet
+                aiebu::aiebu_assembler::buffer_type packet_type =
+                identify_control_packet(psec->get_data(), psec->get_size());
+                packets pprint(psec->get_data(), psec->get_size(), packet_type);
+                stream << pprint.get_dump();
             }
-
-            // Write out the ctrlcode in rudimentary ASM format
-            std::filesystem::path file(root);
-            file += psec->get_name();
-            file += ".asm";
-            std::ofstream stream(file);
-            stream << ";  [" << i << "] " << psec->get_name() << "\t"
-                   << psec->get_size() << 'B' << std::endl;
-
-            transaction tprint(psec->get_data(), psec->get_size());
-            stream << tprint.get_all_ops() << std::endl;
+            continue;
         }
+
+        // Write out the ctrlcode in rudimentary ASM format
+        std::filesystem::path file(root);
+        file += psec->get_name();
+        file += ".asm";
+        std::ofstream stream(file);
+        stream << ";  [" << i << "] " << psec->get_name() << "\t"
+               << psec->get_size() << 'B' << std::endl;
+
+        transaction tprint(psec->get_data(), psec->get_size());
+        stream << tprint.get_all_ops() << std::endl;
     }
+}
 
-    void reporter::disassemble(std::ostream &stream, bool all) const
-    {
-        ELFIO::Elf_Half sec_num = my_elf_reader.sections.size();
-        for ( int i = 0; i < sec_num; ++i ) {
-            const ELFIO::section* psec = my_elf_reader.sections[i];
+void reporter::disassemble(std::ostream &stream, bool all) const
+{
+    ELFIO::Elf_Half sec_num = my_elf_reader.sections.size();
+    for (int i = 0; i < sec_num; ++i) {
+        const ELFIO::section* psec = my_elf_reader.sections[i];
 
-            if (psec->get_type() != ELFIO::SHT_PROGBITS)
-                continue;
-            if (is_pm_ctrlpkt(psec->get_name()) || is_ctrldata(psec->get_name())) {
-                if (all) {
-                    stream << "\n";
-                    stream << "Section[" << i << "]: " << psec->get_name()
-                           << "\tSize: " << psec->get_size() << 'B' << std::endl;
+        if (psec->get_type() != ELFIO::SHT_PROGBITS)
+            continue;
+        if (is_pm_ctrlpkt(psec->get_name()) || is_ctrldata(psec->get_name())) {
+            if (all) {
+                stream << "\n";
+                stream << "Section[" << i << "]: " << psec->get_name()
+                       << "\tSize: " << psec->get_size() << 'B' << std::endl;
 
-                    // Check type of control packet
-                    aiebu::aiebu_assembler::buffer_type packet_type =
-                    identify_control_packet(psec->get_data(), psec->get_size());
-                    packets pprint(psec->get_data(), psec->get_size(), packet_type);
-                    stream << "\n" << pprint.get_dump();
-                }
-                continue;
+                // Check type of control packet
+                aiebu::aiebu_assembler::buffer_type packet_type =
+                identify_control_packet(psec->get_data(), psec->get_size());
+                packets pprint(psec->get_data(), psec->get_size(), packet_type);
+                stream << "\n" << pprint.get_dump();
             }
-
-            stream << "\n";
-            stream << "Section[" << i << "]: " << psec->get_name() << "\tSize: "
-                   << psec->get_size() << 'B' << std::endl;
-            transaction tprint(psec->get_data(), psec->get_size());
-            stream << tprint.get_all_ops() << std::endl;
+            continue;
         }
+
+        stream << "\n";
+        stream << "Section[" << i << "]: " << psec->get_name() << "\tSize: "
+               << psec->get_size() << 'B' << std::endl;
+        transaction tprint(psec->get_data(), psec->get_size());
+        stream << tprint.get_all_ops() << std::endl;
     }
+}
+
+void reporter::ctrlcode_blob_summary(std::ostream &stream) const
+{
+    transaction tprint(m_buffer.data(), m_buffer.size());
+    stream << tprint.get_txn_summary() << std::endl;
+}
+
+void reporter::disassemble_blob(std::ostream &stream) const
+{
+    transaction tprint(m_buffer.data(), m_buffer.size());
+    stream << tprint.get_all_ops() << std::endl;
+}
+
 }

--- a/src/cpp/analyzer/reporter.cpp
+++ b/src/cpp/analyzer/reporter.cpp
@@ -16,26 +16,42 @@ namespace aiebu {
     reporter::reporter(aiebu::aiebu_assembler::buffer_type type, const std::vector<char>& buffer) :
         m_buffer_type(type), m_buffer(buffer)
     {
+        if (buffer.empty()) {
+            throw error(error::error_code::invalid_input, "Input buffer is empty");
+        }
         if (type == aiebu::aiebu_assembler::buffer_type::elf_aie2) {
             boost::interprocess::ibufferstream istr(buffer.data(), buffer.size());
             bool result = my_elf_reader.load(istr);
             if (!result)
-                throw error(error::error_code::invalid_buffer_type, "Invalid ELF buffer");
+                throw error(error::error_code::invalid_elf, "Invalid ELF buffer");
         }
     }
 
     void reporter::elf_summary(std::ostream &stream) const
     {
-        if (m_buffer_type != aiebu::aiebu_assembler::buffer_type::elf_aie2) {
-            throw error(error::error_code::invalid_buffer_type, "Invalid buffer type for ELF summary");
+        if (!stream) {
+            throw error(error::error_code::invalid_input, "The given stream is not writable or has failed");
         }
-        ELFIO::dump::header(stream, my_elf_reader );
-        ELFIO::dump::section_headers( stream, my_elf_reader);
-        ELFIO::dump::segment_headers( stream, my_elf_reader);
+        if (m_buffer_type == aiebu::aiebu_assembler::buffer_type::elf_aie2) {
+            ELFIO::dump::header(stream, my_elf_reader );
+            ELFIO::dump::section_headers( stream, my_elf_reader);
+            ELFIO::dump::segment_headers( stream, my_elf_reader);
+        }
+        else if (m_buffer_type == aiebu::aiebu_assembler::buffer_type::elf_aie2ps) {
+            throw error(error::error_code::internal_error,
+                  "AIE2PS and AIE4 ELF are not supported");
+        }
+        else {
+            throw error(error::error_code::invalid_buffer_type,
+                  "Invalid buffer type for ELF summary");
+        }
     }
 
     void reporter::ctrlcode_summary(std::ostream &stream) const
     {
+        if (!stream) {
+            throw error(error::error_code::invalid_input, "The given stream is not writable or has failed");
+        }
         if (m_buffer_type == aiebu::aiebu_assembler::buffer_type::elf_aie2) {
             ELFIO::Elf_Half sec_num = my_elf_reader.sections.size();
             for ( int i = 0; i < sec_num; ++i ) {
@@ -58,9 +74,13 @@ namespace aiebu {
         else if (m_buffer_type == aiebu::aiebu_assembler::buffer_type::blob_instr_transaction) {
             ctrlcode_blob_summary(stream);
         }
+        else if (m_buffer_type == aiebu::aiebu_assembler::buffer_type::elf_aie2ps) {
+            throw error(error::error_code::internal_error,
+                  "AIE2PS and AIE4 ELF are not supported");
+        }
         else {
             throw error(error::error_code::invalid_buffer_type,
-                  "Invalid buffer type");
+                  "Invalid buffer type for summary");
         }
     }
 
@@ -79,6 +99,9 @@ namespace aiebu {
                         file += psec->get_name();
                         file += ".ctrl";
                         std::ofstream stream(file);
+                        if (!stream) {
+                            throw error(error::error_code::internal_error, "Failed to open file for writing");
+                        }
                         stream << ";  [" << i << "] " << psec->get_name() << "\t"
                             << psec->get_size() << 'B' << std::endl;
                         // Check type of control packet
@@ -95,6 +118,9 @@ namespace aiebu {
                 file += psec->get_name();
                 file += ".asm";
                 std::ofstream stream(file);
+                if (!stream) {
+                    throw error(error::error_code::internal_error, "Failed to open file for writing");
+                }
                 stream << ";  [" << i << "] " << psec->get_name() << "\t"
                     << psec->get_size() << 'B' << std::endl;
 
@@ -105,14 +131,21 @@ namespace aiebu {
         else if (m_buffer_type == aiebu::aiebu_assembler::buffer_type::blob_instr_transaction) {
             disassemble_blob(root);
         }
+        else if (m_buffer_type == aiebu::aiebu_assembler::buffer_type::elf_aie2ps) {
+            throw error(error::error_code::internal_error,
+                  "AIE2PS and AIE4 ELF are not supported");
+        }
         else {
             throw error(error::error_code::invalid_buffer_type,
-                  "Invalid buffer type");
+                  "Invalid buffer type for disassembly");
         }
     }
 
     void reporter::disassemble(std::ostream &stream, bool all) const
     {
+        if (!stream) {
+            throw error(error::error_code::invalid_input, "The given stream is not writable or has failed");
+        }
         if (m_buffer_type == aiebu::aiebu_assembler::buffer_type::elf_aie2) {
             ELFIO::Elf_Half sec_num = my_elf_reader.sections.size();
             for ( int i = 0; i < sec_num; ++i ) {
@@ -145,9 +178,13 @@ namespace aiebu {
         else if (m_buffer_type == aiebu::aiebu_assembler::buffer_type::blob_instr_transaction) {
             disassemble_blob(stream);
         }
+        else if (m_buffer_type == aiebu::aiebu_assembler::buffer_type::elf_aie2ps) {
+            throw error(error::error_code::internal_error,
+                  "AIE2PS and AIE4 ELF are not supported");
+        }
         else {
             throw error(error::error_code::invalid_buffer_type,
-                  "Invalid buffer type");
+                  "Invalid buffer type for disassembly");
         }
     }
 
@@ -165,13 +202,13 @@ namespace aiebu {
 
     void reporter::disassemble_blob(const std::filesystem::path &root) const
     {
-        if (m_buffer_type != aiebu::aiebu_assembler::buffer_type::blob_instr_transaction) {
-            throw error(error::error_code::invalid_buffer_type,
-                  "Invalid buffer type for disassemble");
-        }
         std::filesystem::path file(root);
+        file += "disassemble_";
         file += "blob.asm";
         std::ofstream stream(file);
+        if (!stream) {
+            throw error(error::error_code::internal_error, "Failed to open file for writing");
+        }
         disassemble_blob(stream);
     }
 }

--- a/src/cpp/analyzer/reporter.h
+++ b/src/cpp/analyzer/reporter.h
@@ -38,6 +38,9 @@ namespace aiebu {
       reporter(reporter&&) = delete;                    // Move constructor
       reporter& operator=(reporter&&) = delete;         // Move assignment operator
 
+      // Destructor
+      ~reporter() = default;                            // Default destructor
+
       // Member functions
       void elf_summary(std::ostream &stream) const;
       void ctrlcode_summary(std::ostream &stream) const;

--- a/src/cpp/analyzer/reporter.h
+++ b/src/cpp/analyzer/reporter.h
@@ -16,7 +16,6 @@ namespace aiebu {
       const char* m_buffer;
       uint64_t m_buffer_size;
 
-
   protected:
       inline bool is_ctrldata(const std::string& name) const
       {
@@ -28,8 +27,18 @@ namespace aiebu {
         return !name.substr(0,8).compare(".ctrlpkt");
       }
   public:
+      // Constructors
       reporter(aiebu::aiebu_assembler::buffer_type type, const std::vector<char>& elf_data);
-      reporter(aiebu::aiebu_assembler::buffer_type type, const char* buffer, uint64_t size) :  m_buffer_type(type), m_buffer(buffer), m_buffer_size(size) {}
+      reporter(aiebu::aiebu_assembler::buffer_type type, const char* buffer, uint64_t size)
+          : m_buffer_type(type), m_buffer(buffer), m_buffer_size(size) {}
+
+      // Delete copy and move constructors and assignment operators
+      reporter(const reporter&) = delete;               // Copy constructor
+      reporter& operator=(const reporter&) = delete;    // Copy assignment operator
+      reporter(reporter&&) = delete;                    // Move constructor
+      reporter& operator=(reporter&&) = delete;         // Move assignment operator
+
+      // Member functions
       void elf_summary(std::ostream &stream) const;
       void ctrlcode_summary(std::ostream &stream) const;
       void disassemble(const std::filesystem::path &root, bool all = false) const;

--- a/src/cpp/analyzer/reporter.h
+++ b/src/cpp/analyzer/reporter.h
@@ -13,7 +13,8 @@ namespace aiebu {
   private:
       ELFIO::elfio my_elf_reader;
       const aiebu::aiebu_assembler::buffer_type m_buffer_type;
-      const std::vector<char> m_buffer;
+      const char* m_buffer;
+      uint64_t m_buffer_size;
 
 
   protected:
@@ -27,14 +28,14 @@ namespace aiebu {
         return !name.substr(0,8).compare(".ctrlpkt");
       }
   public:
-      reporter(aiebu::aiebu_assembler::buffer_type type, const std::vector<char>& buffer);
+      reporter(aiebu::aiebu_assembler::buffer_type type, const std::vector<char>& elf_data);
+      reporter(aiebu::aiebu_assembler::buffer_type type, const char* buffer, uint64_t size) :  m_buffer_type(type), m_buffer(buffer), m_buffer_size(size) {}
       void elf_summary(std::ostream &stream) const;
       void ctrlcode_summary(std::ostream &stream) const;
       void disassemble(const std::filesystem::path &root, bool all = false) const;
       void disassemble(std::ostream &stream, bool all = false) const;
       void ctrlcode_blob_summary(std::ostream &stream) const;
       void disassemble_blob(std::ostream &stream) const;
-
   };
 }
 

--- a/src/cpp/analyzer/reporter.h
+++ b/src/cpp/analyzer/reporter.h
@@ -9,26 +9,33 @@
 
 namespace aiebu {
 
-    class reporter {
-    private:
-        ELFIO::elfio my_elf_reader;
-    protected:
-        inline bool is_ctrldata(const std::string& name) const
-        {
-          return !name.compare(".ctrldata");
-        }
+  class reporter {
+  private:
+      ELFIO::elfio my_elf_reader;
+      const aiebu::aiebu_assembler::buffer_type m_buffer_type;
+      const std::vector<char> m_buffer;
 
-        inline bool is_pm_ctrlpkt(const std::string& name) const
-        {
-          return !name.substr(0,8).compare(".ctrlpkt");
-        }
-    public:
-        reporter(aiebu::aiebu_assembler::buffer_type type, const std::vector<char>& elf_data);
-        void elf_summary(std::ostream &stream) const;
-        void ctrlcode_summary(std::ostream &stream) const;
-        void disassemble(const std::filesystem::path &root, bool all = false) const;
-        void disassemble(std::ostream &stream, bool all = false) const;
-    };
+
+  protected:
+      inline bool is_ctrldata(const std::string& name) const
+      {
+        return !name.compare(".ctrldata");
+      }
+
+      inline bool is_pm_ctrlpkt(const std::string& name) const
+      {
+        return !name.substr(0,8).compare(".ctrlpkt");
+      }
+  public:
+      reporter(aiebu::aiebu_assembler::buffer_type type, const std::vector<char>& buffer);
+      void elf_summary(std::ostream &stream) const;
+      void ctrlcode_summary(std::ostream &stream) const;
+      void disassemble(const std::filesystem::path &root, bool all = false) const;
+      void disassemble(std::ostream &stream, bool all = false) const;
+      void ctrlcode_blob_summary(std::ostream &stream) const;
+      void disassemble_blob(std::ostream &stream) const;
+
+  };
 }
 
 #endif

--- a/src/cpp/analyzer/reporter.h
+++ b/src/cpp/analyzer/reporter.h
@@ -9,46 +9,45 @@
 
 namespace aiebu {
 
-  class reporter {
-  private:
-      ELFIO::elfio my_elf_reader;
-      const aiebu::aiebu_assembler::buffer_type m_buffer_type;
-      const char* m_buffer;
-      uint64_t m_buffer_size;
+    class reporter {
+    private:
+        ELFIO::elfio my_elf_reader;
+        const aiebu::aiebu_assembler::buffer_type m_buffer_type;
+        const std::vector<char> m_buffer;
+        void ctrlcode_blob_summary(std::ostream &stream) const;
+        void disassemble_blob(std::ostream &stream) const;
+        void disassemble_blob(const std::filesystem::path &root) const;
 
-  protected:
-      inline bool is_ctrldata(const std::string& name) const
-      {
-        return !name.compare(".ctrldata");
-      }
 
-      inline bool is_pm_ctrlpkt(const std::string& name) const
-      {
-        return !name.substr(0,8).compare(".ctrlpkt");
-      }
-  public:
-      // Constructors
-      reporter(aiebu::aiebu_assembler::buffer_type type, const std::vector<char>& elf_data);
-      reporter(aiebu::aiebu_assembler::buffer_type type, const char* buffer, uint64_t size)
-          : m_buffer_type(type), m_buffer(buffer), m_buffer_size(size) {}
+    protected:
+        inline bool is_ctrldata(const std::string& name) const
+        {
+          return !name.compare(".ctrldata");
+        }
 
-      // Delete copy and move constructors and assignment operators
-      reporter(const reporter&) = delete;               // Copy constructor
-      reporter& operator=(const reporter&) = delete;    // Copy assignment operator
-      reporter(reporter&&) = delete;                    // Move constructor
-      reporter& operator=(reporter&&) = delete;         // Move assignment operator
+        inline bool is_pm_ctrlpkt(const std::string& name) const
+        {
+          return !name.substr(0,8).compare(".ctrlpkt");
+        }
+    public:
+        // Constructor
+        reporter(aiebu::aiebu_assembler::buffer_type type, const std::vector<char>& buffer);
 
-      // Destructor
-      ~reporter() = default;                            // Default destructor
+        // Delete copy and move constructors and assignment operators
+        reporter(const reporter&) = delete;               // Copy constructor
+        reporter& operator=(const reporter&) = delete;    // Copy assignment operator
+        reporter(reporter&&) = delete;                    // Move constructor
+        reporter& operator=(reporter&&) = delete;         // Move assignment operator
 
-      // Member functions
-      void elf_summary(std::ostream &stream) const;
-      void ctrlcode_summary(std::ostream &stream) const;
-      void disassemble(const std::filesystem::path &root, bool all = false) const;
-      void disassemble(std::ostream &stream, bool all = false) const;
-      void ctrlcode_blob_summary(std::ostream &stream) const;
-      void disassemble_blob(std::ostream &stream) const;
-  };
+        // Destructor
+        ~reporter() = default;                            // Default destructor
+
+        // Member functions
+        void elf_summary(std::ostream &stream) const;
+        void ctrlcode_summary(std::ostream &stream) const;
+        void disassemble(const std::filesystem::path &root, bool all = false) const;
+        void disassemble(std::ostream &stream, bool all = false) const;
+    };
 }
 
 #endif

--- a/src/cpp/assembler/aiebu_assembler.cpp
+++ b/src/cpp/assembler/aiebu_assembler.cpp
@@ -40,31 +40,37 @@ aiebu_assembler(buffer_type type,
   {
     aiebu::assembler a(assembler::elf_type::aie2_dpu_blob);
     elf_data = a.process(buffer1, libs, libpaths, patch_json, buffer2);
+    m_output_type = aiebu::aiebu_assembler::buffer_type::elf_aie2;
   }
   else if (type == buffer_type::blob_instr_transaction)
   {
     aiebu::assembler a(assembler::elf_type::aie2_transaction_blob);
     elf_data = a.process(buffer1, libs, libpaths, patch_json, buffer2, ctrlpkt);
+    m_output_type = aiebu::aiebu_assembler::buffer_type::elf_aie2;
   }
   else if (type == buffer_type::asm_aie2)
   {
     aiebu::assembler a(assembler::elf_type::aie2_asm);
     elf_data = a.process(buffer1, libs, libpaths, patch_json, buffer2, ctrlpkt);
+    m_output_type = aiebu::aiebu_assembler::buffer_type::elf_aie2;
   }
   else if (type == buffer_type::asm_aie2ps)
   {
     aiebu::assembler a(assembler::elf_type::aie2ps_asm);
     elf_data = a.process(buffer1, libs, libpaths, patch_json);
+    m_output_type = aiebu::aiebu_assembler::buffer_type::elf_aie2ps;
   }
   else if (type == buffer_type::config)
   {
     aiebu::assembler a(assembler::elf_type::config);
     elf_data = a.process(buffer1, libs, libpaths, patch_json, buffer2);
+    m_output_type = aiebu::aiebu_assembler::buffer_type::elf_aie2ps;
   }
   else if (type == buffer_type::asm_aie4)
   {
     aiebu::assembler a(assembler::elf_type::aie4_asm);
     elf_data = a.process(buffer1, libs, libpaths, patch_json);
+    m_output_type = aiebu::aiebu_assembler::buffer_type::elf_aie2ps;
   }
   else {
     throw error(error::error_code::invalid_buffer_type, "Buffer_type not supported !!!");
@@ -83,7 +89,7 @@ void
 aiebu_assembler::
 get_report(std::ostream &stream) const
 {
-    reporter rep(m_type, elf_data);
+    reporter rep(m_output_type, elf_data);
     rep.elf_summary(stream);
     rep.ctrlcode_summary(stream);
 }
@@ -92,7 +98,7 @@ void
 aiebu_assembler::
 disassemble(const std::filesystem::path &root) const
 {
-    reporter rep(m_type, elf_data);
+    reporter rep(m_output_type, elf_data);
     rep.disassemble(root, true);
 }
 }

--- a/src/cpp/assembler/aiebu_assembler.cpp
+++ b/src/cpp/assembler/aiebu_assembler.cpp
@@ -126,13 +126,13 @@ aiebu_assembler_get_elf(enum aiebu_assembler_buffer_type type,
                         size_t pm_ctrlpkt_size)
 {
   int ret = 0;
-  if (buffer2 == NULL && buffer2_size != 0)
+  if (buffer2 == nullptr && buffer2_size != 0)
   {
     std::cout << "ERROR: Invalid buffer2 size" << std::endl;
     return -(static_cast<int>(aiebu::error::error_code::invalid_input));
   }
 
-  if (patch_json == NULL && patch_json_size !=0)
+  if (patch_json == nullptr && patch_json_size !=0)
   {
     std::cout << "ERROR: Invalid patch json size" << std::endl;
     return -(static_cast<int>(aiebu::error::error_code::invalid_input));

--- a/src/cpp/assembler/aiebu_assembler.cpp
+++ b/src/cpp/assembler/aiebu_assembler.cpp
@@ -138,7 +138,7 @@ aiebu_assembler_get_elf(enum aiebu_assembler_buffer_type type,
     return -(static_cast<int>(aiebu::error::error_code::invalid_input));
   }
 
-  if (buffer1 == NULL)
+  if (buffer1 == nullptr)
   {
     std::cout << "ERROR: Invalid input, buffer1 is NULL" << std::endl;
     return -(static_cast<int>(aiebu::error::error_code::invalid_input));

--- a/src/cpp/assembler/aiebu_assembler.cpp
+++ b/src/cpp/assembler/aiebu_assembler.cpp
@@ -36,6 +36,9 @@ aiebu_assembler(buffer_type type,
                 const std::vector<std::string>& libpaths,
                 const std::map<uint32_t, std::vector<char> >& ctrlpkt) : m_type(type)
 {
+  if (buffer1.empty()) {
+    throw error(error::error_code::invalid_input, "Buffer1 is empty.");
+  }
   if (type == buffer_type::blob_instr_dpu)
   {
     aiebu::assembler a(assembler::elf_type::aie2_dpu_blob);
@@ -90,17 +93,21 @@ void
 aiebu_assembler::
 get_report(std::ostream &stream) const
 {
-    reporter rep(m_output_type, elf_data);
-    rep.elf_summary(stream);
-    rep.ctrlcode_summary(stream);
+  if (!stream) {
+    throw error(error::error_code::invalid_input,
+                "The given stream is not writable or has failed.");
+  }
+  reporter rep(m_output_type, elf_data);
+  rep.elf_summary(stream);
+  rep.ctrlcode_summary(stream);
 }
 
 void
 aiebu_assembler::
 disassemble(const std::filesystem::path &root) const
 {
-    reporter rep(m_output_type, elf_data);
-    rep.disassemble(root, true);
+  reporter rep(m_output_type, elf_data);
+  rep.disassemble(root, true);
 }
 }
 
@@ -122,13 +129,25 @@ aiebu_assembler_get_elf(enum aiebu_assembler_buffer_type type,
   if (buffer2 == NULL && buffer2_size != 0)
   {
     std::cout << "ERROR: Invalid buffer2 size" << std::endl;
-    return -(static_cast<int>(aiebu::error::error_code::internal_error));
+    return -(static_cast<int>(aiebu::error::error_code::invalid_input));
   }
 
   if (patch_json == NULL && patch_json_size !=0)
   {
     std::cout << "ERROR: Invalid patch json size" << std::endl;
-    return -(static_cast<int>(aiebu::error::error_code::internal_error));
+    return -(static_cast<int>(aiebu::error::error_code::invalid_input));
+  }
+
+  if (buffer1 == NULL)
+  {
+    std::cout << "ERROR: Invalid input, buffer1 is NULL" << std::endl;
+    return -(static_cast<int>(aiebu::error::error_code::invalid_input));
+  }
+
+  if (buffer1_size == 0)
+  {
+    std::cout << "ERROR: Invalid buffer1 size" << std::endl;
+    return -(static_cast<int>(aiebu::error::error_code::invalid_input));
   }
 
   try

--- a/src/cpp/assembler/aiebu_assembler.cpp
+++ b/src/cpp/assembler/aiebu_assembler.cpp
@@ -64,6 +64,7 @@ aiebu_assembler(buffer_type type,
   {
     aiebu::assembler a(assembler::elf_type::config);
     elf_data = a.process(buffer1, libs, libpaths, patch_json, buffer2);
+    // TODO: Determine architecture type for config. Currently defaulting to elf_aie2ps.
     m_output_type = aiebu::aiebu_assembler::buffer_type::elf_aie2ps;
   }
   else if (type == buffer_type::asm_aie4)

--- a/src/cpp/assembler/aiebu_assembler.cpp
+++ b/src/cpp/assembler/aiebu_assembler.cpp
@@ -67,8 +67,7 @@ aiebu_assembler(buffer_type type,
   {
     aiebu::assembler a(assembler::elf_type::config);
     elf_data = a.process(buffer1, libs, libpaths, patch_json, buffer2);
-    // TODO: Determine architecture type for config. Currently defaulting to elf_aie2ps.
-    m_output_type = aiebu::aiebu_assembler::buffer_type::elf_aie2ps;
+    m_output_type = aiebu::aiebu_assembler::buffer_type::elf_aie2;
   }
   else if (type == buffer_type::asm_aie4)
   {

--- a/src/cpp/include/aiebu/aiebu.h
+++ b/src/cpp/include/aiebu/aiebu.h
@@ -16,7 +16,9 @@ enum aiebu_error_code {
   aiebu_invalid_batch_buffer_type,
   aiebu_invalid_buffer_type,
   aiebu_invalid_offset,
-  aiebu_invalid_internal_error
+  aiebu_invalid_internal_error,
+  aiebu_invalid_input,
+  aiebu_invalid_elf
 };
 
 enum aiebu_assembler_buffer_type {

--- a/src/cpp/include/aiebu/aiebu_assembler.h
+++ b/src/cpp/include/aiebu/aiebu_assembler.h
@@ -36,6 +36,7 @@ class aiebu_assembler
 
   private:
     buffer_type m_type;
+    buffer_type m_output_type;
 
   public:
     /*

--- a/src/cpp/include/aiebu/aiebu_error.h
+++ b/src/cpp/include/aiebu/aiebu_error.h
@@ -20,7 +20,9 @@ public:
     invalid_patch_buffer_type = aiebu_invalid_batch_buffer_type,
     invalid_buffer_type = aiebu_invalid_buffer_type,
     invalid_offset = aiebu_invalid_offset,
-    internal_error = aiebu_invalid_internal_error
+    internal_error = aiebu_invalid_internal_error,
+    invalid_input = aiebu_invalid_input,
+    invalid_elf = aiebu_invalid_elf
   };
 
   error(error_code ec, const std::error_category& cat, const std::string& what = "");

--- a/src/cpp/utils/dump/dump.cpp
+++ b/src/cpp/utils/dump/dump.cpp
@@ -53,6 +53,7 @@ cxxopts::ParseResult main_helper(int argc, const char* const *argv,
     global_options.add_options()
       ("a,archive-headers", "Display archive header information", cxxopts::value<bool>()->default_value("false"))
       ("f,file-headers", "Display the contents of the overall file header", cxxopts::value<bool>()->default_value("false"))
+      ("p,private-headers", "Display opcode frequency in the control code binary", cxxopts::value<bool>()->default_value("false"))
       ("x,all-headers", "Display contents of all elf headers", cxxopts::value<bool>()->default_value("false"))
       ("d,disassemble", "Display assembler contents of ctrltext sections if elf file is provided or display control packet \
         in assembled format if control packet binary file is provided", cxxopts::value<bool>()->default_value("false"))
@@ -118,34 +119,32 @@ int main(int argc, char* argv[])
   const std::vector<char> buffer = aiebu::readfile(result["filename"].as<std::string>());
   aiebu::aiebu_assembler::buffer_type type = aiebu::identify_buffer_type(buffer);
   std::cout << aiebu::buffer_type_table.at(type) << std::endl;
-  if (type == aiebu::aiebu_assembler::buffer_type::elf_aie2) {
-    aiebu::reporter rep(aiebu::aiebu_assembler::buffer_type::elf_aie2, buffer);
-    if (result["all-headers"].as<bool>()) {
-      rep.elf_summary(std::cout);
-      rep.ctrlcode_summary(std::cout);
-    }
-    else if (result["disassemble"].as<bool>()) {
-      rep.disassemble(std::cout);
-    }
-    else if (result["disassemble-all"].as<bool>()) {
-      rep.disassemble(std::cout, true);
-    }
-  }
-  else if (type == aiebu::aiebu_assembler::buffer_type::blob_control_packet || 
+
+  if (type == aiebu::aiebu_assembler::buffer_type::blob_control_packet ||
            type == aiebu::aiebu_assembler::buffer_type::blob_control_packet_aie2) {
     if (result["disassemble"].as<bool>()) {
       aiebu::packets packetprint(buffer.data(), static_cast<uint64_t>(buffer.size()), type);
       std::cout <<  packetprint.get_dump() << std::endl;
     }
   }
-  else if (type == aiebu::aiebu_assembler::buffer_type::blob_instr_transaction) {
-    aiebu::reporter rep(type, buffer.data(), buffer.size());
-    if (result["all-headers"].as<bool>()) {
-      rep.ctrlcode_blob_summary(std::cout);
+  else {
+      aiebu::reporter rep(type, buffer);
+      if (result["all-headers"].as<bool>()) {
+        if (type == aiebu::aiebu_assembler::buffer_type::elf_aie2) {
+          rep.elf_summary(std::cout);
+        }
+      }
+      else if (result["disassemble"].as<bool>()) {
+        rep.disassemble(std::cout);
+      }
+      else if (result["disassemble-all"].as<bool>()) {
+        if (type == aiebu::aiebu_assembler::buffer_type::elf_aie2) {
+          rep.disassemble(std::cout, true);
+        }
+      }
+      else if (result["private-headers"].as<bool>()) {
+        rep.ctrlcode_summary(std::cout);
+      }
     }
-    else if (result["disassemble"].as<bool>()) {
-      rep.disassemble_blob(std::cout);
-    }
-  }
   return 0;
 }

--- a/src/cpp/utils/dump/dump.cpp
+++ b/src/cpp/utils/dump/dump.cpp
@@ -117,10 +117,7 @@ int main(int argc, char* argv[])
 
   const std::vector<char> buffer = aiebu::readfile(result["filename"].as<std::string>());
   aiebu::aiebu_assembler::buffer_type type = aiebu::identify_buffer_type(buffer);
-
   std::cout << aiebu::buffer_type_table.at(type) << std::endl;
-
-
   if (type == aiebu::aiebu_assembler::buffer_type::elf_aie2) {
     aiebu::reporter rep(aiebu::aiebu_assembler::buffer_type::elf_aie2, buffer);
     if (result["all-headers"].as<bool>()) {

--- a/src/cpp/utils/dump/dump.cpp
+++ b/src/cpp/utils/dump/dump.cpp
@@ -119,6 +119,8 @@ int main(int argc, char* argv[])
   aiebu::aiebu_assembler::buffer_type type = aiebu::identify_buffer_type(buffer);
 
   std::cout << aiebu::buffer_type_table.at(type) << std::endl;
+
+
   if (type == aiebu::aiebu_assembler::buffer_type::elf_aie2) {
     aiebu::reporter rep(aiebu::aiebu_assembler::buffer_type::elf_aie2, buffer);
     if (result["all-headers"].as<bool>()) {
@@ -137,6 +139,15 @@ int main(int argc, char* argv[])
     if (result["disassemble"].as<bool>()) {
       aiebu::packets packetprint(buffer.data(), static_cast<uint64_t>(buffer.size()), type);
       std::cout <<  packetprint.get_dump() << std::endl;
+    }
+  }
+  else if (type == aiebu::aiebu_assembler::buffer_type::blob_instr_transaction) {
+    aiebu::reporter rep(aiebu::aiebu_assembler::buffer_type::blob_instr_transaction, buffer);
+    if (result["all-headers"].as<bool>()) {
+      rep.ctrlcode_blob_summary(std::cout);
+    }
+    else if (result["disassemble"].as<bool>()) {
+      rep.disassemble_blob(std::cout);
     }
   }
   return 0;

--- a/src/cpp/utils/dump/dump.cpp
+++ b/src/cpp/utils/dump/dump.cpp
@@ -118,9 +118,7 @@ int main(int argc, char* argv[])
 
   const std::vector<char> buffer = aiebu::readfile(result["filename"].as<std::string>());
   aiebu::aiebu_assembler::buffer_type type = aiebu::identify_buffer_type(buffer);
-
   std::cout << aiebu::buffer_type_table.at(type) << std::endl;
-
 
   if (type == aiebu::aiebu_assembler::buffer_type::elf_aie2) {
     aiebu::reporter rep(aiebu::aiebu_assembler::buffer_type::elf_aie2, buffer);

--- a/src/cpp/utils/dump/dump.cpp
+++ b/src/cpp/utils/dump/dump.cpp
@@ -53,6 +53,7 @@ cxxopts::ParseResult main_helper(int argc, const char* const *argv,
     global_options.add_options()
       ("a,archive-headers", "Display archive header information", cxxopts::value<bool>()->default_value("false"))
       ("f,file-headers", "Display the contents of the overall file header", cxxopts::value<bool>()->default_value("false"))
+      ("p,private-headers", "Display opcode frequency in the control code binary", cxxopts::value<bool>()->default_value("false"))
       ("x,all-headers", "Display contents of all elf headers", cxxopts::value<bool>()->default_value("false"))
       ("d,disassemble", "Display assembler contents of ctrltext sections if elf file is provided or display control packet \
         in assembled format if control packet binary file is provided", cxxopts::value<bool>()->default_value("false"))
@@ -143,10 +144,10 @@ int main(int argc, char* argv[])
   }
   else if (type == aiebu::aiebu_assembler::buffer_type::blob_instr_transaction) {
     aiebu::reporter rep(aiebu::aiebu_assembler::buffer_type::blob_instr_transaction, buffer);
-    if (result["all-headers"].as<bool>()) {
+    if (result["private-headers"].as<bool>()) {
       rep.ctrlcode_blob_summary(std::cout);
     }
-    else if (result["disassemble"].as<bool>()) {
+    else if (result["disassemble"].as<bool>() || result["disassemble-all"].as<bool>()) {
       rep.disassemble_blob(std::cout);
     }
   }

--- a/src/cpp/utils/dump/dump.cpp
+++ b/src/cpp/utils/dump/dump.cpp
@@ -53,7 +53,6 @@ cxxopts::ParseResult main_helper(int argc, const char* const *argv,
     global_options.add_options()
       ("a,archive-headers", "Display archive header information", cxxopts::value<bool>()->default_value("false"))
       ("f,file-headers", "Display the contents of the overall file header", cxxopts::value<bool>()->default_value("false"))
-      ("p,private-headers", "Display opcode frequency in the control code binary", cxxopts::value<bool>()->default_value("false"))
       ("x,all-headers", "Display contents of all elf headers", cxxopts::value<bool>()->default_value("false"))
       ("d,disassemble", "Display assembler contents of ctrltext sections if elf file is provided or display control packet \
         in assembled format if control packet binary file is provided", cxxopts::value<bool>()->default_value("false"))
@@ -118,7 +117,9 @@ int main(int argc, char* argv[])
 
   const std::vector<char> buffer = aiebu::readfile(result["filename"].as<std::string>());
   aiebu::aiebu_assembler::buffer_type type = aiebu::identify_buffer_type(buffer);
+
   std::cout << aiebu::buffer_type_table.at(type) << std::endl;
+
 
   if (type == aiebu::aiebu_assembler::buffer_type::elf_aie2) {
     aiebu::reporter rep(aiebu::aiebu_assembler::buffer_type::elf_aie2, buffer);
@@ -141,11 +142,11 @@ int main(int argc, char* argv[])
     }
   }
   else if (type == aiebu::aiebu_assembler::buffer_type::blob_instr_transaction) {
-    aiebu::reporter rep(aiebu::aiebu_assembler::buffer_type::blob_instr_transaction, buffer);
-    if (result["private-headers"].as<bool>()) {
+    aiebu::reporter rep(type, buffer.data(), buffer.size());
+    if (result["all-headers"].as<bool>()) {
       rep.ctrlcode_blob_summary(std::cout);
     }
-    else if (result["disassemble"].as<bool>() || result["disassemble-all"].as<bool>()) {
+    else if (result["disassemble"].as<bool>()) {
       rep.disassemble_blob(std::cout);
     }
   }


### PR DESCRIPTION
#### Problem solved by the commit
Support for Txn Ctrlcode binary to asm conversion to Dump tool

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
N/A

#### How problem was solved, alternative solutions (if any) and why they were rejected
Currently added new APIs for blob dump in reporter class to not break the existing disassemble(), ctrlcode_summary() which are used by AIEBU assembler.
1. -d and -D option will print the control code .asm file from .bin file
2. -p will display the frequency of each opcode present in the control code binary.

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
1> Printed control codes using -d and -D option by providing .bin files and .elf files and compared the output.
2> Printed output for -f option to see opcode frequency.

1. Opcode frequency
**./aiebu-dump -p <path>/<ctrlcode.bin>**

aie2-ctrlcode
v0.1, gen4
6x4 M1
435188B, 13789ops
XAIE_IO_WRITE                               9048
XAIE_IO_BLOCKWRITE                          3232
XAIE_IO_MASKWRITE                              0
XAIE_IO_MASKPOLL                               0
XAIE_IO_MASKPOLL_BUSY                          0
XAIE_IO_NOOP                                   0
XAIE_IO_PREEMPT                               35
XAIE_IO_LOAD_PM_START                          1
XAIE_IO_CUSTOM_OP_TCT                         59
XAIE_IO_CUSTOM_OP_DDR_PATCH                 1220
XAIE_IO_CUSTOM_OP_MERGE_SYNC                 194
XAIE_IO_CUSTOM_OP_RECORD_TIMER                 0

2. ASM Control code from binary using -d option.
**./aiebu-dump -d <path>/<ctrlcode.bin >**

    .attach_to_group 0
    .attach_to_group 1
    .attach_to_group 2
    .attach_to_group 3

XAIE_IO_LOAD_PM_START           0x9, #2
XAIE_IO_BLOCKWRITE              @0x1d000, [8]
XAIE_IO_BLOCKWRITE.0            0x1291
XAIE_IO_BLOCKWRITE.1            0xbb88
XAIE_IO_BLOCKWRITE.2            0x0
XAIE_IO_BLOCKWRITE.3            0x0
XAIE_IO_BLOCKWRITE.4            0xc0000000
XAIE_IO_BLOCKWRITE.5            0x2000000
XAIE_IO_BLOCKWRITE.6            0x0
XAIE_IO_BLOCKWRITE.7            0x2000000
XAIE_IO_WRITE                   @0x1d214, 0x80000000
...

3. ASM Control code from binary and opcode frequency using -D option.
**./aiebu-dump -D <path>/<ctrlcode.bin>**

    .attach_to_group 0
    .attach_to_group 1
    .attach_to_group 2
    .attach_to_group 3

XAIE_IO_LOAD_PM_START           0x9, #2
XAIE_IO_BLOCKWRITE              @0x1d000, [8]
XAIE_IO_BLOCKWRITE.0            0x1291
XAIE_IO_BLOCKWRITE.1            0xbb88
XAIE_IO_BLOCKWRITE.2            0x0
XAIE_IO_BLOCKWRITE.3            0x0
XAIE_IO_BLOCKWRITE.4            0xc0000000
XAIE_IO_BLOCKWRITE.5            0x2000000
XAIE_IO_BLOCKWRITE.6            0x0
XAIE_IO_BLOCKWRITE.7            0x2000000
XAIE_IO_WRITE                   @0x1d214, 0x80000000
...

v0.1, gen4
6x4 M1
435188B, 13789ops
XAIE_IO_WRITE                               9048
XAIE_IO_BLOCKWRITE                          3232
XAIE_IO_MASKWRITE                              0
XAIE_IO_MASKPOLL                               0
XAIE_IO_MASKPOLL_BUSY                          0
XAIE_IO_NOOP                                   0
XAIE_IO_PREEMPT                               35
XAIE_IO_LOAD_PM_START                          1
XAIE_IO_CUSTOM_OP_TCT                         59
XAIE_IO_CUSTOM_OP_DDR_PATCH                 1220
XAIE_IO_CUSTOM_OP_MERGE_SYNC                 194
XAIE_IO_CUSTOM_OP_RECORD_TIMER                 0

#### Documentation impact (if any)
N/A