### PR TITLE
Robustness improvements

### DIFF
--- a/cmake/linux.cmake
+++ b/cmake/linux.cmake
@@ -8,4 +8,4 @@ if (AIEBU_PYTHON STREQUAL "ON")
 
   find_program (READELF eu-readelf REQUIRED)
 endif()
-add_compile_options(-Wall -Wextra -Werror)
+add_compile_options(-Wall -Wextra -Werror -fvisibility=hidden)

--- a/src/cpp/analyzer/packets.h
+++ b/src/cpp/analyzer/packets.h
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
 
+#ifndef AIEBU_PACKETS_H_
+#define AIEBU_PACKETS_H_
+
 #include <string>
 #include <cstdint>
 #include <iostream>
@@ -25,3 +28,5 @@ public:
 };
 
 }
+
+#endif

--- a/src/cpp/elf/aie2/aie2_blob_elfwriter.h
+++ b/src/cpp/elf/aie2/aie2_blob_elfwriter.h
@@ -34,8 +34,12 @@ public:
    * It add partition info in note section and finalize to generate elf
    */
   std::vector<char>
-  process(std::vector<std::shared_ptr<writer>>& mwriter) override
+  process(std::vector<std::shared_ptr<writer>> &mwriter) override
   {
+
+    if (mwriter.empty())
+      return {};
+
     auto mconfig_writer = std::dynamic_pointer_cast<aie2_config_writer>(mwriter[0]);
     init_symtab();
     uint32_t index=0;

--- a/src/cpp/elf/aie2/aie2_blob_elfwriter.h
+++ b/src/cpp/elf/aie2/aie2_blob_elfwriter.h
@@ -34,7 +34,7 @@ public:
    * It add partition info in note section and finalize to generate elf
    */
   std::vector<char>
-  process(std::vector<std::shared_ptr<writer>> &mwriter) override
+  process(std::vector<std::shared_ptr<writer>>& mwriter) override
   {
 
     if (mwriter.empty())

--- a/src/cpp/encoder/aie2/aie2_blob_encoder.h
+++ b/src/cpp/encoder/aie2/aie2_blob_encoder.h
@@ -47,7 +47,12 @@ public:
   process(std::shared_ptr<preprocessed_output> input) override
   {
     auto tinput = std::static_pointer_cast<aie2_config_preprocessed_output>(input);
-    // lets get partition info for first instance and compare this with other instances
+    // lets get partition info for first instance and compare this with other
+    // instances
+    if (tinput->get_kernel_map().empty())
+        return twriter;
+    if (tinput->get_kernel_map().begin()->second.get_instance_map().empty())
+        return twriter;
     auto pinfo_first_instance = tinput->get_kernel_map().begin()->second.get_instance_map().begin()->second->get_partition_info();
     auto output_writer = std::make_shared<aie2_config_writer>(pinfo_first_instance);
     twriter.push_back(output_writer);

--- a/src/cpp/preprocessor/aie2/aie2_blob_preprocessor_input.cpp
+++ b/src/cpp/preprocessor/aie2/aie2_blob_preprocessor_input.cpp
@@ -178,7 +178,7 @@ add_preemption_code(uint32_t col)
   void
   aie2_blob_preprocessor_input::
   validate_json(uint32_t offset, uint32_t size, uint32_t arg_index, offset_type type) const {
-    // Return if the offset and arg_index are within their respective sizes. 
+    // Return if the offset and arg_index are within their respective sizes.
     if ((offset <= size) && (arg_index <= MAX_ARG_INDEX)) {
       return;
     }
@@ -1002,10 +1002,9 @@ add_preemption_code(uint32_t col)
     boost::property_tree::read_json(patch_json, pt);
 
     const auto& pt_xrt_kernel_instance = pt.get_child_optional("xrt-kernels");
-    if (!pt_xrt_kernel_instance) {
-      std::cout << "xrt-kernels instance not found returning\n";
-      return;
-    }
+    if (!pt_xrt_kernel_instance)
+      throw error(error::error_code::invalid_input, "xrt-kernels not found in config json file");
+
     const auto& p_xrt_kernel_instance = pt_xrt_kernel_instance.get();
     for (const auto& [unused, ctrlcode] : p_xrt_kernel_instance)
     {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

1. Improve the handling of non compliant aie2 binaries. The bugs were discovered when adding the full ELF support.
2. On Linux hide, all symbols except explicitly exported ones

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA

#### How problem was solved, alternative solutions (if any) and why they were rejected
Check if a map or a vector is empty before trying to use its first element

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
ctest validated

#### Documentation impact (if any)
NA