### PR TITLE
Add missing link with -pthread in gen-copy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,8 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+#        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
 
     runs-on: ${{ matrix.os }}
 

--- a/lib/src/CMakeLists.txt
+++ b/lib/src/CMakeLists.txt
@@ -72,7 +72,10 @@ target_include_directories(${AIEBU_COPY_EXE}
   ${AIEBU_SOURCE_DIR}/src/cpp/include
 )
 
-target_link_libraries(${AIEBU_COPY_EXE} xaiengine aiebu_static)
+target_link_libraries(${AIEBU_COPY_EXE} PRIVATE xaiengine aiebu_static)
+if (NOT WIN32)
+  target_link_libraries(${AIEBU_COPY_EXE} PRIVATE pthread)
+endif()
 
 add_custom_command(
   OUTPUT ${AIEBU_COPY_GEN_FILES}


### PR DESCRIPTION
#### Problem solved by the commit
call_once requires executable linked with -pthread.  What this really means is that when linking with libaiebu_static, one must add -pthread, we need this to trickle through the find_package, but right now I am just fixing in place.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The failure stack was this:
```
    __once=..., __f=...) at /opt/rh/gcc-toolset-9/root/usr/include/c++/9/mutex:697
697		__throw_system_error(__e);
242	  std::call_once(dynamic_flag, [this] {
237
238	void
239	elf_writer::
240	init_dynamic_sections()
241	{
242	  std::call_once(dynamic_flag, [this] {
```

#### Disable CI windows workflow 
Disable windows workflow until vcpkg issue is resolved
https://github.com/microsoft/vcpkg/issues/46657
