### PR TITLE
Remove i/p buffer1 null check, add o/p buffer_type for aie2ps and aie4 config

### DIFF
--- a/src/cpp/analyzer/reporter.cpp
+++ b/src/cpp/analyzer/reporter.cpp
@@ -25,6 +25,13 @@ namespace aiebu {
             if (!result)
                 throw error(error::error_code::invalid_elf, "Invalid ELF buffer");
         }
+        else if (m_buffer_type == aiebu::aiebu_assembler::buffer_type::elf_aie2_config ||
+            m_buffer_type == aiebu::aiebu_assembler::buffer_type::elf_aie2ps ||
+            m_buffer_type == aiebu::aiebu_assembler::buffer_type::elf_aie2ps_config ||
+            m_buffer_type == aiebu::aiebu_assembler::buffer_type::elf_aie4 ||
+            m_buffer_type == aiebu::aiebu_assembler::buffer_type::elf_aie4_config) {
+               throw error(error::error_code::internal_error, "Not supported");
+        }
     }
 
     void reporter::elf_summary(std::ostream &stream) const
@@ -36,10 +43,6 @@ namespace aiebu {
             ELFIO::dump::header(stream, my_elf_reader );
             ELFIO::dump::section_headers( stream, my_elf_reader);
             ELFIO::dump::segment_headers( stream, my_elf_reader);
-        }
-        else if (m_buffer_type == aiebu::aiebu_assembler::buffer_type::elf_aie2ps) {
-            throw error(error::error_code::internal_error,
-                  "AIE2PS and AIE4 ELF are not supported");
         }
         else {
             throw error(error::error_code::invalid_buffer_type,
@@ -73,10 +76,6 @@ namespace aiebu {
         }
         else if (m_buffer_type == aiebu::aiebu_assembler::buffer_type::blob_instr_transaction) {
             ctrlcode_blob_summary(stream);
-        }
-        else if (m_buffer_type == aiebu::aiebu_assembler::buffer_type::elf_aie2ps) {
-            throw error(error::error_code::internal_error,
-                  "AIE2PS and AIE4 ELF are not supported");
         }
         else {
             throw error(error::error_code::invalid_buffer_type,
@@ -131,10 +130,6 @@ namespace aiebu {
         else if (m_buffer_type == aiebu::aiebu_assembler::buffer_type::blob_instr_transaction) {
             disassemble_blob(root);
         }
-        else if (m_buffer_type == aiebu::aiebu_assembler::buffer_type::elf_aie2ps) {
-            throw error(error::error_code::internal_error,
-                  "AIE2PS and AIE4 ELF are not supported");
-        }
         else {
             throw error(error::error_code::invalid_buffer_type,
                   "Invalid buffer type for disassembly");
@@ -177,10 +172,6 @@ namespace aiebu {
         }
         else if (m_buffer_type == aiebu::aiebu_assembler::buffer_type::blob_instr_transaction) {
             disassemble_blob(stream);
-        }
-        else if (m_buffer_type == aiebu::aiebu_assembler::buffer_type::elf_aie2ps) {
-            throw error(error::error_code::internal_error,
-                  "AIE2PS and AIE4 ELF are not supported");
         }
         else {
             throw error(error::error_code::invalid_buffer_type,

--- a/src/cpp/assembler/aiebu_assembler.cpp
+++ b/src/cpp/assembler/aiebu_assembler.cpp
@@ -36,9 +36,6 @@ aiebu_assembler(buffer_type type,
                 const std::vector<std::string>& libpaths,
                 const std::map<uint32_t, std::vector<char> >& ctrlpkt) : m_type(type)
 {
-  //if (buffer1.empty()) {
-  //  throw error(error::error_code::invalid_input, "Buffer1 is empty.");
-  //}
   if (type == buffer_type::blob_instr_dpu)
   {
     aiebu::assembler a(assembler::elf_type::aie2_dpu_blob);
@@ -79,11 +76,13 @@ aiebu_assembler(buffer_type type,
   {
     aiebu::assembler a(assembler::elf_type::aie2ps_config);
     elf_data = a.process(buffer1, libs, libpaths, patch_json, buffer2);
+    m_output_type = aiebu::aiebu_assembler::buffer_type::elf_aie2ps;
   }
   else if (type == buffer_type::aie4_config)
   {
     aiebu::assembler a(assembler::elf_type::aie4_config);
     elf_data = a.process(buffer1, libs, libpaths, patch_json, buffer2);
+    m_output_type = aiebu::aiebu_assembler::buffer_type::elf_aie2ps;
   }
   else {
     throw error(error::error_code::invalid_buffer_type, "Buffer_type not supported !!!");
@@ -135,6 +134,13 @@ aiebu_assembler_get_elf(enum aiebu_assembler_buffer_type type,
                         size_t pm_ctrlpkt_size)
 {
   int ret = 0;
+
+  if (buffer1 == nullptr && buffer1_size != 0)
+  {
+    std::cout << "ERROR: Invalid buffer1 size" << std::endl;
+    return -(static_cast<int>(aiebu::error::error_code::invalid_input));
+  }
+
   if (buffer2 == nullptr && buffer2_size != 0)
   {
     std::cout << "ERROR: Invalid buffer2 size" << std::endl;
@@ -144,18 +150,6 @@ aiebu_assembler_get_elf(enum aiebu_assembler_buffer_type type,
   if (patch_json == nullptr && patch_json_size !=0)
   {
     std::cout << "ERROR: Invalid patch json size" << std::endl;
-    return -(static_cast<int>(aiebu::error::error_code::invalid_input));
-  }
-
-  if (buffer1 == nullptr)
-  {
-    std::cout << "ERROR: Invalid input, buffer1 is NULL" << std::endl;
-    return -(static_cast<int>(aiebu::error::error_code::invalid_input));
-  }
-
-  if (buffer1_size == 0)
-  {
-    std::cout << "ERROR: Invalid buffer1 size" << std::endl;
     return -(static_cast<int>(aiebu::error::error_code::invalid_input));
   }
 

--- a/src/cpp/assembler/aiebu_assembler.cpp
+++ b/src/cpp/assembler/aiebu_assembler.cpp
@@ -64,25 +64,25 @@ aiebu_assembler(buffer_type type,
   {
     aiebu::assembler a(assembler::elf_type::config);
     elf_data = a.process(buffer1, libs, libpaths, patch_json, buffer2);
-    m_output_type = aiebu::aiebu_assembler::buffer_type::elf_aie2;
+    m_output_type = aiebu::aiebu_assembler::buffer_type::elf_aie2_config;
   }
   else if (type == buffer_type::asm_aie4)
   {
     aiebu::assembler a(assembler::elf_type::aie4_asm);
     elf_data = a.process(buffer1, libs, libpaths, patch_json);
-    m_output_type = aiebu::aiebu_assembler::buffer_type::elf_aie2ps;
+    m_output_type = aiebu::aiebu_assembler::buffer_type::elf_aie4;
   }
   else if (type == buffer_type::aie2ps_config)
   {
     aiebu::assembler a(assembler::elf_type::aie2ps_config);
     elf_data = a.process(buffer1, libs, libpaths, patch_json, buffer2);
-    m_output_type = aiebu::aiebu_assembler::buffer_type::elf_aie2ps;
+    m_output_type = aiebu::aiebu_assembler::buffer_type::elf_aie2ps_config;
   }
   else if (type == buffer_type::aie4_config)
   {
     aiebu::assembler a(assembler::elf_type::aie4_config);
     elf_data = a.process(buffer1, libs, libpaths, patch_json, buffer2);
-    m_output_type = aiebu::aiebu_assembler::buffer_type::elf_aie2ps;
+    m_output_type = aiebu::aiebu_assembler::buffer_type::elf_aie4_config;
   }
   else {
     throw error(error::error_code::invalid_buffer_type, "Buffer_type not supported !!!");

--- a/src/cpp/include/aiebu/aiebu_assembler.h
+++ b/src/cpp/include/aiebu/aiebu_assembler.h
@@ -33,6 +33,10 @@ class aiebu_assembler
       pdi_aie2,
       pdi_aie2ps,
       blob_control_packet_aie2,
+      elf_aie2_config,
+      elf_aie2ps_config,
+      elf_aie4,
+      elf_aie4_config,
       unspecified,
     };
 


### PR DESCRIPTION
#### Problem solved by the commit
1>  i/p buffer1 null check was breaking target = config.
2> Add output buffer type for the new configs added

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://github.com/Xilinx/aiebu/pull/99

#### How problem was solved, alternative solutions (if any) and why they were rejected
1>  Removed i/p buffer1 null check
2> Added output buffer type for the new configs added

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
Ran build and tests successfully

#### Documentation impact (if any)
