### PR TITLE
bug: converting 0xff/0xffff/0xffffffff to 0 with original is correct

### DIFF
--- a/src/cpp/ops/ops.cpp
+++ b/src/cpp/ops/ops.cpp
@@ -82,13 +82,9 @@ serialize(std::shared_ptr<assembler_state> state, std::vector<symbol>& symbols,
 
       if (arg.m_width == width_8)
       {
-        if (val == static_cast<uint32_t>(-1))
-          val = 0;
         ret.push_back(val & BYTE_MASK);
       } else if (arg.m_width == width_16)
       {
-        if (val == static_cast<uint32_t>(-1))
-          val = 0;
         // For opcode is 'apply_offset_57' and arg is 'offset',
         // if val is 0xFFFF means we need to patch the host address of 1st page of controlcode
         // and we can patch in host and firmware, we send "control-code-X" as symbol name and 0xFFFF in apply_offset_57
@@ -148,8 +144,6 @@ serialize(std::shared_ptr<assembler_state> state, std::vector<symbol>& symbols,
         ret.push_back((val >> SECOND_BYTE_SHIFT) & BYTE_MASK);
       } else if (arg.m_width == width_32)
       {
-        if (val == static_cast<uint32_t>(-1))
-          val = 0;
         ret.push_back((val >> FIRST_BYTE_SHIFT)& BYTE_MASK);
         ret.push_back((val >> SECOND_BYTE_SHIFT) & BYTE_MASK);
         ret.push_back((val >> THIRD_BYTE_SHIFT) & BYTE_MASK);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
bug: converting 0xff/0xffff/0xffffffff to 0 with original is correct

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
MASK_POLL_32            0x1C000, 0xFFFFFFFF, 0xCAFECAFE
get decoded as 
14000000 00c00100 00000000 fecafeca
while it should be 
14000000 00c00100 ffffffff fecafeca
#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
