### PR TITLE
Fix start of data section detection bug

### DIFF
--- a/src/cpp/preprocessor/asm/asm_parser.cpp
+++ b/src/cpp/preprocessor/asm/asm_parser.cpp
@@ -181,7 +181,9 @@ parse_lines(const std::vector<char>& data, std::string& file)
       insert_col_asmdata(std::make_shared<asm_data>(std::make_shared<operation>(sm[1].str(), sm[2].str()),
                                                     operation_type::op, code_section::unknown, 0, (uint32_t)-1,
                                                     linenumber, line, file));
-      if (!sm[1].str().compare("EOF"))
+      std::string op_name = sm[1].str();
+      std::transform(op_name.begin(), op_name.end(), op_name.begin(), ::tolower);
+      if (!op_name.compare("eof"))
         set_data_state(true);
     }
   }


### PR DESCRIPTION
#### Problem solved by the commit
AIEBU checks "EOF" in uppercase to mark start of data section whereas all other places AIEBU first converts all opcodes including EOF to lower case and then checks.
Currently only for marking data section start AIEBU is not converting it to lower case before checking

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Discovered while running disassembled asm having opcodes in lower case via aiebu-asm

#### How problem was solved, alternative solutions (if any) and why they were rejected
Fixed this issue by first converting EOF to lowercase and then checking it.

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
1> Ran aiebu-asm on disassembled asm and it created ELF successfully. Below disassembled ASM was used.

`start_job       0x0
    uc_dma_write_des    $r0, @label0
    wait_uc_dma $r0
    local_barrier       $lb0, 0x2
end_job
start_job       0x1
    local_barrier       $lb0, 0x2
    write_32    0x1A0634, 0x80000000
    wait_tcts   TILE_0_1, MEM_MM2S_0, 0x1
end_job
eof

.align 16
label0:
UC_DMA_BD        0x00000000,  0x001A0000,  @label1,  8,  0,  0
.align 4
label1:
.long    0x00000001
.long    0x00020000
.long    0x00000000
.long    0x00000000
.long    0x00000000
.long    0x00000000
.long    0x00000000
.long    0x80000000`


#### Documentation impact (if any)
