### PR TITLE
Update markdown-graphviz-svg url

### DIFF
--- a/specification/CMakeLists.txt
+++ b/specification/CMakeLists.txt
@@ -3,14 +3,14 @@
 if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
   add_custom_target(spec-tool-deps
     COMMAND wget -q -O markdown_graphviz_svg.py
-    https://raw.githubusercontent.com/Tanami/markdown-graphviz-svg/master/markdown_graphviz_svg.py
+    https://raw.githubusercontent.com/Tanami/markdown-graphviz-svg/master/src/markdown_graphviz_svg/markdown_graphviz_svg.py
     BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/markdown_graphviz_svg.py
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     )
 else()
   add_custom_target(spec-tool-deps
     COMMAND powershell wget -O markdown_graphviz_svg.py
-    https://raw.githubusercontent.com/Tanami/markdown-graphviz-svg/master/markdown_graphviz_svg.py
+    https://raw.githubusercontent.com/Tanami/markdown-graphviz-svg/master/src/markdown_graphviz_svg/markdown_graphviz_svg.py
     BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/markdown_graphviz_svg.py
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     )


### PR DESCRIPTION
#### Problem solved by the commit

Update the URL used to download markdown-graphviz-svg via wget. The previous location has stopped working with `404 Not Found` after https://github.com/Tanami/markdown-graphviz-svg/pull/2:
```
$ wget https://raw.githubusercontent.com/Tanami/markdown-graphviz-svg/master/markdown_graphviz_svg.py
--2025-07-02 09:20:53--  https://raw.githubusercontent.com/Tanami/markdown-graphviz-svg/master/markdown_graphviz_svg.py
Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 185.199.111.133, 185.199.108.133, 185.199.109.133, ...
Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|185.199.111.133|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
2025-07-02 09:20:53 ERROR 404: Not Found.
```
resulting in cryptic build error `AttributeError: module 'markdown_graphviz_svg' has no attribute 'GraphvizBlocksExtension'`, which happens because wget is creating an empty `markdown_graphviz_svg.py` file instead of causing an error.

