### PR TITLE
Remove _static suffix from static libraries on Linux

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -94,6 +94,9 @@ add_library(aiebu_static STATIC
 
 if (MSVC)
   target_link_libraries(aiebu_static advapi32)
+else()
+  # On linux use xrt_coreutil.a
+  set_target_properties(aiebu_static PROPERTIES OUTPUT_NAME "aiebu")
 endif()
 
 install (TARGETS aiebu_static


### PR DESCRIPTION
#### Problem solved by the commit
Static libraries are named same as shared libraries.  CMake targets are unchanged to distinguish linking with static vs shared, but refer to the renamed static library.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Upstreaming package content may not have _static.a

#### How problem was solved, alternative solutions (if any) and why they were rejected
Sample CMakeLists.txt change:
```
if (NOT MSVC)
  # On linux use xrt_coreutil.a
  set_target_properties(aiebu_static PROPERTIES OUTPUT_NAME "aiebu")
endif()
```
Both the build and install version of the static libraries are changed, but internal build targets that link against static libraries continue to refer to e.g. `aiebu_static`. Under the hood CMake is aware of the renaming.

While AIEBU only builds a static library, I chose to follow the XRT convention to support both static and shared just in case we add a shared library later.