### PR TITLE
aie4: fix control packet offset correction

### DIFF
--- a/src/cpp/preprocessor/aie2ps/aie2ps_preprocessor_input.cpp
+++ b/src/cpp/preprocessor/aie2ps/aie2ps_preprocessor_input.cpp
@@ -78,7 +78,7 @@ namespace aiebu {
       // Check if the control packet offset is within the control packet size
       validate_json(control_packet_offset, control_packet_size, arg_index, offset_type::CONTROL_PACKET);
       // move 8 bytes(header) up for unifying the patching scheme between DPU sequence and transaction-buffer
-      uint32_t offset = control_packet_offset - 8;
+      uint32_t offset = control_packet_offset - m_control_packet_offset_correction;
 
       // TODO added symbols name hardcoded to ".pad.0" and col 0
       // this will change once compiler decide on how to generate multi col control packet design
@@ -138,8 +138,7 @@ namespace aiebu {
       uint32_t arg_index = get_32_bit_property(patch, "xrt_arg_id");
       // check if the offset is less than the size of the control packet
       validate_json(control_packet_offset, control_packet_size, arg_index, offset_type::CONTROL_PACKET);
-      // move 8 bytes(header) up for unifying the patching scheme between DPU sequence and transaction-buffer
-      uint32_t offset = control_packet_offset - 8;
+      uint32_t offset = control_packet_offset - m_control_packet_offset_correction;
       const uint32_t addend = get_32_bit_property(patch, "bo_offset");
 
       // TODO added symbols name hardcoded to ".pad.0" and col 0

--- a/src/cpp/preprocessor/aie2ps/aie2ps_preprocessor_input.h
+++ b/src/cpp/preprocessor/aie2ps/aie2ps_preprocessor_input.h
@@ -27,6 +27,7 @@ protected:
   std::vector<std::string> m_libpaths;
   std::vector<std::string> m_flags;
   uint32_t m_control_packet_index = 0xFFFFFFFF;
+  uint32_t m_control_packet_offset_correction = 8;
   enum class offset_type {
     CONTROL_PACKET,
     COALESED_BUFFER

--- a/src/cpp/preprocessor/aie4/aie4_preprocessor_input.h
+++ b/src/cpp/preprocessor/aie4/aie4_preprocessor_input.h
@@ -10,7 +10,10 @@ namespace aiebu {
 class aie4_preprocessor_input : public asm_preprocessor_input
 {
 public:
-  aie4_preprocessor_input() { control_packet_patching = symbol::patch_schema::control_packet_57_aie4;}
+  aie4_preprocessor_input() {
+    control_packet_patching = symbol::patch_schema::control_packet_57_aie4;
+    m_control_packet_offset_correction = 4;
+  }
 
 };
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
aie4 control packet offset correction is 4 while aie2ps its 8
 
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
