### PR TITLE
Add asm writer and helper functions: AIE2PS disassembler Part 1

### DIFF
--- a/src/cpp/common/disassembler_state.h
+++ b/src/cpp/common/disassembler_state.h
@@ -40,7 +40,7 @@ public:
         return local_ptr;
     }
 
-    const std::map<uint32_t, std::string>& get_externallabels() const {
+    const std::map<uint32_t, std::string>& get_external_labels() const {
         return external_labels;
     }
 

--- a/src/cpp/common/disassembler_state.h
+++ b/src/cpp/common/disassembler_state.h
@@ -44,7 +44,7 @@ public:
         return external_labels;
     }
 
-    void add_externallabel(uint32_t address, std::string label) {
+    void add_external_label(uint32_t address, std::string label) {
         external_labels[address] = std::move(label);
     }
 

--- a/src/cpp/common/disassembler_state.h
+++ b/src/cpp/common/disassembler_state.h
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+
+#ifndef AIEBU_SRC_CPP_COMMON_DISASSEMBLER_STATE_H
+#define AIEBU_SRC_CPP_COMMON_DISASSEMBLER_STATE_H
+
+#include <cstdint>
+#include <string>
+#include <vector>
+#include <map>
+#include <sstream>
+
+#include "aiebu/aiebu_error.h"
+
+namespace aiebu {
+
+class disassembler_state {
+private:
+    uint32_t position = 0;
+    std::map<uint32_t, std::string> labels;
+    std::map<uint32_t, std::string> external_labels;
+    std::map<uint32_t, std::pair<std::string, uint32_t>> local_ptr;
+
+public:
+    uint32_t get_address() const { return position; }
+
+    void increment_address(uint32_t offset) {
+        position += offset;
+    }
+
+    const std::map<uint32_t, std::string>& get_labels() const {
+        return labels;
+    }
+
+    void add_label(uint32_t addr, const std::string& label) {
+        labels[addr] = label;
+    }
+
+    const std::map<uint32_t, std::pair<std::string, uint32_t>>& get_local_ptrs() const {
+        return local_ptr;
+    }
+
+    const std::map<uint32_t, std::string>& get_externallabels() const {
+        return external_labels;
+    }
+
+    void add_externallabel(uint32_t address, std::string label) {
+        external_labels[address] = std::move(label);
+    }
+
+    void add_local_ptr(uint32_t address, const std::string& label, uint32_t offset) {
+        local_ptr[address] = std::make_pair(label, offset);
+    }
+
+    void reset() {
+        position = 0;
+        labels.clear();
+        external_labels.clear();
+        local_ptr.clear();
+    }
+
+    std::string to_string() const {
+        std::ostringstream oss;
+        oss << "[POS:" << position
+            << "\tLABELS:" << labels.size()
+            << "\tLOCAL_PTRS:" << local_ptr.size() << "]";
+        return oss.str();
+    }
+
+    std::string to_tile(uint32_t arg) {
+        uint32_t row = arg & 0x1F;   //NOLINT
+        uint32_t col = (arg >> 5) & 0x7F;  //NOLINT
+        return "TILE_" + std::to_string(col) + "_" + std::to_string(row);
+    }
+
+    // FOR AIE2PS
+    std::string to_actor(uint32_t val, uint32_t tile) {
+        uint32_t row = tile & 0x1F;  //NOLINT
+
+        if (row == 0) {  //NOLINT
+          // One SHIM TILE
+          switch(val)
+          {
+            case 0: return "SHIM_S2MM_0"; //NOLINT
+            case 1: return "SHIM_S2MM_1"; //NOLINT
+            case 6: return "SHIM_MM2S_0"; //NOLINT
+            case 7: return "SHIM_MM2S_1"; //NOLINT
+            default: throw error(error::error_code::invalid_asm, "Invalid Shim tile actor:" + std::to_string(val) + "\n");          }
+        }
+        else if (row == 1 || row == 2) { //NOLINT
+          // Two MEM TILE
+          switch(val)
+          {
+            case 0: return "MEM_S2MM_0"; //NOLINT
+            case 1: return "MEM_S2MM_1"; //NOLINT
+            case 2: return "MEM_S2MM_2"; //NOLINT
+            case 3: return "MEM_S2MM_3"; //NOLINT
+            case 4: return "MEM_S2MM_4"; //NOLINT
+            case 5: return "MEM_S2MM_5"; //NOLINT
+            case 6: return "MEM_MM2S_0"; //NOLINT
+            case 7: return "MEM_MM2S_1"; //NOLINT
+            case 8: return "MEM_MM2S_2"; //NOLINT
+            case 9: return "MEM_MM2S_3"; //NOLINT
+            case 10: return "MEM_MM2S_4"; //NOLINT
+            case 11: return "MEM_MM2S_5"; //NOLINT
+            default: throw error(error::error_code::invalid_asm, "Invalid Mem tile actor:" + std::to_string(val) + "\n");
+          }
+        }
+        else { // CORE TILE
+          switch(val)
+          {
+            case 0: return "TILE_S2MM_0"; //NOLINT
+            case 1: return "TILE_S2MM_1"; //NOLINT
+            case 6: return "TILE_MM2S_0"; //NOLINT
+            case 7: return "TILE_MM2S_1"; //NOLINT
+            case 15: return "TILE_CORE"; //NOLINT
+            default: throw error(error::error_code::invalid_asm, "Invalid Core tile actor:" + std::to_string(val) + "\n");
+          }
+        }
+    }
+};
+
+}// namespace aiebu
+
+#endif //AIEBU_COMMON_DISASSEMBLER_STATE_H_

--- a/src/cpp/common/writer.cpp
+++ b/src/cpp/common/writer.cpp
@@ -5,6 +5,8 @@
 #include "writer.h"
 
 #include "aiebu/aiebu_error.h"
+#include <iostream>
+#include <utility>
 
 namespace aiebu {
 
@@ -29,7 +31,8 @@ offset_type
 section_writer::
 tell() const
 {
-  return static_cast<offset_type>(m_data.size());
+  auto size = static_cast<offset_type>(m_data.size());
+  return size;
 }
 
 uint32_t
@@ -38,10 +41,11 @@ read_word(offset_type offset) const
 {
   if (offset + 3 >= m_data.size())
     throw error(error::error_code::internal_error, "reading beyond data size !!!");
-  return (m_data[offset + 3] << FORTH_BYTE_SHIFT)
+  uint32_t result = (m_data[offset + 3] << FORTH_BYTE_SHIFT)
          + (m_data[offset + 2] << THIRD_BYTE_SHIFT)
          + (m_data[offset + 1] << SECOND_BYTE_SHIFT)
          + m_data[offset];
+  return result;
 }
 
 void
@@ -64,6 +68,90 @@ padding(offset_type pagesize)
   auto padsize = pagesize - datasize;
   for( auto i=0U; i<padsize; ++i)
     write_byte(0x00);
+}
+
+asm_writer::asm_writer(std::ostream& stream)
+{
+  m_streams.push_back(&stream);
+}
+
+asm_writer::asm_writer(const std::string& filename)
+  : m_ofstream(std::make_unique<std::ofstream>(filename))
+{
+  if (!m_ofstream->is_open())
+    throw std::runtime_error("Failed to open file: " + filename);
+  m_streams.push_back(m_ofstream.get());
+}
+
+asm_writer::asm_writer(std::ostream& stream, const std::string& filename)
+  : m_ofstream(std::make_unique<std::ofstream>(filename))
+{
+  if (!m_ofstream->is_open())
+    throw std::runtime_error("Failed to open file: " + filename);
+  m_streams.push_back(&stream);
+  m_streams.push_back(m_ofstream.get());
+}
+
+asm_writer::~asm_writer() = default;
+template <typename Func>
+void for_all_streams(std::vector<std::ostream*>& streams, Func&& func) {
+  for (auto s : streams) {
+    std::forward<Func>(func)(s);
+  }
+}
+
+void asm_writer::write_label(const std::string& name)
+{
+  std::string clean_name = name;
+  if (!name.empty() && name.front() == '@')
+    clean_name = name.substr(1);
+  for_all_streams(m_streams, [&](std::ostream* s) { (*s) << clean_name << ":\n"; });
+  current_label = clean_name;
+}
+
+void asm_writer::write_attach_to_group(int col)
+{
+  for_all_streams(m_streams, [&](std::ostream* s) { (*s) << ".attach_to_group " << col << '\n'; });
+}
+
+void asm_writer::write_directive(const std::string& name)
+{
+  for_all_streams(m_streams, [&](std::ostream* s) { (*s) << name << '\n'; });
+}
+
+void asm_writer::write_endl(const std::string& name)
+{
+  std::string clean_name = name;
+  if (!clean_name.empty() && clean_name.front() == '@')
+    clean_name = clean_name.substr(1);
+  for_all_streams(m_streams, [&](std::ostream* s) { (*s) << ".endl " << clean_name << '\n'; });
+}
+
+void asm_writer::write_eop()
+{
+  for_all_streams(m_streams, [&](std::ostream* s) { (*s) << ".eop\n"; });
+}
+
+void asm_writer::write_operation(const std::string& name,
+                                  const std::vector<std::string>& args,
+                                  const std::string& label)
+{
+  for_all_streams(m_streams, [&](std::ostream* s) {
+    if (current_label == label) {
+      if (!(name == "start_job" || name == "end_job" || name == "eof")) {
+        (*s) << "    ";
+      }
+    }
+    (*s) << name << "\t";
+    for (size_t index = 0; index < args.size(); ++index) {
+      if (current_label != label)
+        (*s) << " ";
+      (*s) << args[index];
+      if (index < args.size() - 1)
+        (*s) << ", ";
+    }
+    (*s) << '\n';
+  });
 }
 
 }

--- a/src/cpp/common/writer.h
+++ b/src/cpp/common/writer.h
@@ -9,6 +9,8 @@
 #include <utility>
 #include <vector>
 #include <unordered_map>
+#include <fstream>
+#include <sstream>
 #include "symbol.h"
 #include "code_section.h"
 
@@ -39,7 +41,7 @@ public:
   section_writer(const section_writer& rhs) = default;
   section_writer& operator=(const section_writer& rhs) = delete;
   section_writer(section_writer &&s) = default;
-  //section_writer& operator=(const section_writer&& rhs) = default;
+
 
   virtual void write_byte(uint8_t byte);
 
@@ -150,7 +152,6 @@ public:
 
 class config_writer: public writer
 {
-  // map<kernel, map<instance, vector<section_writer object having control code pages and symbol info>>
   std::map<std::string, std::map<std::string, std::vector<std::shared_ptr<writer>>>> m_output;
   std::shared_ptr<const partition_info> m_partition;
 
@@ -165,6 +166,36 @@ public:
   }
 
   std::shared_ptr<const partition_info> get_partition_info() const { return m_partition; }
+};
+
+class asm_writer
+{
+public:
+  explicit asm_writer(std::ostream& stream); // For single stream
+  explicit asm_writer(const std::string& filename); // For file only
+  asm_writer(std::ostream& stream, const std::string& filename); // For both
+
+  ~asm_writer();
+
+  // Delete copy operations since we manage unique resources
+  asm_writer(const asm_writer&) = delete;
+  asm_writer& operator=(const asm_writer&) = delete;
+
+  // Delete move operations to be explicit
+  asm_writer(asm_writer&&) = delete;
+  asm_writer& operator=(asm_writer&&) = delete;
+
+  void write_directive(const std::string& directive);
+  void write_label(const std::string& label);
+  void write_attach_to_group(int colnum);
+  void write_operation(const std::string& name, const std::vector<std::string>& args, const std::string& label);
+  void write_endl(const std::string& label);
+  void write_eop();
+
+private:
+  std::vector<std::ostream*> m_streams;
+  std::unique_ptr<std::ofstream> m_ofstream;
+  std::string current_label;
 };
 
 }


### PR DESCRIPTION
#### Problem solved by the commit
Add helper functions for AIEBU disassembler that writes operation, label, directive, etc. to a stream as well as to a file.
Add disassembler state related to helper functions

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
N/A

#### How problem was solved, alternative solutions (if any) and why they were rejected
1> Added disassembler writer and disassembler state related functionality
Note - This PR is part of breaking the original PR into smaller sections.
original PR - https://github.com/Xilinx/aiebu/pull/118


#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
Built successfully and unit tests ran successfully.

#### Documentation impact (if any)
1> This PR is Part 1 of breaking the original PR into smaller sections.
original PR - https://github.com/Xilinx/aiebu/pull/118


