### PR TITLE
Use dynamic linking for aiebu-asm/dump for upstreaming

### DIFF
--- a/src/cpp/utils/asm/CMakeLists.txt
+++ b/src/cpp/utils/asm/CMakeLists.txt
@@ -30,24 +30,32 @@ target_link_libraries(aiebu-asm PRIVATE aiebu_static)
 
 if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
   target_link_libraries(aiebu-asm PRIVATE pthread)
-  target_link_options(aiebu-asm PRIVATE "-static")
-  set_target_properties(aiebu-asm PROPERTIES INSTALL_RPATH "" BUILD_RPATH "")
 
-  # Create a dynamically linked executable. aiebu-asm-dyn, on Linux for running
-  # valgrind, etc. This binary is not released for deployment but only used for
-  # internal testing. Note that valgrind known to report many glibc related
-  # errors when running with fully statically linked executables, hence the
-  # dynamically linked binary for testing
-  add_executable(aiebu-asm-dyn $<TARGET_OBJECTS:aiebu_asm_objects>)
-  target_link_libraries(aiebu-asm-dyn PRIVATE aiebu_static)
+  # Upstreaming does not allow statically linked executables.  AIEBU_UPSTREAM is
+  # set by projects that are built for upstreaming and includes AIEBU as a
+  # submodule
+  if (NOT AIEBU_UPSTREAM)
+    target_link_options(aiebu-asm PRIVATE "-static")
+    set_target_properties(aiebu-asm PROPERTIES INSTALL_RPATH "" BUILD_RPATH "")
+
+    # Create a dynamically linked executable. aiebu-asm-dyn, on Linux for running
+    # valgrind, etc. This binary is not released for deployment but only used for
+    # internal testing. Note that valgrind known to report many glibc related
+    # errors when running with fully statically linked executables, hence the
+    # dynamically linked binary for testing
+    add_executable(aiebu-asm-dyn $<TARGET_OBJECTS:aiebu_asm_objects>)
+    target_link_libraries(aiebu-asm-dyn PRIVATE aiebu_static)
+  endif()
 endif()
 
 # This custom target fails if aiebu-asm has any dynamic dependencies
-add_custom_target(asm_check_dynamic_deps ALL
-  COMMAND ${CMAKE_COMMAND} -E echo "Checking for dynamic dependencies ..."
-  COMMAND ${CMAKE_COMMAND} -P "${AIEBU_SOURCE_DIR}/cmake/depends.cmake" $<TARGET_FILE:aiebu-asm> aiebu-asm_depends.txt
-  DEPENDS aiebu-asm
-  )
+if (NOT AIEBU_UPSTREAM)
+  add_custom_target(asm_check_dynamic_deps ALL
+    COMMAND ${CMAKE_COMMAND} -E echo "Checking for dynamic dependencies ..."
+    COMMAND ${CMAKE_COMMAND} -P "${AIEBU_SOURCE_DIR}/cmake/depends.cmake" $<TARGET_FILE:aiebu-asm> aiebu-asm_depends.txt
+    DEPENDS aiebu-asm
+    )
+endif()
 
 install(TARGETS aiebu-asm
   RUNTIME DESTINATION ${AIEBU_INSTALL_BIN_DIR}

--- a/src/cpp/utils/dump/CMakeLists.txt
+++ b/src/cpp/utils/dump/CMakeLists.txt
@@ -25,24 +25,32 @@ target_link_libraries(aiebu-dump PRIVATE aiebu_static)
 
 if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
   target_link_libraries(aiebu-dump PRIVATE pthread)
-  target_link_options(aiebu-dump PRIVATE "-static")
-  set_target_properties(aiebu-dump PROPERTIES INSTALL_RPATH "" BUILD_RPATH "")
 
-  # Create a dynamically linked executable. aiebu-dump-dyn, on Linux for running
-  # valgrind, etc. This binary is not released for deployment but only used for
-  # internal testing. Note that valgrind known to report many glibc related
-  # errors when running with fully statically linked executables, hence the
-  # dynamically linked binary for testing
-  add_executable(aiebu-dump-dyn $<TARGET_OBJECTS:aiebu_dump_objects>)
-  target_link_libraries(aiebu-dump-dyn PRIVATE aiebu_static)
+  # Upstreaming does not allow statically linked executables.  AIEBU_UPSTREAM is
+  # set by projects that are built for upstreaming and includes AIEBU as a
+  # submodule
+  if (NOT AIEBU_UPSTREAM)
+    target_link_options(aiebu-dump PRIVATE "-static")
+    set_target_properties(aiebu-dump PROPERTIES INSTALL_RPATH "" BUILD_RPATH "")
+
+    # Create a dynamically linked executable. aiebu-dump-dyn, on Linux for
+    # running valgrind, etc. This binary is not released for deployment but only
+    # used for internal testing. Note that valgrind known to report many glibc
+    # related errors when running with fully statically linked executables,
+    # hence the dynamically linked binary for testing
+    add_executable(aiebu-dump-dyn $<TARGET_OBJECTS:aiebu_dump_objects>)
+    target_link_libraries(aiebu-dump-dyn PRIVATE aiebu_static)
+  endif()
 endif()
 
 # This custom target fails if aiebu-dump has any dynamic dependencies
-add_custom_target(dump_check_dynamic_deps ALL
-  COMMAND ${CMAKE_COMMAND} -E echo "Checking for dynamic dependencies ..."
-  COMMAND ${CMAKE_COMMAND} -P "${AIEBU_SOURCE_DIR}/cmake/depends.cmake" $<TARGET_FILE:aiebu-dump> aiebu-dump_depends.txt
-  DEPENDS aiebu-dump
-  )
+if (NOT AIEBU_UPSTREAM)
+  add_custom_target(dump_check_dynamic_deps ALL
+    COMMAND ${CMAKE_COMMAND} -E echo "Checking for dynamic dependencies ..."
+    COMMAND ${CMAKE_COMMAND} -P "${AIEBU_SOURCE_DIR}/cmake/depends.cmake" $<TARGET_FILE:aiebu-dump> aiebu-dump_depends.txt
+    DEPENDS aiebu-dump
+    )
+endif()
 
 install(TARGETS aiebu-dump
   RUNTIME DESTINATION ${AIEBU_INSTALL_BIN_DIR}


### PR DESCRIPTION
#### Problem solved by the commit
Use AIEBU_UPSTREAM which is set by projects that are built for upstreaming and includes AIEBU as a submodule.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Upstreaming does not allow statically linked executables.

