### PR TITLE
Change vcpkg feed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,14 +14,13 @@ on:
 
 # see binary-caching-github-actions-cache
 env:
-  VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
+  VCPKG_BINARY_SOURCES: "clear;nuget,https://pkgs.dev.azure.com/vcpkg/public/_packaging/public/nuget/v3/index.json,readwrite"
 
 jobs:
   build:
     strategy:
       matrix:
-#        os: [ubuntu-latest, windows-latest]
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
#### Problem solved by the commit
x-gha is no longer supported as of July 2025.
Caching is not implemented properly, still need to fix workflow for that.
