### PR TITLE
Disable findpackage.cmake if cmake < 3.20

### DIFF
--- a/cmake/findpackage.cmake
+++ b/cmake/findpackage.cmake
@@ -3,6 +3,12 @@
 #
 message("-- Preparing aiebu CMake find_package() support files")
 
+if (CMAKE_VERSION VERSION_LESS "3.20.0")
+  # cmake_path(...) function was introduced in 3.20.0
+  message(WARNING "CMake version is less than 3.20.0, find_package is disabled")
+  return()
+endif()
+
 # Provides write_basic_package_version_file
 include(CMakePackageConfigHelpers)
 


### PR DESCRIPTION
#### Problem solved by the commit
cmake_path used in findpackage.cmake is available only in cmake >= 3.20.  XRT builds with an insane old version of cmake on CentOS7.9

