### PR TITLE
 aie2ps/aie4 support for xclbin2elf 

### DIFF
--- a/specification/aie2ps/isa-spec.yaml
+++ b/specification/aie2ps/isa-spec.yaml
@@ -831,6 +831,22 @@ directives:
       .setpad ctrl_pkt, ctrlpkt.bin
       ...
       ```
+  - mnemonic: .partition
+    brief: This directive is used to specify the size of a partition.
+    arguments:
+      - name: partition size information
+        type: string
+    description: |
+      Specify size of a partition where the design can run. Depending on whether the design is in single-app mode or dual-app mode, the size of partition can be specified in number of columns as `Xcolumn` or number of cores plus number of 256kB memtile chunks as `Ycore:Zmem`
+      Example:
+      ```
+      ...
+      ;For a 3 column partition in single-app mode
+      .partiton 3column
+      ;For 2 core plus 1.5MB memory partition in dual-app mode
+      .partition 2core:6mem
+      ...
+      ```
   - mnemonic: UC_DMA_BD
     brief: In control code, the BD that needs to patch is defined by directive UC_DMA_BD
     arguments:

--- a/src/cpp/assembler/aiebu_assembler.cpp
+++ b/src/cpp/assembler/aiebu_assembler.cpp
@@ -66,6 +66,16 @@ aiebu_assembler(buffer_type type,
     aiebu::assembler a(assembler::elf_type::aie4_asm);
     elf_data = a.process(buffer1, libs, libpaths, patch_json);
   }
+  else if (type == buffer_type::aie2ps_config)
+  {
+    aiebu::assembler a(assembler::elf_type::aie2ps_config);
+    elf_data = a.process(buffer1, libs, libpaths, patch_json, buffer2);
+  }
+  else if (type == buffer_type::aie4_config)
+  {
+    aiebu::assembler a(assembler::elf_type::aie4_config);
+    elf_data = a.process(buffer1, libs, libpaths, patch_json, buffer2);
+  }
   else {
     throw error(error::error_code::invalid_buffer_type, "Buffer_type not supported !!!");
   }

--- a/src/cpp/assembler/assembler.cpp
+++ b/src/cpp/assembler/assembler.cpp
@@ -67,6 +67,20 @@ assembler(const elf_type type)
     m_elfwriter = std::make_unique<aie4_elf_writer>();
     m_ppi = std::make_shared<aie4_preprocessor_input>();
   }
+  else if (type == elf_type::aie2ps_config)
+  {
+    m_preprocessor = std::make_unique<asm_config_preprocessor<aie2ps_preprocessor, aie2ps_preprocessor_input, aie2ps_preprocessed_output>>();
+    m_enoder = std::make_unique<asm_config_encoder<aie2ps_encoder, aie2ps_preprocessed_output>>();
+    m_elfwriter = std::make_unique<aie2ps_config_elf_writer>();
+    m_ppi = std::make_shared<controlcode_config_preprocessor_input<aie2ps_preprocessor_input>>();
+  }
+  else if (type == elf_type::aie4_config)
+  {
+    m_preprocessor = std::make_unique<asm_config_preprocessor<aie4_preprocessor, aie4_preprocessor_input, aie2ps_preprocessed_output>>();
+    m_enoder = std::make_unique<asm_config_encoder<aie4_encoder, aie2ps_preprocessed_output>>();
+    m_elfwriter = std::make_unique<aie4_config_elf_writer>();
+    m_ppi = std::make_shared<controlcode_config_preprocessor_input<aie4_preprocessor_input>>();
+  }
   else {
     throw error(error::error_code::invalid_buffer_type ,"Invalid elf type!!!");
   }

--- a/src/cpp/assembler/assembler.h
+++ b/src/cpp/assembler/assembler.h
@@ -31,7 +31,9 @@ public:
     aie2ps_asm,
     aie2_asm,
     config,
-    aie4_asm
+    aie4_asm,
+    aie2ps_config,
+    aie4_config
   };
 
   explicit assembler(const elf_type type);

--- a/src/cpp/common/file_utils.h
+++ b/src/cpp/common/file_utils.h
@@ -4,6 +4,7 @@
 #ifndef AIEBU_COMMOM_FILE_UTILS_H_
 #define AIEBU_COMMOM_FILE_UTILS_H_
 
+#include <iostream>
 #include <filesystem>
 #include <fstream>
 #include <string>
@@ -51,14 +52,24 @@ readfile(const std::string& filename)
   if (!file_size)
     throw error(error::error_code::invalid_asm, "filename " + filename + " is empty!!");
 
+  std::cout << "READING: " << filename <<"\n";
   std::vector<char> buffer(file_size);
   input.read(buffer.data(), static_cast<std::streamsize>(file_size));
   return buffer;
 }
 
+inline bool
+is_absolute_path(const std::string& path) {
+  std::filesystem::path p(path);
+  return p.is_absolute();
+}
+
 inline std::string
 findFilePath(const std::string& filename, const std::vector<std::string>& libpaths)
 {
+
+  if (is_absolute_path(filename))
+    return filename;
   for (const auto &dir : libpaths ) {
     auto ret = std::filesystem::exists(dir + "/" + filename);
     if (ret) {
@@ -68,11 +79,23 @@ findFilePath(const std::string& filename, const std::vector<std::string>& libpat
   throw error(error::error_code::internal_error, filename + " file not found!!\n");
 }
 
+inline std::vector<char>
+readfile(const std::string& file, const std::vector<std::string>& paths)
+{
+  std::string fullpath = findFilePath(file, paths);
+  return readfile(fullpath);
+}
+
 aiebu_assembler::buffer_type
 identify_buffer_type(const std::vector<char> &buffer);
 
 aiebu_assembler::buffer_type
 identify_control_packet(const char* buffer, uint64_t size);
+
+inline std::string get_parent_directory(const std::string& relativePath) {
+  std::filesystem::path absolutePath = std::filesystem::absolute(relativePath);  // Convert relative to absolute
+  return absolutePath.parent_path().string();  // Return the parent directory
+}
 
 }
 

--- a/src/cpp/common/file_utils.h
+++ b/src/cpp/common/file_utils.h
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
 
-#ifndef AIEBU_COMMOM_FILE_UTILS_H_
-#define AIEBU_COMMOM_FILE_UTILS_H_
+#ifndef AIEBU_COMMON_FILE_UTILS_H_
+#define AIEBU_COMMON_FILE_UTILS_H_
 
 #include <iostream>
 #include <filesystem>
@@ -99,4 +99,4 @@ inline std::string get_parent_directory(const std::string& relativePath) {
 
 }
 
-#endif // AIEBU_COMMOM_FILE_UTILS_H_
+#endif // AIEBU_COMMON_FILE_UTILS_H_

--- a/src/cpp/common/utils.h
+++ b/src/cpp/common/utils.h
@@ -49,6 +49,31 @@ namespace aiebu {
         return m_##FNAME;                     \
     }
 
+constexpr uint32_t DEFAULT_COLUMN = 4;
+class partition_info {
+  union {
+    struct {
+      uint32_t core;
+      uint32_t mem;
+    };
+    uint32_t column;
+  };
+  public:
+  partition_info() : partition_info(0, 0) {}
+  partition_info(uint32_t core, uint32_t mem): core(core), mem(mem) { }
+
+  uint32_t get_numcore() const { return core; }
+
+  uint32_t get_numcolumn() const { return column; }
+
+  uint32_t get_nummem() const { return mem; }
+
+  void set_numcolumn(uint32_t val) { column = val; }
+
+  void set_numcore(uint32_t val) { core = val; }
+
+  void set_nummem(uint32_t val) { mem = val; }
+};
 
 inline uint8_t low_8(uint32_t num) { return (num >> FIRST_BYTE_SHIFT ) & BYTE_MASK; }
 inline uint8_t high_8(uint32_t num) { return (num >> SECOND_BYTE_SHIFT) & BYTE_MASK; }

--- a/src/cpp/common/writer.cpp
+++ b/src/cpp/common/writer.cpp
@@ -9,14 +9,14 @@
 namespace aiebu {
 
 void
-writer::
+section_writer::
 write_byte(uint8_t byte)
 {
   m_data.push_back(byte);
 }
 
 void
-writer::
+section_writer::
 write_word(uint32_t word)
 {
   write_byte((word >> FIRST_BYTE_SHIFT) & BYTE_MASK);
@@ -26,14 +26,14 @@ write_word(uint32_t word)
 }
 
 offset_type
-writer::
+section_writer::
 tell() const
 {
   return static_cast<offset_type>(m_data.size());
 }
 
 uint32_t
-writer::
+section_writer::
 read_word(offset_type offset) const
 {
   if (offset + 3 >= m_data.size())
@@ -45,7 +45,7 @@ read_word(offset_type offset) const
 }
 
 void
-writer::
+section_writer::
 write_word_at(offset_type offset, uint32_t word)
 {
   m_data[offset] = ((word >> FIRST_BYTE_SHIFT) & BYTE_MASK);
@@ -55,7 +55,7 @@ write_word_at(offset_type offset, uint32_t word)
 }
 
 void
-writer::
+section_writer::
 padding(offset_type pagesize)
 {
   auto datasize = tell();

--- a/src/cpp/common/writer.h
+++ b/src/cpp/common/writer.h
@@ -6,6 +6,7 @@
 
 #include <map>
 #include <string>
+#include <utility>
 #include <vector>
 #include <unordered_map>
 #include "symbol.h"
@@ -116,7 +117,7 @@ class config_writer: public writer
   std::shared_ptr<const partition_info> m_partition;
 
 public:
-  config_writer(std::shared_ptr<const partition_info> partition): m_partition(partition) {}
+  explicit config_writer(std::shared_ptr<const partition_info> partition): m_partition(std::move(partition)) {}
 
   const std::map<std::string, std::map<std::string,  std::vector<std::shared_ptr<writer>>>>&
   get_kernel_map() const { return m_output; }

--- a/src/cpp/common/writer.h
+++ b/src/cpp/common/writer.h
@@ -16,6 +16,12 @@ namespace aiebu {
 // Class to hold sections name, data, symbols, type
 class writer
 {
+public:
+  virtual ~writer() = default;
+};
+
+class section_writer: public writer
+{
   const std::string m_name;
   const code_section m_type;
   std::vector<uint8_t> m_data;
@@ -23,12 +29,17 @@ class writer
   std::unordered_map<std::string, std::string> m_metadata;
 
 public:
-  writer(std::string name, code_section type, std::vector<uint8_t>&& data)
+  section_writer(std::string name, code_section type, std::vector<uint8_t>&& data)
     : m_name(std::move(name)),
       m_type(type),
       m_data(std::move(data)) {}
-  writer(std::string name, code_section type): m_name(std::move(name)), m_type(type) {}
-  virtual ~writer() = default;
+  section_writer(std::string name, code_section type): m_name(std::move(name)), m_type(type) {}
+
+  ~section_writer() override= default;
+  section_writer(const section_writer& rhs) = default;
+  section_writer& operator=(const section_writer& rhs) = delete;
+  section_writer(section_writer &&s) = default;
+  //section_writer& operator=(const section_writer&& rhs) = default;
 
   virtual void write_byte(uint8_t byte);
 
@@ -97,5 +108,25 @@ public:
     return m_metadata[key];
   }
 };
+
+class config_writer: public writer
+{
+  // map<kernel, map<instance, vector<section_writer object having control code pages and symbol info>>
+  std::map<std::string, std::map<std::string, std::vector<std::shared_ptr<writer>>>> m_output;
+  std::shared_ptr<const partition_info> m_partition;
+
+public:
+  config_writer(std::shared_ptr<const partition_info> partition): m_partition(partition) {}
+
+  const std::map<std::string, std::map<std::string,  std::vector<std::shared_ptr<writer>>>>&
+  get_kernel_map() const { return m_output; }
+
+  void add_kernel_map(const std::string& kernel, const std::string& instance, std::vector<std::shared_ptr<writer>> val) {
+    m_output[kernel][instance] = std::move(val);
+  }
+
+  std::shared_ptr<const partition_info> get_partition_info() const { return m_partition; }
+};
+
 }
 #endif //_AIEBU_COMMON_WRITER_H_

--- a/src/cpp/elf/aie2ps/aie2ps_elfwriter.h
+++ b/src/cpp/elf/aie2ps/aie2ps_elfwriter.h
@@ -10,12 +10,80 @@ namespace aiebu {
 
 class aie2ps_elf_writer: public elf_writer
 {
-  constexpr static unsigned char ob_abi = 0x40;
+  constexpr static unsigned char ob_abi = 0x46;
   constexpr static unsigned char version = 0x02;
 public:
   aie2ps_elf_writer(): elf_writer(ob_abi, version)
   { }
 };
 
+class aie2ps_config_elf_writer: public elf_writer
+{
+  constexpr static unsigned char ob_abi = 0x46;
+  constexpr static unsigned char version = 0x03;
+  const std::string const_configuration = "configuration";
+  const std::string xrt_configuration = ".note.xrt.configuration";
+  const std::string const_kernel_signature = "kernel.signature";
+
+public:
+  aie2ps_config_elf_writer(): elf_writer(ob_abi, version)
+  { }
+
+  std::string get_group_name(uint32_t index) {return ".group."+ std::to_string(index); }
+  std::string get_section_prefix(uint32_t index) {return "."+ std::to_string(index); }
+
+  void
+  add_group(const std::string& name, const std::vector<uint32_t>& member, ELFIO::Elf_Word info_index)
+  {
+    // add section
+    ELFIO::section* sec = m_elfio.sections.add(name);
+    sec->set_type(ELFIO::SHT_GROUP);
+    sec->set_flags(ELFIO::SHF_ALLOC);
+    sec->set_addr_align(align);
+    sec->set_info(info_index);
+    sec->set_entry_size(4);
+
+    if(member.size())
+      sec->set_data(reinterpret_cast<const char*>(member.data()), static_cast<ELFIO::Elf_Word>(member.size()*4));
+
+    const ELFIO::section* lsec = m_elfio.sections[".symtab"];
+    sec->set_link(lsec->get_index());
+  }
+
+  /**
+   * This function gets config_writer object which has map<kernel, map<instance, vector<pages>>.
+   * It traverse each kernel, its instances and push corresponding pages in elf.
+   * It add dynamic section correspondly.
+   * It add partition info in note section and finalize to generate elf
+   */
+  std::vector<char>
+  process(std::vector<std::shared_ptr<writer>>& mwriter) override
+  {
+    auto mconfig_writer = std::dynamic_pointer_cast<config_writer>(mwriter[0]);
+    init_symtab();
+    uint32_t index=0;
+    for( auto& [kernel, instances] : mconfig_writer->get_kernel_map())
+    {
+       auto kernel_index = add_symtab(kernel);
+       for(auto& [iname, instance] : instances)
+       {
+         auto instance_index = add_symtab_section(iname, kernel_index);
+         std::vector<uint32_t> group_data = process_common_helper(instance, get_section_prefix(index));
+         // first word is GRP_COMDAT
+         group_data.insert(group_data.begin(), 1);
+         add_group(get_group_name(index), group_data, instance_index);
+         index++;
+       }
+    }
+    if (dstr_sec)
+      add_dynamic_section_segment();
+    std::vector<char> configuration_vec(4);
+    auto col = mconfig_writer->get_partition_info()->get_numcolumn();
+    std::memcpy(configuration_vec.data(), &col, sizeof(uint32_t));
+
+    add_note(NT_XRT_PARTITION_SIZE, xrt_configuration, configuration_vec);
+    return finalize();
+  }
+};
 }
 #endif //_AIEBU_ELF_AIE2PS_ELF_WRITER_H_

--- a/src/cpp/elf/aie4/aie4_elfwriter.h
+++ b/src/cpp/elf/aie4/aie4_elfwriter.h
@@ -15,5 +15,11 @@ public:
   { }
 };
 
+class aie4_config_elf_writer: public aie2ps_config_elf_writer
+{
+public:
+  aie4_config_elf_writer(): aie2ps_config_elf_writer()
+  { }
+};
 }
 #endif //AIEBU_ELF_AIE4_ELF_WRITER_H_

--- a/src/cpp/elf/config/config_elfwriter.h
+++ b/src/cpp/elf/config/config_elfwriter.h
@@ -21,22 +21,25 @@ public:
   { }
 
   std::vector<char>
-  process(std::vector<writer>& mwriter) override
+  process(std::vector<std::shared_ptr<writer>>& mwriter) override
   {
-    process_common_helper(mwriter);
+    process_common_helper(mwriter, "");
     //std::string uuid = mwriter[0].get_metadata("kernel.config.uuid");
     //if (!uuid.empty())
     //  add_note(NT_XRT_UUID, ".note.xrt.kernel.config.uuid", uuid);
 
-    const std::string configuration = mwriter[0].get_metadata(const_configuration);
+    auto element = std::dynamic_pointer_cast<section_writer>(mwriter[0]);
+    const std::string configuration = element->get_metadata(const_configuration);
     std::vector<char> configuration_vec(configuration.begin(), configuration.end());
     if (!configuration.empty())
       add_note(NT_XRT_PARTITION_SIZE, xrt_configuration, configuration_vec);
 
-    std::string kernel_signature = mwriter[0].get_metadata(const_kernel_signature);
+    std::string kernel_signature = element->get_metadata(const_kernel_signature);
     if (!kernel_signature.empty())
+    {
+      init_symtab();
       add_symtab(kernel_signature);
-
+    }
     return finalize();
   }
 };

--- a/src/cpp/elf/elfwriter.cpp
+++ b/src/cpp/elf/elfwriter.cpp
@@ -51,38 +51,24 @@ ELFIO::string_section_accessor
 elf_writer::
 add_dynstr_section()
 {
-  // add .dynstr section
-  ELFIO::section* dstr_sec = m_elfio.sections.add( ".dynstr" );
-  dstr_sec->set_type( ELFIO::SHT_STRTAB );
-  dstr_sec->set_entry_size( 0 );
   ELFIO::string_section_accessor stra( dstr_sec );
   return stra;
 }
 
 void
 elf_writer::
-add_dynsym_section(ELFIO::string_section_accessor* stra, std::vector<symbol>& syms)
+add_dynsym_section(ELFIO::string_section_accessor* stra, std::vector<symbol>& syms, const std::string&index_string)
 {
-  // add .dynsym section
-  ELFIO::section* dsym_sec = m_elfio.sections.add(".dynsym");
-  dsym_sec->set_type( ELFIO::SHT_DYNSYM );
-  dsym_sec->set_flags(ELFIO::SHF_ALLOC);
-  dsym_sec->set_addr_align( phdr_align );
-  dsym_sec->set_entry_size(m_elfio.get_default_entry_size(ELFIO::SHT_SYMTAB));
-  ELFIO::section* dstr_sec = m_elfio.sections[".dynstr"];
-  dsym_sec->set_link( dstr_sec->get_index() );
-  dsym_sec->set_info( 1 );
-
   // Create symbol table writer
   ELFIO::symbol_section_accessor syma( m_elfio, dsym_sec );
   std::map<std::string, ELFIO::Elf_Word> hash;
   for (auto & sym : syms) {
-    std::string key = sym.get_section_name() + "_" + sym.get_name() + "_" +
+    std::string key = sym.get_section_name() + index_string + "_" + sym.get_name() + "_" +
                       std::to_string(sym.get_size());
     auto it = hash.find(key);
     if (it == hash.end())
     {
-      const ELFIO::section* sec = m_elfio.sections[sym.get_section_name()];
+      const ELFIO::section* sec = m_elfio.sections[sym.get_section_name()+ index_string];
       auto index = syma.add_symbol(*stra, sym.get_name().c_str(), 0,
                                    sym.get_size(), ELFIO::STB_GLOBAL, ELFIO::STT_OBJECT,
                                    0, sec->get_index());
@@ -97,17 +83,6 @@ void
 elf_writer::
 add_reldyn_section(std::vector<symbol>& syms)
 {
-  // Create relocation table section
-  ELFIO::section* rel_sec = m_elfio.sections.add( ".rela.dyn" );
-  rel_sec->set_type( ELFIO::SHT_RELA );
-  rel_sec->set_flags(ELFIO::SHF_ALLOC);
-  //section* data_sec = m_elfio.sections[".data"];
-  //rel_sec->set_info( data_sec->get_index());
-  rel_sec->set_addr_align(phdr_align);
-  rel_sec->set_entry_size(m_elfio.get_default_entry_size(ELFIO::SHT_RELA));
-  ELFIO::section* dsym_sec = m_elfio.sections[".dynsym"];
-  rel_sec->set_link( dsym_sec->get_index() );
-
   // Create relocation table writer
   ELFIO::relocation_section_accessor rela( m_elfio, rel_sec );
   for (auto & sym : syms) {
@@ -133,7 +108,6 @@ add_dynamic_section_segment()
   dyn_sec->set_info( 0 );
 
   ELFIO::dynamic_section_accessor dyn(m_elfio, dyn_sec);
-  ELFIO::section* rel_sec = m_elfio.sections[".rela.dyn"];
   dyn.add_entry(ELFIO::DT_RELA, rel_sec->get_index());
   dyn.add_entry(ELFIO::DT_RELASZ, rel_sec->get_size());
 
@@ -177,93 +151,142 @@ finalize()
   return v;
 }
 
-void
+std::vector<uint32_t>
 elf_writer::
-add_text_data_section(const std::vector<writer>& mwriter, std::vector<symbol>& syms)
+add_text_data_section(const std::vector<std::shared_ptr<writer>>& mwriter, std::vector<symbol>& syms, const std::string& index_string)
 {
-  for(auto buffer : mwriter)
+  std::vector<uint32_t> section_index_list;
+  for(auto element : mwriter)
   {
-    if (buffer.get_data().size() == 0)
+    auto buffer = std::dynamic_pointer_cast<section_writer>(element);
+    if (buffer->get_data().size() == 0)
       continue;
 
-    m_uid.update(buffer.get_data());
+    m_uid.update(buffer->get_data());
     elf_section sec_data;
-    sec_data.set_name(buffer.get_name());
+    sec_data.set_name(buffer->get_name()+index_string);
     sec_data.set_type(ELFIO::SHT_PROGBITS);
-    if (buffer.get_type() == code_section::text)
+    if (buffer->get_type() == code_section::text)
       sec_data.set_flags(ELFIO::SHF_ALLOC | ELFIO::SHF_EXECINSTR);
     else
       sec_data.set_flags(ELFIO::SHF_ALLOC | ELFIO::SHF_WRITE);
     sec_data.set_align(align);
-    sec_data.set_buffer(buffer.get_data());
+    sec_data.set_buffer(buffer->get_data());
     sec_data.set_link("");
 
     elf_segment seg_data;
     seg_data.set_type(ELFIO::PT_LOAD);
-    if (buffer.get_type() == code_section::text)
+    if (buffer->get_type() == code_section::text)
       seg_data.set_flags(ELFIO::PF_X | ELFIO::PF_R);
     else
       seg_data.set_flags(ELFIO::PF_W | ELFIO::PF_R);
     seg_data.set_vaddr(0x0);
     seg_data.set_paddr(0x0);
-    seg_data.set_link(buffer.get_name());
+    seg_data.set_link(buffer->get_name()+index_string);
     seg_data.set_align(text_align);
 
-    add_section(sec_data);
+    section_index_list.push_back(add_section(sec_data)->get_index());
     add_segment(seg_data);
-    if (buffer.hassymbols())
+    if (buffer->hassymbols())
     {
-      auto lsyms = buffer.get_symbols();
+      auto lsyms = buffer->get_symbols();
       syms.insert(syms.end(), lsyms.begin(), lsyms.end());
     }
   }
+  return section_index_list;
 }
 
 void
 elf_writer::
+init_symtab()
+{
+  str_sec = m_elfio.sections.add(".strtab");
+  str_sec->set_type(ELFIO::SHT_STRTAB);
+  str_sec->set_entry_size(0);
+  sym_sec = m_elfio.sections.add(".symtab");
+  sym_sec->set_type(ELFIO::SHT_SYMTAB);
+  sym_sec->set_info(1);
+  sym_sec->set_addr_align(0x4);
+  sym_sec->set_entry_size(m_elfio.get_default_entry_size(ELFIO::SHT_SYMTAB));
+  sym_sec->set_link(str_sec->get_index());
+}
+
+ELFIO::Elf_Word
+elf_writer::
 add_symtab(const std::string& name)
 {
-  std::call_once(symtab_flag, [this] {
-    str_sec = m_elfio.sections.add(".strtab");
-    str_sec->set_type(ELFIO::SHT_STRTAB);
-    str_sec->set_entry_size(0);
-    sym_sec = m_elfio.sections.add(".symtab");
-    sym_sec->set_type(ELFIO::SHT_SYMTAB);
-    sym_sec->set_info(1);
-    sym_sec->set_addr_align(0x4);
-    sym_sec->set_entry_size(m_elfio.get_default_entry_size(ELFIO::SHT_SYMTAB));
-    sym_sec->set_link(str_sec->get_index());
-  });
-
   ELFIO::string_section_accessor stra(str_sec);
   // Create symbol table writer
   ELFIO::symbol_section_accessor syma( m_elfio, sym_sec );
   // Another way to add symbol
-  syma.add_symbol( stra, name.c_str(), 0x00000000, 0, ELFIO::STB_WEAK, ELFIO::STT_FUNC, 0,
+  return syma.add_symbol( stra, name.c_str(), 0x00000000, 0, ELFIO::STB_WEAK, ELFIO::STT_FUNC, 0,
                    ELFIO::SHN_UNDEF );
+}
+
+ELFIO::Elf_Word
+elf_writer::
+add_symtab_section(const std::string& name, ELFIO::Elf_Word index)
+{
+  ELFIO::string_section_accessor stra(str_sec);
+  // Create symbol table writer
+  ELFIO::symbol_section_accessor syma( m_elfio, sym_sec );
+  // Another way to add symbol
+  return syma.add_symbol( stra, name.c_str(), 0x00000000, 0, ELFIO::STB_WEAK, ELFIO::STT_OBJECT, 0,
+                   index );
 }
 
 void
 elf_writer::
-process_common_helper(std::vector<writer>& mwriter)
+init_dynamic_sections()
+{
+  std::call_once(dynamic_flag, [this] {
+    dstr_sec = m_elfio.sections.add( ".dynstr" );
+    dstr_sec->set_type( ELFIO::SHT_STRTAB );
+    dstr_sec->set_entry_size( 0 );
+    ELFIO::string_section_accessor stra( dstr_sec );
+
+    dsym_sec = m_elfio.sections.add(".dynsym");
+    dsym_sec->set_type( ELFIO::SHT_DYNSYM );
+    dsym_sec->set_flags(ELFIO::SHF_ALLOC);
+    dsym_sec->set_addr_align( phdr_align );
+    dsym_sec->set_entry_size(m_elfio.get_default_entry_size(ELFIO::SHT_SYMTAB));
+    dsym_sec->set_link( dstr_sec->get_index() );
+    dsym_sec->set_info( 1 );
+
+
+    rel_sec = m_elfio.sections.add( ".rela.dyn" );
+    rel_sec->set_type( ELFIO::SHT_RELA );
+    rel_sec->set_flags(ELFIO::SHF_ALLOC);
+    rel_sec->set_addr_align(phdr_align);
+    rel_sec->set_entry_size(m_elfio.get_default_entry_size(ELFIO::SHT_RELA));
+    rel_sec->set_link( dsym_sec->get_index() );
+  });
+}
+
+std::vector<uint32_t>
+elf_writer::
+process_common_helper(const std::vector<std::shared_ptr<writer>>& mwriter, const std::string& index_string)
 {
   // add sections
   std::vector<symbol> syms;
-  add_text_data_section(mwriter, syms);
+  auto section_index_list = add_text_data_section(mwriter, syms, index_string);
   if (syms.size())
   {
+    init_dynamic_sections();
     ELFIO::string_section_accessor str = add_dynstr_section();
-    add_dynsym_section(&str, syms);
+    add_dynsym_section(&str, syms, index_string);
     add_reldyn_section(syms);
-    add_dynamic_section_segment();
   }
+  return section_index_list;
 }
 
 std::vector<char>
 elf_writer::
-process(std::vector<writer>& mwriter)
+process(std::vector<std::shared_ptr<writer>>& mwriter)
 {
-  process_common_helper(mwriter);
+  process_common_helper(mwriter, "");
+  if (dstr_sec)
+    add_dynamic_section_segment();
   return finalize();
 }
 

--- a/src/cpp/elf/elfwriter.h
+++ b/src/cpp/elf/elfwriter.h
@@ -70,24 +70,32 @@ public:
 
 class elf_writer
 {
-protected:
+protected:  // NOLINT(cppcoreguidelines-non-private-member-variables-in-classes)
   ELFIO::elfio m_elfio;
   ELFIO::section* str_sec = nullptr;
   ELFIO::section* sym_sec = nullptr;
-  std::once_flag symtab_flag;
+
+  ELFIO::section* dstr_sec = nullptr;
+  ELFIO::section* dsym_sec = nullptr;
+  ELFIO::section* rel_sec = nullptr;
+  ELFIO::section* dynamic_sec = nullptr;
+  std::once_flag dynamic_flag;
   uid_md5 m_uid;
 
   ELFIO::section* add_section(const elf_section& data);
   ELFIO::segment* add_segment(const elf_segment& data);
   ELFIO::string_section_accessor add_dynstr_section();
-  void add_dynsym_section(ELFIO::string_section_accessor* stra, std::vector<symbol>& syms);
+  void add_dynsym_section(ELFIO::string_section_accessor* stra, std::vector<symbol>& syms, const std::string& index_string);
   void add_reldyn_section(std::vector<symbol>& syms);
   void add_dynamic_section_segment();
   std::vector<char> finalize();
-  void add_text_data_section(const std::vector<writer>& mwriter, std::vector<symbol>& syms);
+  std::vector<uint32_t> add_text_data_section(const std::vector<std::shared_ptr<writer>>& mwriter, std::vector<symbol>& syms, const std::string& index_string);
   void add_note(ELFIO::Elf_Word type, const std::string& name, const std::vector<char>& dec);
-  void add_symtab(const std::string& name);
-  void process_common_helper(std::vector<writer>& mwriter);
+  ELFIO::Elf_Word add_symtab(const std::string& name);
+  ELFIO::Elf_Word add_symtab_section(const std::string& name, ELFIO::Elf_Word index);
+  void init_symtab();
+  void init_dynamic_sections();
+  std::vector<uint32_t> process_common_helper(const std::vector<std::shared_ptr<writer>>& mwriter, const std::string& index_string);
 public:
 
   elf_writer(unsigned char abi, unsigned char version)
@@ -102,15 +110,17 @@ public:
 
     ELFIO::segment* seg = m_elfio.segments.add();
     seg->set_type( ELFIO::PT_PHDR );
+    //seg->set_type( ELFIO::PT_LOAD );
     seg->set_virtual_address( 0x0 );
     seg->set_physical_address( 0x0 );
     seg->set_flags( ELFIO::PF_R );
+    //seg->set_flags( ELFIO::PF_R | ELFIO::PF_X);
     seg->set_file_size(0x0);
     seg->set_memory_size(0x0);
 
   }
 
-  virtual std::vector<char> process(std::vector<writer>& mwriter);
+  virtual std::vector<char> process(std::vector<std::shared_ptr<writer>>& mwriter);
 
   virtual ~elf_writer() = default;
 

--- a/src/cpp/encoder/aie2/aie2_blob_encoder.h
+++ b/src/cpp/encoder/aie2/aie2_blob_encoder.h
@@ -16,20 +16,21 @@ class aie2_blob_encoder: public encoder
 public:
   aie2_blob_encoder() {}
 
-  virtual std::vector<writer> process(std::shared_ptr<preprocessed_output> input) override
+  std::vector<std::shared_ptr<writer>> process(std::shared_ptr<preprocessed_output> input) override
   {
     // encode : nothing to be done as blob is already encoded
     auto rinput = std::static_pointer_cast<aie2_blob_preprocessed_output>(input);
-    std::vector<writer> rwriter;
+    std::vector<std::shared_ptr<writer>> rwriter;
 
     for(auto key : rinput->get_keys())
       if ( !key.compare(".ctrltext") )
-        rwriter.emplace_back(key, code_section::text, std::move(rinput->get_data(key)));
+        rwriter.emplace_back(std::make_shared<section_writer>(key, code_section::text, std::move(rinput->get_data(key))));
       else
-        rwriter.emplace_back(key, code_section::data, std::move(rinput->get_data(key)));
+        rwriter.emplace_back(std::make_shared<section_writer>(key, code_section::data, std::move(rinput->get_data(key))));
 
-    rwriter[0].add_symbols(rinput->get_symbols());
-    rwriter[0].add_metadata(std::move(rinput->get_metadata()));
+    std::shared_ptr<section_writer> element = std::dynamic_pointer_cast<section_writer>(rwriter[0]);
+    element->add_symbols(rinput->get_symbols());
+    element->add_metadata(std::move(rinput->get_metadata()));
     return rwriter;
   }
 };

--- a/src/cpp/encoder/aie2ps/aie2ps_encoder.cpp
+++ b/src/cpp/encoder/aie2ps/aie2ps_encoder.cpp
@@ -10,7 +10,7 @@ namespace aiebu {
 
 void
 aie2ps_encoder::
-fill_scratchpad(writer& padwriter, const std::map<std::string, std::shared_ptr<scratchpad_info>>& scratchpads)
+fill_scratchpad(std::shared_ptr<section_writer> padwriter, const std::map<std::string, std::shared_ptr<scratchpad_info>>& scratchpads)
 {
   for (auto& pad : scratchpads)
   {
@@ -19,16 +19,16 @@ fill_scratchpad(writer& padwriter, const std::map<std::string, std::shared_ptr<s
     {
       assert((void("Pad content size and size doesnt match\n"), content.size() == pad.second->get_size()));
       for (auto& val : content)
-        padwriter.write_byte(val);
+        padwriter->write_byte(val);
     } else
       for (auto i = 0ul; i < pad.second->get_size(); ++i)
-        padwriter.write_byte(0x00);
+        padwriter->write_byte(0x00);
   }
 }
 
 void
 aie2ps_encoder::
-fill_control_packet_symbols(writer& padwriter,const uint32_t col,const std::string& controlpacket_padname,
+fill_control_packet_symbols(std::shared_ptr<section_writer> padwriter,const uint32_t col,const std::string& controlpacket_padname,
                             std::vector<symbol>& syms,
                             const std::map<std::string, std::shared_ptr<scratchpad_info>>& scratchpads)
 {
@@ -46,11 +46,11 @@ fill_control_packet_symbols(writer& padwriter,const uint32_t col,const std::stri
       continue;
     sym.set_section_name(get_PadSectionName(col));
     sym.set_pos(sym.get_pos() + pad->get_offset());
-    padwriter.add_symbol(sym);
+    padwriter->add_symbol(sym);
   }
 }
 
-std::vector<writer>
+std::vector<std::shared_ptr<writer>>
 aie2ps_encoder::
 process(std::shared_ptr<preprocessed_output> input)
 {
@@ -76,7 +76,7 @@ process(std::shared_ptr<preprocessed_output> input)
     if (!coldata.second->m_scratchpad.size())
       continue;
 
-    writer padwriter(get_PadSectionName(colnum), code_section::data);
+    auto padwriter = std::make_shared<section_writer>(get_PadSectionName(colnum), code_section::data);
     fill_scratchpad(padwriter, coldata.second->m_scratchpad);
     fill_control_packet_symbols(padwriter, colnum, controlpacket_padname, totalsyms, coldata.second->m_scratchpad);
 
@@ -96,11 +96,11 @@ process(std::shared_ptr<preprocessed_output> input)
 
   // Optional binary dump if debug flag is active
   if (tinput->get_debug()) {
-    writer dumpwriter(".dump", code_section::data);
+    auto dumpwriter = std::make_shared<section_writer>(".dump", code_section::data);
     std::string dbg_str = dbg_json.dump(); // no indent for compact output
     for (char c : dbg_str)
-      dumpwriter.write_byte(c);
-    twriter.push_back(std::move(dumpwriter));
+      dumpwriter->write_byte(c);
+    twriter.push_back(dumpwriter);
   }
   return twriter;
 }
@@ -150,14 +150,14 @@ page_writer(page& lpage, std::map<std::string, std::shared_ptr<scratchpad_info>>
   all.insert(all.end(), lpage.m_data.begin(), lpage.m_data.end());
   std::shared_ptr<assembler_state> page_state = create_assembler_state(m_isa, all, scratchpad, labelpageindex, control_packet_index, false);
 
-  writer textwriter(get_TextSectionName(colnum, pagenum), code_section::text);
-  writer datawriter(get_DataSectionName(colnum, pagenum), code_section::data);
+  auto textwriter = std::make_shared<section_writer>(get_TextSectionName(colnum, pagenum), code_section::text);
+  auto datawriter = std::make_shared<section_writer>(get_DataSectionName(colnum, pagenum), code_section::data);
 
   for (auto byte : page_header)
-    textwriter.write_byte(byte);
+    textwriter->write_byte(byte);
 
   // encode text section
-  offset_type offset = textwriter.tell();
+  offset_type offset = textwriter->tell();
   std::vector<symbol> tsym;
   std::string fid;
   for (auto text : lpage.m_text)
@@ -166,21 +166,21 @@ page_writer(page& lpage, std::map<std::string, std::shared_ptr<scratchpad_info>>
     std::string name = text->get_operation()->get_name();
     offset_type pc_low, pc_high;
     if (name == "start_job" || name == "start_job_deferred") {
-      pc_low = pagenum * PAGE_SIZE + textwriter.tell();
+      pc_low = pagenum * PAGE_SIZE + textwriter->tell();
       pc_high = pc_low + page_state->m_jobmap[page_state->gen_job_name(false, text)]->get_size() - 1;
       fid = m_debug.add_function(text->get_file(), name + "_" + page_state->gen_job_name(false, text), pc_high, pc_low, colnum, pagenum);
     }
-    pc_low = pagenum * PAGE_SIZE + textwriter.tell();
+    pc_low = pagenum * PAGE_SIZE + textwriter->tell();
     pc_high = pc_low + (*m_isa)[name]->serializer(text->get_operation()->get_args())->size(*page_state) - 1;
     m_debug.add_textline(fid, text->get_linenumber(), pc_high, pc_low, text->get_line(), text->get_annotation_index());
 
     if (text->isOpcode())
     {
-      page_state->set_pos(textwriter.tell() - offset);
+      page_state->set_pos(textwriter->tell() - offset);
       std::vector<uint8_t> ret = (*m_isa)[name]->serializer(text->get_operation()->get_args())
                                                ->serialize(page_state, tsym, colnum, pagenum);
       for (uint8_t byte : ret) {
-        textwriter.write_byte(byte);
+        textwriter->write_byte(byte);
       }
     } else 
       throw error(error::error_code::internal_error, "Invalid operation: " + name + " in TEXT section !!!");
@@ -190,7 +190,7 @@ page_writer(page& lpage, std::map<std::string, std::shared_ptr<scratchpad_info>>
   // encode data section
   for (auto data : lpage.m_data)
   {
-    page_state->set_pos(datawriter.tell() + textwriter.tell() - offset);
+    page_state->set_pos(datawriter->tell() + textwriter->tell() - offset);
     std::string name = data->get_operation()->get_name();
     if (!name.compare("eof"))
       continue;
@@ -199,13 +199,13 @@ page_writer(page& lpage, std::map<std::string, std::shared_ptr<scratchpad_info>>
       // TODO assert
     } else if (data->isOpcode())
     {
-      offset_type pc_low = pagenum * PAGE_SIZE + textwriter.tell() + datawriter.tell();
+      offset_type pc_low = pagenum * PAGE_SIZE + textwriter->tell() + datawriter->tell();
       offset_type pc_high = pc_low + (*m_isa)[name]->serializer(data->get_operation()->get_args())->size(*page_state) - 1;
       m_debug.add_dataline(fid, data->get_linenumber(), pc_high, pc_low, data->get_line(), data->get_annotation_index());
       std::vector<uint8_t> ret = (*m_isa)[name]->serializer(data->get_operation()->get_args())
                                                ->serialize(page_state, dsym, colnum, pagenum);
       for (auto byte : ret) {
-        datawriter.write_byte(byte);
+        datawriter->write_byte(byte);
       }
     } else 
       throw error(error::error_code::internal_error, "Invalid operation: " + name + " in DATA section !!!");
@@ -221,13 +221,13 @@ page_writer(page& lpage, std::map<std::string, std::shared_ptr<scratchpad_info>>
     }
   }
 
-  datawriter.padding(PAGE_SIZE-textwriter.tell());
+  datawriter->padding(PAGE_SIZE-textwriter->tell());
 
-  textwriter.add_symbols(tsym);
-  datawriter.add_symbols(dsym);
+  textwriter->add_symbols(tsym);
+  datawriter->add_symbols(dsym);
   twriter.push_back(textwriter);
   twriter.push_back(datawriter);
-  m_report.addpage(lpage, page_state, textwriter.tell(), datawriter.tell());
+  m_report.addpage(lpage, page_state, textwriter->tell(), datawriter->tell());
 
   return page_state->m_controlpacket_padname;
   // TODO add size and generate report
@@ -235,18 +235,18 @@ page_writer(page& lpage, std::map<std::string, std::shared_ptr<scratchpad_info>>
 
 void
 aie2ps_encoder::
-patch57(const writer& textwriter, writer& datawriter, offset_type offset, uint64_t patch)
+patch57(const std::shared_ptr<section_writer> textwriter, std::shared_ptr<section_writer> datawriter, offset_type offset, uint64_t patch)
 {
-  offset = offset - textwriter.tell();
-  uint64_t bd1 = datawriter.read_word(offset + 1*4);
-  uint64_t bd2 = datawriter.read_word(offset + 2*4);
-  uint64_t bd8 = datawriter.read_word(offset + 8*4);
+  offset = offset - textwriter->tell();
+  uint64_t bd1 = datawriter->read_word(offset + 1*4); // NOLINT
+  uint64_t bd2 = datawriter->read_word(offset + 2*4); // NOLINT
+  uint64_t bd8 = datawriter->read_word(offset + 8*4); // NOLINT
 
   uint64_t arg = ((bd8 & 0x1FF) << 48) + ((bd2 & 0xFFFF) << 32) + (bd1 & 0xFFFFFFFF); // NOLINT
   patch = arg + patch;
-  datawriter.write_word_at(offset + 1*4, patch & 0xFFFFFFFF);
-  datawriter.write_word_at(offset + 2*4, ((patch >> 32) & 0xFFFF) | (bd2 & 0xFFFF0000));
-  datawriter.write_word_at(offset + 8*4, ((patch >> 48) & 0x1FF) | (bd8 & 0xFFFFFE00));
+  datawriter->write_word_at(offset + 1*4, patch & 0xFFFFFFFF); // NOLINT
+  datawriter->write_word_at(offset + 2*4, ((patch >> 32) & 0xFFFF) | (bd2 & 0xFFFF0000)); // NOLINT
+  datawriter->write_word_at(offset + 8*4, ((patch >> 48) & 0x1FF) | (bd8 & 0xFFFFFE00));  // NOLINT
 }
 
 }

--- a/src/cpp/encoder/aie2ps/aie2ps_encoder.h
+++ b/src/cpp/encoder/aie2ps/aie2ps_encoder.h
@@ -18,7 +18,7 @@ namespace aiebu {
 class aie2ps_encoder : public encoder
 {
   std::shared_ptr<std::map<std::string, std::shared_ptr<isa_op>>> m_isa;
-  std::vector<writer> twriter;
+  std::vector<std::shared_ptr<writer>> twriter;
   asm_report m_report;
   Debug m_debug;
 public:
@@ -27,15 +27,15 @@ public:
     m_isa = i.get_isamap();
   }
 
-  virtual std::vector<writer>
+  virtual std::vector<std::shared_ptr<writer>>
   process(std::shared_ptr<preprocessed_output> input) override;
-  std::string get_TextSectionName(uint32_t colnum, pageid_type pagenum) {return ".ctrltext." + std::to_string(colnum) + "." + std::to_string(pagenum); }
-  std::string get_DataSectionName(uint32_t colnum, pageid_type pagenum) {return ".ctrldata." + std::to_string(colnum) + "." + std::to_string(pagenum); }
-  std::string get_PadSectionName(uint32_t colnum) {return ".pad." + std::to_string(colnum); }
+  virtual std::string get_TextSectionName(uint32_t colnum, pageid_type pagenum) {return ".ctrltext." + std::to_string(colnum) + "." + std::to_string(pagenum); }
+  virtual std::string get_DataSectionName(uint32_t colnum, pageid_type pagenum) {return ".ctrldata." + std::to_string(colnum) + "." + std::to_string(pagenum); }
+  virtual std::string get_PadSectionName(uint32_t colnum) {return ".pad." + std::to_string(colnum); }
   std::string page_writer(page& lpage, std::map<std::string, std::shared_ptr<scratchpad_info>>& scratchpad, std::map<std::string, uint32_t>& labelpageindex, uint32_t control_packet_index);
-  virtual void patch57(const writer& textwriter, writer& datawriter, offset_type offset, uint64_t patch);
-  void fill_scratchpad(writer& padwriter,const std::map<std::string, std::shared_ptr<scratchpad_info>>& scratchpads);
-  void fill_control_packet_symbols(writer& padwriter,const uint32_t col, const std::string& controlpacket_padname, std::vector<symbol>& syms, const std::map<std::string, std::shared_ptr<scratchpad_info>>& scratchpads);
+  virtual void patch57(const std::shared_ptr<section_writer> textwriter, std::shared_ptr<section_writer> datawriter, offset_type offset, uint64_t patch);
+  void fill_scratchpad(std::shared_ptr<section_writer> padwriter,const std::map<std::string, std::shared_ptr<scratchpad_info>>& scratchpads);
+  void fill_control_packet_symbols(std::shared_ptr<section_writer> padwriter,const uint32_t col, const std::string& controlpacket_padname, std::vector<symbol>& syms, const std::map<std::string, std::shared_ptr<scratchpad_info>>& scratchpads);
   std::string findKey(const std::map<std::string, std::vector<std::string>>& myMap, const std::string& value);
 
   virtual std::shared_ptr<assembler_state>
@@ -47,7 +47,41 @@ public:
   {
     return std::make_shared<assembler_state_aie2ps>(isa, data, scratchpad, labelpageindex, control_packet_index, makeunique);
   }
+
+  std::vector<std::shared_ptr<writer>> get_writers() { return twriter; }
+
+  virtual void check_partition_info(std::shared_ptr<const partition_info> source, std::shared_ptr<const partition_info> dest)
+  {
+    if(dest->get_numcolumn() != source->get_numcolumn())
+      throw error(error::error_code::invalid_asm, "Partition column " + std::to_string(dest->get_numcolumn()) + " != " + std::to_string(source->get_numcolumn()) + "\n");
+  }
 };
 
+//asm_config_preprocessor<aie2ps_config_encoder, aie2ps_preprocessed_output>
+template <typename T, typename input_tamplete>
+class asm_config_encoder : public encoder
+{
+  std::vector<std::shared_ptr<writer>> twriter;
+public:
+  std::vector<std::shared_ptr<writer>>
+  process(std::shared_ptr<preprocessed_output> input) override
+  {
+    auto tinput = std::static_pointer_cast<asm_config_preprocessed_output<input_tamplete>>(input);
+    // lets get partition info for first instance and compare this with other instances
+    auto pinfo_first_instance = tinput->get_kernel_map().begin()->second.begin()->second->get_partition_info();
+    auto output_writer = std::make_shared<config_writer>(pinfo_first_instance);
+    twriter.push_back(output_writer);
+
+    for (auto& [kernel, instances] : tinput->get_kernel_map()) {
+      for(auto& [iname, instance] : instances)
+      {
+        T encoder_object;
+        encoder_object.check_partition_info(instance->get_partition_info(), output_writer->get_partition_info());
+        output_writer->add_kernel_map(kernel, iname, encoder_object.process(instance));
+      }
+    }
+    return twriter;
+  }
+};
 }
 #endif //_AIEBU_ENCODER_AIE2PS_ENCODER_H_

--- a/src/cpp/encoder/aie4/aie4_encoder.h
+++ b/src/cpp/encoder/aie4/aie4_encoder.h
@@ -32,16 +32,22 @@ public:
   }
 
   void
-  patch57(const writer& textwriter, writer& datawriter, offset_type offset, uint64_t patch) override
+  patch57(const std::shared_ptr<section_writer> textwriter, std::shared_ptr<section_writer> datawriter, offset_type offset, uint64_t patch) override
   {
-    offset = offset - textwriter.tell();
-    uint64_t bd0 = datawriter.read_word(offset);
-    uint64_t bd1 = datawriter.read_word(offset + 1*4);             // NOLINT
+    offset = offset - textwriter->tell();
+    uint64_t bd0 = datawriter->read_word(offset);
+    uint64_t bd1 = datawriter->read_word(offset + 1*4);             // NOLINT
 
     uint64_t arg = (bd1 & 0xFFFFFFFF) + ((bd0 & 0x1FFFFFF) << 32); // NOLINT
     patch = arg + patch;
-    datawriter.write_word_at(offset + 1*4, patch & 0xFFFFFFFF);    // NOLINT
-    datawriter.write_word_at(offset, (((patch >> 32) & 0x1FFFFFF) | (bd0 & 0xFE000000)));  // NOLINT
+    datawriter->write_word_at(offset + 1*4, patch & 0xFFFFFFFF);    // NOLINT
+    datawriter->write_word_at(offset, (((patch >> 32) & 0x1FFFFFF) | (bd0 & 0xFE000000)));  // NOLINT
+  }
+
+  void check_partition_info(std::shared_ptr<const partition_info> source, std::shared_ptr<const partition_info> dest) override
+  {
+    if(dest->get_numcore() != source->get_numcore() || dest->get_nummem() != source->get_nummem())
+      throw error(error::error_code::invalid_asm, "Partition (core, mem) (" + std::to_string(dest->get_numcore()) + ", " + std::to_string(dest->get_numcore()) + ") != (" + std::to_string(source->get_nummem()) + ", " + std::to_string(source->get_nummem()) + ")\n");
   }
 
 };

--- a/src/cpp/encoder/encoder.h
+++ b/src/cpp/encoder/encoder.h
@@ -16,7 +16,7 @@ class encoder
 public:
   encoder() = default;
 
-  virtual std::vector<writer>
+  virtual std::vector<std::shared_ptr<writer>>
   process(std::shared_ptr<preprocessed_output> input) = 0;
   virtual ~encoder() = default;
 };

--- a/src/cpp/include/aiebu/aiebu.h
+++ b/src/cpp/include/aiebu/aiebu.h
@@ -26,7 +26,9 @@ enum aiebu_assembler_buffer_type {
   aiebu_assembler_buffer_type_blob_control_packet,
   aiebu_assembler_buffer_type_asm_aie2ps,
   aiebu_assembler_buffer_type_config,
-  aiebu_assembler_buffer_type_asm_aie4
+  aiebu_assembler_buffer_type_asm_aie4,
+  aiebu_assembler_buffer_type_aie2ps_config,
+  aiebu_assembler_buffer_type_aie4_config
 };
 
 struct pm_ctrlpkt {

--- a/src/cpp/include/aiebu/aiebu_assembler.h
+++ b/src/cpp/include/aiebu/aiebu_assembler.h
@@ -26,6 +26,8 @@ class aiebu_assembler
       asm_aie2,
       asm_aie4,
       config,
+      aie2ps_config,
+      aie4_config,
       elf_aie2,
       elf_aie2ps,
       pdi_aie2,

--- a/src/cpp/preprocessor/aie2/aie2_blob_preprocessor_input.h
+++ b/src/cpp/preprocessor/aie2/aie2_blob_preprocessor_input.h
@@ -302,42 +302,6 @@ protected:
   {
     return ".ctrldata." + instance_id;
   }
-  class argument {
-    public:
-    std::string name;
-    std::string type;
-    std::string offset;
-
-    argument(std::string na, std::string ty, std::string off):
-             name(std::move(na)),
-             type(std::move(ty)),
-             offset(std::move(off)) {}
-    argument(const argument& rhs) = default;
-    argument& operator=(const argument& rhs) = default;
-    argument(argument &&s) = default;
-    ~argument() = default;
-  };
-
-  struct function {
-    std::string name;
-    std::vector<argument> arguments;
-  };
-
-  std::string mangle_function_name(const function& func) {
-    std::string mangled_name = "_Z" + std::to_string(func.name.length()) + func.name;
-    for (const auto& arg : func.arguments) {
-        if (arg.type == "char *") {
-            mangled_name += "Pc"; // 'Pc' represents 'char *' in Itanium C++ ABI
-        } else if (arg.type == "void *") {
-            mangled_name += "Pv"; // 'Pv' represents 'void *' in Itanium C++ ABI
-        } else if (arg.type == "scalar") {
-            mangled_name += "i"; // 'i' represents 'int' in Itanium C++ ABI for scalar
-        } else if (arg.type == "int *") {
-            mangled_name += "Pi"; // 'Pi' represents 'int *' in Itanium C++ ABI
-        }
-    }
-    return mangled_name;
-  }
 public:
   config_preprocessor_input() = default;
   void set_args(const std::vector<char>& /*mc_code*/,

--- a/src/cpp/preprocessor/aie2ps/aie2ps_preprocessed_output.h
+++ b/src/cpp/preprocessor/aie2ps/aie2ps_preprocessed_output.h
@@ -5,6 +5,7 @@
 #define _AIEBU_PREPROCESSOR_AIE2PS_PREPROCESSED_OUTPUT_H_
 
 #include "asm/page.h"
+#include "symbol.h"
 #include "preprocessed_output.h"
 
 namespace aiebu {
@@ -24,8 +25,12 @@ class aie2ps_preprocessed_output : public preprocessed_output
   std::vector<symbol> m_sym;
   std::vector<annotation_type> m_annotation_list;
   bool isdebug = true;
+  std::shared_ptr<const partition_info> m_partition;
 public:
-  aie2ps_preprocessed_output() {}
+
+  aie2ps_preprocessed_output(std::shared_ptr<const partition_info> partition): m_partition(partition) {}
+
+  std::shared_ptr<const partition_info> get_partition_info() const { return m_partition; }
 
   void set_coldata(const uint32_t col, const std::vector<page> &pages, std::map<std::string, std::shared_ptr<scratchpad_info>> &scratchpad, std::map<std::string, uint32_t>& labelpageindex, uint32_t control_packet_index)
   {
@@ -62,6 +67,20 @@ public:
   bool get_debug() const
   {
     return isdebug;
+  }
+};
+
+template <typename T>
+class asm_config_preprocessed_output: public preprocessed_output
+{
+  std::map<std::string, std::map<std::string, std::shared_ptr<T>>> m_output;
+
+public:
+  const std::map<std::string, std::map<std::string, std::shared_ptr<T>>>&
+  get_kernel_map() const { return m_output; }
+
+  void add_kernel_map(const std::string& kernel, const std::string& instance, std::shared_ptr<T> val) {
+    m_output[kernel][instance] = val;
   }
 };
 

--- a/src/cpp/preprocessor/aie2ps/aie2ps_preprocessed_output.h
+++ b/src/cpp/preprocessor/aie2ps/aie2ps_preprocessed_output.h
@@ -7,6 +7,7 @@
 #include "asm/page.h"
 #include "symbol.h"
 #include "preprocessed_output.h"
+#include <utility>
 
 namespace aiebu {
 
@@ -28,7 +29,7 @@ class aie2ps_preprocessed_output : public preprocessed_output
   std::shared_ptr<const partition_info> m_partition;
 public:
 
-  aie2ps_preprocessed_output(std::shared_ptr<const partition_info> partition): m_partition(partition) {}
+  explicit aie2ps_preprocessed_output(std::shared_ptr<const partition_info> partition): m_partition(std::move(partition)) {}
 
   std::shared_ptr<const partition_info> get_partition_info() const { return m_partition; }
 

--- a/src/cpp/preprocessor/aie2ps/aie2ps_preprocessor.h
+++ b/src/cpp/preprocessor/aie2ps/aie2ps_preprocessor.h
@@ -42,13 +42,13 @@ public:
   std::shared_ptr<preprocessed_output>
   process_internal(std::shared_ptr<asm_preprocessor_input> tinput)
   {
-    auto toutput = std::make_shared<aie2ps_preprocessed_output>();
     //auto keys = tinput->get_keys();
     std::shared_ptr<asm_parser> parser(new asm_parser(tinput->get_data(), tinput->get_include_paths()));
     parser->parse_lines();
     auto collist = parser->get_col_list();
     isa i;
     m_isa = i.get_isamap();
+    auto toutput = std::make_shared<aie2ps_preprocessed_output>(parser->get_partition_info());
     auto flags = tinput->get_flags();
     for (const auto& flag: flags)
     {
@@ -111,5 +111,27 @@ public:
   }
 };
 
+template <typename preprocessor_template, typename input_tamplete, typename output_tamplete>
+class asm_config_preprocessor: public preprocessor
+{
+
+public:
+  std::shared_ptr<preprocessed_output>
+  process(std::shared_ptr<preprocessor_input> input) override
+  {
+    preprocessor_template m_preprocessor;
+    auto rinput = std::dynamic_pointer_cast<asm_config_preprocessor_input>(input);
+    auto toutput = std::make_shared<asm_config_preprocessed_output<output_tamplete>>();
+
+    for (auto& [kernel, instances] : rinput->get_kernel_map()) {
+      for(auto& [iname, instance] : instances)
+      {
+        auto val = std::dynamic_pointer_cast<output_tamplete>(m_preprocessor.process(instance));
+        toutput->add_kernel_map(kernel, iname, val);
+      }
+    }
+    return toutput;
+  }
+};
 }
 #endif //_AIEBU_PREPROCESSOR_AIE2PS_PREPROCESSOR_H_

--- a/src/cpp/preprocessor/aie2ps/aie2ps_preprocessor_input.h
+++ b/src/cpp/preprocessor/aie2ps/aie2ps_preprocessor_input.h
@@ -7,6 +7,7 @@
 #include <map>
 #include "symbol.h"
 #include "utils.h"
+#include "file_utils.h"
 #include "preprocessor_input.h"
 #include <boost/format.hpp>
 #include <boost/property_tree/json_parser.hpp>
@@ -43,6 +44,10 @@ protected:
 
 public:
   asm_preprocessor_input() = default;
+  asm_preprocessor_input(const asm_preprocessor_input& rhs) = default;
+  asm_preprocessor_input& operator=(const asm_preprocessor_input& rhs) = default;
+  asm_preprocessor_input(asm_preprocessor_input &&s) = default;
+  asm_preprocessor_input& operator=(asm_preprocessor_input&& rhs) = default;
 
   const std::vector<std::string>& get_include_paths() const { return m_libpaths; }
   uint32_t get_control_packet_index() const { return m_control_packet_index; }
@@ -86,6 +91,123 @@ class aie2ps_preprocessor_input : public asm_preprocessor_input
 public:
   aie2ps_preprocessor_input() { control_packet_patching = symbol::patch_schema::control_packet_57;}
 
+};
+
+class asm_config_preprocessor_input : public preprocessor_input
+{
+protected: // NOLINT
+  std::map<std::string, std::map<std::string, std::shared_ptr<asm_preprocessor_input>>> m_preprocessor_input;
+
+public:
+
+  const std::map<std::string, std::map<std::string, std::shared_ptr<asm_preprocessor_input>>>&
+  get_kernel_map() const { return m_preprocessor_input; }
+
+  void add_instance(const std::string& kernel,
+                    const boost::property_tree::ptree& pinstance,
+                    const std::vector<std::string>& flags,
+                    const std::vector<std::string>& paths)
+  {
+    for (const auto& [unused, pic] : pinstance)
+    {
+      auto tname = pic.get<std::string>("id");
+      auto ccode_file = findFilePath(pic.get<std::string>("ctrl_code_file"), paths);
+      auto ccode = readfile(ccode_file);
+      //std::cout << "TXN_ctrl_code_file id:" << pic.get<std::string>("id") << std::endl;
+      //std::cout << "TXN_ctrl_code_file:" << pic.get<std::string>("TXN_ctrl_code_file") << std::endl;
+
+      std::vector<char> jdata;
+      if (!pic.get<std::string>("patch_info_file", "").empty())
+        jdata = readfile(pic.get<std::string>("patch_info_file"), paths);
+
+      std::vector<std::string> asmpath;
+      asmpath.emplace_back(get_parent_directory(ccode_file));
+      add_preprocessor_input(kernel, tname, ccode, jdata, flags, asmpath);
+    }
+  }
+
+  void parse_config_json(std::istream& patch_json,
+                         const std::vector<std::string>& flags,
+                         const std::vector<std::string>& paths)
+  {
+    boost::property_tree::ptree pt;
+    boost::property_tree::read_json(patch_json, pt);
+
+    const auto& pt_xrt_kernel_instance = pt.get_child_optional("xrt-kernels");
+    if (!pt_xrt_kernel_instance) {
+      std::cout << "xrt-kernels instance not found returning\n";
+      return;
+    }
+    const auto& p_xrt_kernel_instance = pt_xrt_kernel_instance.get();
+    for (const auto& [unused, ctrlcode] : p_xrt_kernel_instance)
+    {
+      //const auto& ctrlcode = pt_ctrlcode.second;
+      //get mangled kernel name
+      function func;
+      func.name = ctrlcode.get<std::string>("name");
+      for (const auto& item : ctrlcode.get_child("arguments")) {
+        func.arguments.emplace_back(item.second.get<std::string>("name"),
+                                    item.second.get<std::string>("type"),
+                                    item.second.get<std::string>("offset"));
+      }
+      std::string mangled_name = mangle_function_name(func);
+      //std::cout << "Mangled Function Name: " << mangled_name << std::endl;
+      add_metadata("kernel.signature", mangled_name);
+
+      const auto& pt_pdis = ctrlcode.get_child_optional("PDIs");
+      if (pt_pdis)
+        throw error(error::error_code::invalid_asm, "PDIs section should not be present for json with controlcode in asm format\n");
+
+      const auto& pt_instance = ctrlcode.get_child_optional("instance");
+      if (pt_instance) {
+        const auto& pinstance = pt_instance.get();
+        add_instance(mangled_name, pinstance, flags, paths);
+      } else {
+        std::cout << "instance not found\n";
+      }
+    }
+  }
+
+  void set_args(const std::vector<char>& /*control_code*/,
+                const std::vector<char>& patch_json,
+                const std::vector<char>& /*buffer2*/,
+                const std::vector<std::string>& libs,
+                const std::vector<std::string>& libpaths,
+                const std::map<uint32_t, std::vector<char> >& /*ctrlpkt*/) override
+  {
+    if (patch_json.size() !=0)
+    {
+      vector_streambuf vsb(patch_json);
+      std::istream elf_stream(&vsb);
+      parse_config_json(elf_stream, libs, libpaths);
+    }
+  }
+
+  virtual void add_preprocessor_input(const std::string& /*kernel*/,
+                                      const std::string& /*instance*/,
+                                      const std::vector<char>& /*control_code*/,
+                                      const std::vector<char>& /*patch_json*/,
+                                      const std::vector<std::string>& /*flags*/,
+                                      const std::vector<std::string>& /*paths*/) = 0;
+
+  ~asm_config_preprocessor_input() override = default;
+};
+
+template <typename T>
+class controlcode_config_preprocessor_input : public asm_config_preprocessor_input
+{
+public:
+  void add_preprocessor_input(const std::string& kernel,
+                              const std::string& instance,
+                              const std::vector<char>& control_code,
+                              const std::vector<char>& patch_json,
+                              const std::vector<std::string>& flags,
+                              const std::vector<std::string>& paths) override
+  {
+    auto input = std::make_shared<T>();
+    input->set_args(control_code, patch_json, {}, flags, paths, {});
+    m_preprocessor_input[kernel][instance] = input;
+  }
 };
 
 }

--- a/src/cpp/preprocessor/asm/asm_parser.cpp
+++ b/src/cpp/preprocessor/asm/asm_parser.cpp
@@ -104,6 +104,7 @@ parse_lines()
   directive_list[".endl"] = std::make_shared<end_of_label_directive>();
   directive_list[".setpad"] = std::make_shared<pad_directive>();
   directive_list[".section"] = std::make_shared<section_directive>();
+  directive_list[".partition"] = std::make_shared<partition_directive>();
   std::string file = "default";
   parse_lines(m_data, file);
 }
@@ -219,6 +220,29 @@ operate(std::shared_ptr<asm_parser> parserptr, const std::smatch& sm)
     std::cout << "section directive with unknown section found:" << args[0] << std::endl;
 }
 
+void
+partition_directive::
+operate(std::shared_ptr<asm_parser> parserptr, const std::smatch& sm)
+{
+  m_parserptr = parserptr;
+  static const std::regex pattern(R"(\.partition\s+(\d+)(column|core:(\d+)mem))");
+  std::smatch match;
+  std::cout << "PARTITION:" << sm[0].str() << "\n";
+  std::string line = sm[0].str();
+  if (std::regex_match(line, match, pattern)) {
+    if (match[2] == "column") {
+      std::cout << "Column count: " << match[1] << std::endl;
+      m_parserptr->set_numcolumn(to_uinteger<uint32_t>(match[1]));
+    } else {
+      m_parserptr->set_numcore(to_uinteger<uint32_t>(match[1]));
+      m_parserptr->set_nummem(to_uinteger<uint32_t>(match[3]));
+      std::cout << "Core count: " << match[1] << std::endl;
+      std::cout << "Memory size: " << match[3] << std::endl;
+    }
+  } else
+    throw error(error::error_code::invalid_asm, "Invalid format!! " + line + "\n");
+}
+
 bool
 include_directive::
 read_include_file(std::string filename)
@@ -248,7 +272,7 @@ operate(std::shared_ptr<asm_parser> parserptr, const std::smatch& sm)
   if (file.size() >= 2 && file.front() == '"' && file.back() == '"')
     file =  file.substr(1, file.size() - 2);
 
-  if (isAbsolutePath(file))
+  if (is_absolute_path(file))
   {
     if (!read_include_file(file))
       throw error(error::error_code::internal_error, "File " + file + " not exist\n");
@@ -311,7 +335,7 @@ add_scratchpad(std::string& name, std::string& str) {
   if (file.front() == '"' && file.back() == '"')
     file = str.substr(1, str.size() - 2);
 
-  if (isAbsolutePath(file))
+  if (is_absolute_path(file))
   {
     if (!read_pad_file(name, file))
       throw error(error::error_code::internal_error, "File " + file + " not exist\n");

--- a/src/cpp/preprocessor/asm/asm_parser.h
+++ b/src/cpp/preprocessor/asm/asm_parser.h
@@ -293,7 +293,7 @@ class asm_parser: public std::enable_shared_from_this<asm_parser>
   std::shared_ptr<partition_info> m_partition;
 
 public:
-  asm_parser(const std::vector<char>& data, const std::vector<std::string>& include_list):m_data(data), m_include_list(include_list)//, m_partition(DEFAULT_COLUMN,0)
+  asm_parser(const std::vector<char>& data, const std::vector<std::string>& include_list):m_data(data), m_include_list(include_list)
   {
     set_data_state(false);
     m_current_col = -1;

--- a/src/cpp/preprocessor/asm/asm_parser.h
+++ b/src/cpp/preprocessor/asm/asm_parser.h
@@ -5,6 +5,7 @@
 
 #include "code_section.h"
 #include "utils.h"
+#include "file_utils.h"
 
 #include <map>
 #include <memory>
@@ -77,62 +78,32 @@ public:
 class attach_to_group_directive: public directive
 {
 public:
-  attach_to_group_directive() {}
-  void operate(std::shared_ptr<asm_parser> parserptr, const std::smatch& sm);
+  attach_to_group_directive() = default;
+  void operate(std::shared_ptr<asm_parser> parserptr, const std::smatch& sm) override;
+  ~attach_to_group_directive() override = default;
 };
 
 class include_directive: public directive
 {
 
   bool read_include_file(std::string filename);
-  bool isAbsolutePath(const std::string& path) {
-    // On Unix-like systems, an absolute path starts with '/'
-    if (path.empty()) {
-      return false;
-    }
-    if (path[0] == '/') {
-      return true;
-    }
-
-    // On Windows, an absolute path can start with a drive letter followed by ':'
-    // and a backslash or forward slash, e.g., "C:\\" or "C:/"
-    if (path.size() > 1 && path[1] == ':' && (path[2] == '\\' || path[2] == '/')) {
-      return true;
-    }
-    return false;
-  }
 public:
-  include_directive() {}
-  void operate(std::shared_ptr<asm_parser> parserptr, const std::smatch& sm);
+  include_directive() = default;
+  void operate(std::shared_ptr<asm_parser> parserptr, const std::smatch& sm) override;
+  ~include_directive() override = default;
 };
 
 class end_of_label_directive: public directive
 {
 public:
-  end_of_label_directive() {}
-  void operate(std::shared_ptr<asm_parser> parserptr, const std::smatch& sm);
+  end_of_label_directive() = default;
+  void operate(std::shared_ptr<asm_parser> parserptr, const std::smatch& sm) override;
+  ~end_of_label_directive() override = default;
 };
 
 class pad_directive: public directive
 {
   bool read_pad_file(std::string& name, std::string& filename);
-
-  bool isAbsolutePath(const std::string& path) {
-    // On Unix-like systems, an absolute path starts with '/'
-    if (path.empty()) {
-      return false;
-    }
-    if (path[0] == '/') {
-      return true;
-    }
-
-    // On Windows, an absolute path can start with a drive letter followed by ':'
-    // and a backslash or forward slash, e.g., "C:\\" or "C:/"
-    if (path.size() > 1 && path[1] == ':' && (path[2] == '\\' || path[2] == '/')) {
-      return true;
-    }
-    return false;
-  }
 public:
   offset_type convert2int(std::string& str)
   {
@@ -151,8 +122,9 @@ public:
     return size;
   }
   void add_scratchpad(std::string& name, std::string& str);
-  pad_directive() {}
-  void operate(std::shared_ptr<asm_parser> parserptr, const std::smatch& sm);
+  pad_directive() = default;
+  void operate(std::shared_ptr<asm_parser> parserptr, const std::smatch& sm) override;
+  ~pad_directive() override = default;
 };
 
 class section_directive: public directive
@@ -161,8 +133,21 @@ class section_directive: public directive
   bool is_data_section(const std::string& str) {return !str.substr(0,9).compare(".ctrldata"); }
   bool is_annotation_section(const std::string& str) {return !str.substr(0,10).compare("annotation"); }
 public:
-  section_directive() {}
-  void operate(std::shared_ptr<asm_parser> parserptr, const std::smatch& sm);
+  section_directive() = default;
+  void operate(std::shared_ptr<asm_parser> parserptr, const std::smatch& sm) override;
+  ~section_directive() override = default;
+};
+
+class partition_directive: public directive
+{
+public:
+  partition_directive() = default;
+  void operate(std::shared_ptr<asm_parser> parserptr, const std::smatch& sm) override;
+  ~partition_directive() override = default;
+  partition_directive(const partition_directive&) = default;
+  partition_directive& operator=(const partition_directive&) = default;
+  partition_directive(partition_directive&&) = default;
+  partition_directive& operator=(partition_directive&&) = default;
 };
 
 class asm_data
@@ -292,6 +277,7 @@ class include_directive;
 class end_of_label_directive;
 class pad_directive;
 class section_directive;
+class partition_directive;
 
 class asm_parser: public std::enable_shared_from_this<asm_parser>
 {
@@ -304,12 +290,14 @@ class asm_parser: public std::enable_shared_from_this<asm_parser>
   const std::vector<std::string>& m_include_list;
   bool annotation_state = false;
   std::vector<annotation_type> m_annotation_list;
+  std::shared_ptr<partition_info> m_partition;
 
 public:
-  asm_parser(const std::vector<char>& data, const std::vector<std::string>& include_list):m_data(data), m_include_list(include_list)
+  asm_parser(const std::vector<char>& data, const std::vector<std::string>& include_list):m_data(data), m_include_list(include_list)//, m_partition(DEFAULT_COLUMN,0)
   {
     set_data_state(false);
     m_current_col = -1;
+    m_partition = std::make_shared<partition_info>(DEFAULT_COLUMN, 0);
   }
 
   void set_data_state(bool state) { isdatastack.push(state); }
@@ -355,6 +343,14 @@ public:
   std::vector<uint32_t> get_col_list();
 
   col_data& get_col_asmdata(uint32_t colnum);
+
+  std::shared_ptr<const partition_info> get_partition_info() const { return std::const_pointer_cast<const partition_info>(m_partition); }
+
+  void set_numcolumn(uint32_t val) { m_partition->set_numcolumn(val); }
+
+  void set_numcore(uint32_t val) { m_partition->set_numcore(val); }
+
+  void set_nummem(uint32_t val) { m_partition->set_nummem(val); }
 
   void parse_lines();
 

--- a/src/cpp/preprocessor/preprocessed_output.h
+++ b/src/cpp/preprocessor/preprocessed_output.h
@@ -9,7 +9,8 @@ namespace aiebu {
 class preprocessed_output
 {
 public:
-  preprocessed_output() {}
+  preprocessed_output() = default;
+  virtual ~preprocessed_output() = default;
 };
 
 }

--- a/src/cpp/preprocessor/preprocessor_input.h
+++ b/src/cpp/preprocessor/preprocessor_input.h
@@ -20,6 +20,45 @@ protected:
   std::map<std::string, std::vector<char>> m_data;
   std::vector<symbol> m_sym;
   std::unordered_map<std::string, std::string> m_metadata;
+
+  class argument {
+    public:
+    std::string name;
+    std::string type;
+    std::string offset;
+
+    argument(std::string na, std::string ty, std::string off):
+             name(std::move(na)),
+             type(std::move(ty)),
+             offset(std::move(off)) {}
+    argument(const argument& rhs) = default;
+    argument& operator=(const argument& rhs) = default;
+    argument(argument &&s) = default;
+    ~argument() = default;
+    argument& operator =(argument &&) = default;
+  };
+
+  struct function {
+    std::string name;
+    std::vector<argument> arguments;
+  };
+
+  std::string mangle_function_name(const function& func) {
+    std::string mangled_name = "_Z" + std::to_string(func.name.length()) + func.name;
+    for (const auto& arg : func.arguments) {
+        if (arg.type == "char *") {
+            mangled_name += "Pc"; // 'Pc' represents 'char *' in Itanium C++ ABI
+        } else if (arg.type == "void *") {
+            mangled_name += "Pv"; // 'Pv' represents 'void *' in Itanium C++ ABI
+        } else if (arg.type == "scalar") {
+            mangled_name += "i"; // 'i' represents 'int' in Itanium C++ ABI for scalar
+        } else if (arg.type == "int *") {
+            mangled_name += "Pi"; // 'Pi' represents 'int *' in Itanium C++ ABI
+        }
+    }
+    return mangled_name;
+  }
+
 public:
   preprocessor_input() {}
   virtual ~preprocessor_input() = default;

--- a/src/cpp/utils/asm/asm.cpp
+++ b/src/cpp/utils/asm/asm.cpp
@@ -29,7 +29,7 @@ void main_helper(int argc, char** argv,
       .allow_unrecognised_options()
       .add_options()
       ("h,help", "show help message and exit", cxxopts::value<bool>()->default_value("false"))
-      ("t,target", "supported targets aie2ps/aie2asm/aie2txn/aie2dpu/config/aie4", cxxopts::value<decltype(target_name)>())
+      ("t,target", "supported targets aie2ps/aie2asm/aie2txn/aie2dpu/config/aie4/aie2ps_config", cxxopts::value<decltype(target_name)>())
       ("v,version", "show version and exit", cxxopts::value<bool>()->default_value("false"))
       ;
 
@@ -91,6 +91,8 @@ int main( int argc, char** argv )
     targets.emplace_back(std::make_shared<aiebu::utilities::target_aie2blob_dpu>(executable));
     targets.emplace_back(std::make_shared<aiebu::utilities::target_config>(executable));
     targets.emplace_back(std::make_shared<aiebu::utilities::target_aie4>(executable));
+    targets.emplace_back(std::make_shared<aiebu::utilities::target_aie2ps_config>(executable));
+    targets.emplace_back(std::make_shared<aiebu::utilities::target_aie4_config>(executable));
   }
 
   // -- Program Description

--- a/src/cpp/utils/target/target.cpp
+++ b/src/cpp/utils/target/target.cpp
@@ -9,6 +9,7 @@
 
 #include "target.h"
 #include "utils.h"
+#include "file_utils.h"
 
 std::map<uint32_t, std::vector<char> >
 aiebu::utilities::
@@ -393,6 +394,80 @@ target_aie4::assemble(const sub_cmd_options &_options)
     aiebu::aiebu_assembler as(aiebu::aiebu_assembler::buffer_type::asm_aie4, asmBuffer, flags, libpaths, patch_data_buffer);
     write_elf(as, output_elffile);
   } catch (aiebu::error &ex) {
+    auto errMsg = boost::format("Error: %s, code:%d\n") % ex.what() % ex.get_code() ;
+    throw std::runtime_error(errMsg.str());
+  }
+}
+
+void
+aiebu::utilities::
+asm_config_parser::parser(const sub_cmd_options &options)
+{
+  std::string json_file;
+  cxxopts::Options all_options("Target config Options", m_description);
+
+  try {
+    all_options.add_options()
+            ("o,outputelf", "ELF output file name", cxxopts::value<decltype(output_elffile)>())
+            ("j,json", "control packet Patching json file", cxxopts::value<decltype(json_file)>())
+            ("h,help", "show help message and exit", cxxopts::value<bool>()->default_value("false"))
+    ;
+
+
+    auto char_ver = aiebu::utilities::vector_of_string_to_vector_of_char(options);
+
+    auto result = all_options.parse(static_cast<int>(char_ver.size()), char_ver.data());
+
+    if (result.count("help")) {
+      std::cout << all_options.help({"", "Target config Options"});
+      return;
+    }
+
+    if (result.count("outputelf"))
+      output_elffile = result["outputelf"].as<decltype(output_elffile)>();
+    else
+      throw std::runtime_error("the option '--outputelf' is required but missing\n");
+
+    if (result.count("json"))
+      json_file = result["json"].as<decltype(json_file)>();
+  }
+  catch (const cxxopts::exceptions::exception& e) {
+    std::cout << all_options.help({"", "Target config Options"});
+    auto errMsg = boost::format("Error parsing options: %s\n") % e.what() ;
+    throw std::runtime_error(errMsg.str());
+  }
+
+  if (!json_file.empty()) {
+    readfile(json_file, json_buffer);
+    libpaths.push_back(get_parent_directory(json_file));
+  }
+}
+
+void
+aiebu::utilities::
+target_aie2ps_config::assemble(const sub_cmd_options &options)
+{
+  parser(options);
+  try {
+    aiebu::aiebu_assembler as(aiebu::aiebu_assembler::buffer_type::aie2ps_config, {}, {}, libpaths, json_buffer);
+    write_elf(as, output_elffile);
+  }
+  catch (aiebu::error &ex) {
+    auto errMsg = boost::format("Error: %s, code:%d\n") % ex.what() % ex.get_code() ;
+    throw std::runtime_error(errMsg.str());
+  }
+}
+
+void
+aiebu::utilities::
+target_aie4_config::assemble(const sub_cmd_options &options)
+{
+ parser(options);
+ try {
+    aiebu::aiebu_assembler as(aiebu::aiebu_assembler::buffer_type::aie4_config, {}, {}, libpaths, json_buffer);
+    write_elf(as, output_elffile);
+  }
+  catch (aiebu::error &ex) {
     auto errMsg = boost::format("Error: %s, code:%d\n") % ex.what() % ex.get_code() ;
     throw std::runtime_error(errMsg.str());
   }

--- a/src/cpp/utils/target/target.cpp
+++ b/src/cpp/utils/target/target.cpp
@@ -410,6 +410,7 @@ asm_config_parser::parser(const sub_cmd_options &options)
     all_options.add_options()
             ("o,outputelf", "ELF output file name", cxxopts::value<decltype(output_elffile)>())
             ("j,json", "control packet Patching json file", cxxopts::value<decltype(json_file)>())
+            ("f,flag", "flags", cxxopts::value<decltype(flags)>())
             ("h,help", "show help message and exit", cxxopts::value<bool>()->default_value("false"))
     ;
 
@@ -430,6 +431,9 @@ asm_config_parser::parser(const sub_cmd_options &options)
 
     if (result.count("json"))
       json_file = result["json"].as<decltype(json_file)>();
+
+    if (result.count("flag"))
+      flags = result["flag"].as<decltype(flags)>();
   }
   catch (const cxxopts::exceptions::exception& e) {
     std::cout << all_options.help({"", "Target config Options"});
@@ -449,7 +453,7 @@ target_aie2ps_config::assemble(const sub_cmd_options &options)
 {
   parser(options);
   try {
-    aiebu::aiebu_assembler as(aiebu::aiebu_assembler::buffer_type::aie2ps_config, {}, {}, libpaths, json_buffer);
+    aiebu::aiebu_assembler as(aiebu::aiebu_assembler::buffer_type::aie2ps_config, {}, flags, libpaths, json_buffer);
     write_elf(as, output_elffile);
   }
   catch (aiebu::error &ex) {
@@ -464,7 +468,7 @@ target_aie4_config::assemble(const sub_cmd_options &options)
 {
  parser(options);
  try {
-    aiebu::aiebu_assembler as(aiebu::aiebu_assembler::buffer_type::aie4_config, {}, {}, libpaths, json_buffer);
+    aiebu::aiebu_assembler as(aiebu::aiebu_assembler::buffer_type::aie4_config, {}, flags, libpaths, json_buffer);
     write_elf(as, output_elffile);
   }
   catch (aiebu::error &ex) {

--- a/src/cpp/utils/target/target.h
+++ b/src/cpp/utils/target/target.h
@@ -135,6 +135,7 @@ class asm_config_parser: public target
   std::string output_elffile;
   std::vector<char> json_buffer;
   std::vector<std::string> libpaths;
+  std::vector<std::string> flags;
   void parser(const sub_cmd_options &options);
   public:
   asm_config_parser(const std::string& exename, const std::string& name, const std::string& description)

--- a/src/cpp/utils/target/target.h
+++ b/src/cpp/utils/target/target.h
@@ -129,6 +129,31 @@ class target_aie4: public target
   explicit target_aie4(const std::string& name): target(name, "aie4", "aie4 asm assembler") {}
 };
 
+class asm_config_parser: public target
+{
+  protected: // NOLINT
+  std::string output_elffile;
+  std::vector<char> json_buffer;
+  std::vector<std::string> libpaths;
+  void parser(const sub_cmd_options &options);
+  public:
+  asm_config_parser(const std::string& exename, const std::string& name, const std::string& description)
+    : target(exename, name, description) {}
+};
+
+class target_aie2ps_config: public asm_config_parser
+{
+  public:
+  void assemble(const sub_cmd_options &_options) override;
+  explicit target_aie2ps_config(const std::string& name): asm_config_parser(name, "aie2ps_config", "generate aie2ps config elf") {}
+};
+
+class target_aie4_config: public asm_config_parser
+{
+  public:
+  void assemble(const sub_cmd_options &_options) override;
+  explicit target_aie4_config(const std::string& name): asm_config_parser(name, "aie4_config", "generate aie4 config elf") {}
+};
 } //namespace aiebu::utilities
 
 #endif // AIEBU_UTILITIES_TARGET_H_

--- a/test/cpp_test/aie2ps/eff_net_coal/gold.md5
+++ b/test/cpp_test/aie2ps/eff_net_coal/gold.md5
@@ -1,1 +1,1 @@
-e749a52dc8510f37e1f78e32f2b3eee7
+cf78beee0c5bdffca0bfa2c9dbdfe891


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
aie2ps/aie4 support for xclbin2elf 
aiebu-asm utility target added 
1. aie2ps_config
2. aie4_config

Note: all path in config are relative to config and all path in asm are relative to merge_control.asm.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)

### config.json
```
{
  "xrt-kernels": [
    {
      "name" : "DPU",
      "arguments" : [
        {
          "name" : "arg0",
          "type" : "char *",
          "offset" : "0x00"
        },
        {
          "name" : "arg1",
          "type" : "char *",
          "offset" : "0x08"
        },
        {
          "name" : "arg2",
          "type" : "char *",
          "offset" : "0x10"
        }
      ],
      "instance" : [
                 {
                   "id" : "dpu",
                   "ctrl_code_file" : "./Telluride/test/getting_started/simple_int8/Work/ps/ml_asm/merged_control.asm"
                 }
        ]
    }
  ]
}
```

> command
```
 ./Debug/aiebu/bin/aiebu-asm -t aie2ps_config -j config_simple_int8.json -o simple_int8.elf
```

> readelf -a simple_int8.elf
```
ELF Header:
  Magic:   7f 45 4c 46 01 01 01 40 03 00 00 00 00 00 00 00 
  Class:                             ELF32
  Data:                              2's complement, little endian
  Version:                           1 (current)
  OS/ABI:                            <unknown: 40>
  ABI Version:                       3
  Type:                              EXEC (Executable file)
  Machine:                           WE32100
  Version:                           0x1
  Entry point address:               0x0
  Start of program headers:          52 (bytes into file)
  Start of section headers:          42000 (bytes into file)
  Flags:                             0x0
  Size of this header:               52 (bytes)
  Size of program headers:           32 (bytes)
  Number of program headers:         12
  Size of section headers:           40 (bytes)
  Number of section headers:         21
  Section header string table index: 1

Section Headers:
  [Nr] Name              Type            Addr     Off    Size   ES Flg Lk Inf Al
  [ 0]                   NULL            00000000 000000 000000 00      0   0  0
  [ 1] .shstrtab         STRTAB          00000000 00a1e0 00010d 00      0   0  1
  [ 2] .strtab           STRTAB          00000000 00a2ed 000012 00      0   0  0
  [ 3] .symtab           SYMTAB          00000000 00a300 000030 10      2   1  4
  [ 4] .ctrltext.0.0.0   PROGBITS        00000000 0001c0 000028 00  AX  0   0 16
  [ 5] .ctrldata.0.0.0   PROGBITS        00000000 0001f0 001fd8 00  WA  0   0 16
  [ 6] .ctrltext.0.1.0   PROGBITS        00000000 0021d0 000090 00  AX  0   0 16
  [ 7] .ctrldata.0.1.0   PROGBITS        00000000 002260 001f70 00  WA  0   0 16
  [ 8] .ctrltext.0.2.0   PROGBITS        00000000 0041d0 000040 00  AX  0   0 16
  [ 9] .ctrldata.0.2.0   PROGBITS        00000000 004210 001fc0 00  WA  0   0 16
  [10] .ctrltext.0.3.0   PROGBITS        00000000 0061d0 000090 00  AX  0   0 16
  [11] .ctrldata.0.3.0   PROGBITS        00000000 006260 001f70 00  WA  0   0 16
  [12] .ctrltext.0.4.0   PROGBITS        00000000 0081d0 000030 00  AX  0   0 16
  [13] .ctrldata.0.4.0   PROGBITS        00000000 008200 001fd0 00  WA  0   0 16
  [14] .dynstr           STRTAB          00000000 00a330 000007 00      0   0  0
  [15] .dynsym           DYNSYM          00000000 00a338 000040 10   A 14   1  8
  [16] .rela.dyn         RELA            00000000 00a378 000024 0c   A 15   0  8
  [17] .group.0          GROUP           00000000 00a3a0 00002c 04   A  3   2 16
  [18] .dynamic          DYNAMIC         00000000 00a1d0 000010 08   A 14   0  8
  [19] .note.xrt.co[...] NOTE            00000000 00a3cc 000014 00      0   0  1
  [20] .note.xrt.UID     NOTE            00000000 00a3e0 000020 00      0   0  1
Key to Flags:
  W (write), A (alloc), X (execute), M (merge), S (strings), I (info),
  L (link order), O (extra OS processing required), G (group), T (TLS),
  C (compressed), x (unknown), o (OS specific), E (exclude),
  p (processor specific)

COMDAT group section [   17] `.group.0' [dpu] contains 10 sections:
   [Index]    Name
   [    4]   .ctrltext.0.0.0
   [    5]   .ctrldata.0.0.0
   [    6]   .ctrltext.0.1.0
   [    7]   .ctrldata.0.1.0
   [    8]   .ctrltext.0.2.0
   [    9]   .ctrldata.0.2.0
   [   10]   .ctrltext.0.3.0
   [   11]   .ctrldata.0.3.0
   [   12]   .ctrltext.0.4.0
   [   13]   .ctrldata.0.4.0

Program Headers:
  Type           Offset   VirtAddr   PhysAddr   FileSiz MemSiz  Flg Align
  PHDR           0x000034 0x00000000 0x00000000 0x00180 0x00180 R   0
readelf: Error: the PHDR segment is not covered by a LOAD segment
  LOAD           0x0001c0 0x00000000 0x00000000 0x00028 0x00028 R E 0x10
  LOAD           0x0001f0 0x00000000 0x00000000 0x01fd8 0x01fd8 RW  0x10
  LOAD           0x0021d0 0x00000000 0x00000000 0x00090 0x00090 R E 0x10
  LOAD           0x002260 0x00000000 0x00000000 0x01f70 0x01f70 RW  0x10
  LOAD           0x0041d0 0x00000000 0x00000000 0x00040 0x00040 R E 0x10
  LOAD           0x004210 0x00000000 0x00000000 0x01fc0 0x01fc0 RW  0x10
  LOAD           0x0061d0 0x00000000 0x00000000 0x00090 0x00090 R E 0x10
  LOAD           0x006260 0x00000000 0x00000000 0x01f70 0x01f70 RW  0x10
  LOAD           0x0081d0 0x00000000 0x00000000 0x00030 0x00030 R E 0x10
  LOAD           0x008200 0x00000000 0x00000000 0x01fd0 0x01fd0 RW  0x10
  DYNAMIC        0x00a1d0 0x00000000 0x00000000 0x00010 0x00010 RW  0x8

 Section to Segment mapping:
  Segment Sections...
   00     
   01     .ctrltext.0.0.0 
   02     .ctrldata.0.0.0 
   03     .ctrltext.0.1.0 
   04     .ctrldata.0.1.0 
   05     .ctrltext.0.2.0 
   06     .ctrldata.0.2.0 
   07     .ctrltext.0.3.0 
   08     .ctrldata.0.3.0 
   09     .ctrltext.0.4.0 
   10     .ctrldata.0.4.0 
   11     .dynamic 

Dynamic section at offset 0xa1d0 contains 2 entries:
  Tag        Type                         Name/Value
 0x00000007 (RELA)                       0x10
 0x00000008 (RELASZ)                     36 (bytes)

Relocation section '.rela.dyn' at offset 0xa378 contains 3 entries:
 Offset     Info    Type            Sym.Value  Sym. Name + Addend
00000270  00000102 unrecognized: 2       00000000   2 + 0
000002cc  00000202 unrecognized: 2       00000000   0 + 0
000003b8  00000302 unrecognized: 2       00000000   1 + 0

The decoding of unwind sections for machine type WE32100 is not currently supported.

Symbol table '.symtab' contains 3 entries:
   Num:    Value  Size Type    Bind   Vis      Ndx Name
     0: 00000000     0 NOTYPE  LOCAL  DEFAULT  UND 
     1: 00000000     0 FUNC    WEAK   DEFAULT  UND _Z3DPUPcPcPc
     2: 00000000     0 OBJECT  WEAK   DEFAULT    1 dpu

Symbol table '.dynsym' contains 4 entries:
   Num:    Value  Size Type    Bind   Vis      Ndx Name
     0: 00000000     0 NOTYPE  LOCAL  DEFAULT  UND 
     1: 00000000     0 OBJECT  GLOBAL DEFAULT    6 2
     2: 00000000     0 OBJECT  GLOBAL DEFAULT    6 0
     3: 00000000     0 OBJECT  GLOBAL DEFAULT    6 1

No version information found in this file.

Displaying notes found in: .note.xrt.configuration
  Owner                Data size 	Description
  XRT                  0x00000004	Unknown note type: (0x00000006)
   description data: 08 00 00 00 

Displaying notes found in: .note.xrt.UID
  Owner                Data size 	Description
  XRT                  0x00000010	GO BUILDID
   description data: 91 db a7 2c a4 cf 2a 42 15 0b a5 80 20 64 0f a4 
```