### PR TITLE
check nested dependent jobs

### DIFF
--- a/src/cpp/preprocessor/asm/pager.cpp
+++ b/src/cpp/preprocessor/asm/pager.cpp
@@ -96,6 +96,11 @@ extractjobs(assembler_state& state, std::shared_ptr<job> pjob)
   }
   // Explicit dependencies (e.g. launch_job relation)
   jobids = union_of_lists_inorder<jobid_type>(jobids, pjob->m_dependentjobs);
+  for (auto& dep_job:pjob->m_dependentjobs)
+  {
+    auto dep_job_list =  extractjobs(state, state.m_jobmap[dep_job]);
+    jobids = union_of_lists_inorder<jobid_type>(jobids, dep_job_list);
+  }
   return jobids;
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
check nested dependent jobs

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
code was not check dependent jobs for a dependent job
it fails in below case
START_JOB 0
  LAUNCH_JOB 1
END_JOB

START_JOB_DEFERRED 1
  LAUNCH_JOB          2
  LOCAL_BARRIER       $lb0, 2
END_JOB

START_JOB_DEFERRED 2
  LOCAL_BARRIER       $lb0, 2
END_JOB

it will have job will take 2 pass in pager and add job 1 tow times

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
