### PR TITLE
Fix clang-tidy issues and enable some aie2ps testing on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,13 +86,13 @@ jobs:
     - name: Build (Linux)
       if: runner.os == 'Linux'
       run: |
-        cmake --build ${{github.workspace}}/build/Release --config Release
+        cmake --build ${{github.workspace}}/build/Release --config Release -j 4
 
     - name: Build (Windows)
       if: runner.os == 'Windows'
       run: |
-        cmake --build ${{github.workspace}}/build/WBuild --config Release
-        
+        cmake --build ${{github.workspace}}/build/WBuild --config Release -j 4
+
     - name: Install (Linux)
       if: runner.os == 'Linux'
       run: |
@@ -112,12 +112,12 @@ jobs:
     - name: Test (Linux)
       if: runner.os == 'Linux'
       run: |
-        cmake --build ${{github.workspace}}/build/Release --config Release --target test
+        cmake --build ${{github.workspace}}/build/Release --config Release --target test -j 4
 
     - name: Test (Windows)
       if: runner.os == 'Windows'
       run: |
-        cmake --build ${{github.workspace}}/build/WBuild --config Release --target run_tests
+        cmake --build ${{github.workspace}}/build/WBuild --config Release --target run_tests -j 4
 
     - name: Package (Linux)
       if: runner.os == 'Linux'

--- a/build/build.sh
+++ b/build/build.sh
@@ -31,10 +31,10 @@ function compile {
     cmake -B $BUILDDIR/$config $cmakeflags $BUILDDIR/..
     cmake --build $BUILDDIR/$config --config $config --verbose -j $CORE
     cmake --install $BUILDDIR/$config --config $config --prefix $BUILDDIR/$config/opt/xilinx/aiebu
-    cmake --build $BUILDDIR/$config --config $config --target test
+    cmake --build $BUILDDIR/$config --config $config --target test -j $CORE
 
     if [[ $run_memtest == "yes" ]]; then
-        cmake --build $BUILDDIR/$config --target test -- ARGS="-L memcheck -T memcheck"
+        cmake --build $BUILDDIR/$config --target test -j $CORE -- ARGS="-L memcheck -T memcheck"
     fi
     if [[ $config == "Release" ]]; then
         cmake --build $BUILDDIR/$config --config $config --target package --verbose -j $CORE

--- a/build/build22.bat
+++ b/build/build22.bat
@@ -85,8 +85,8 @@ if [%DEBUG%] == [1] (
    cmake --install %BUILDDIR%\%PLATFORM% --config Debug --prefix %BUILDDIR%\%PLATFORM%\Debug\xilinx\aiebu --verbose
    if errorlevel 1 (exit /B %errorlevel%)
 
-   echo cmake --build %BUILDDIR%\%PLATFORM% --config Debug --target run_tests
-   cmake --build %BUILDDIR%\%PLATFORM% --config Debug --target run_tests
+   echo cmake --build %BUILDDIR%\%PLATFORM% --config Debug --target run_tests -j %LOCAL_MSVC_PARALLEL_JOBS%
+   cmake --build %BUILDDIR%\%PLATFORM% --config Debug --target run_tests -j %LOCAL_MSVC_PARALLEL_JOBS%
    if errorlevel 1 (exit /B %errorlevel%)
 )
 
@@ -99,8 +99,8 @@ if [%RELEASE%] == [1] (
    cmake --install %BUILDDIR%\%PLATFORM% --config Release --prefix %BUILDDIR%\%PLATFORM%\Release\xilinx\aiebu --verbose
    if errorlevel 1 (exit /B %errorlevel%)
 
-   echo cmake --build %BUILDDIR%\%PLATFORM% --config Release --target run_tests
-   cmake --build %BUILDDIR%\%PLATFORM% --config Release --target run_tests
+   echo cmake --build %BUILDDIR%\%PLATFORM% --config Release --target run_tests -j %LOCAL_MSVC_PARALLEL_JOBS%
+   cmake --build %BUILDDIR%\%PLATFORM% --config Release --target run_tests -j %LOCAL_MSVC_PARALLEL_JOBS%
    if errorlevel 1 (exit /B %errorlevel%)
 
    ECHO ====================== Create SDK ZIP archive ============================

--- a/src/cpp/disassembler/disassembler.h
+++ b/src/cpp/disassembler/disassembler.h
@@ -5,6 +5,7 @@
 
 #include <memory>
 #include <string>
+#include <cstdint>
 #include "elfio/elfio.hpp"
 #include "common/disassembler_state.h"
 #include "specification/aie2ps/isa.h"
@@ -33,7 +34,7 @@ private:
     asm_writer m_asm_writer;
     const std::map<uint8_t, isa_op_disasm>* isa_op_map;
     isa_disassembler isa_disasm;
-    
+
     void process_sections();
     void print_section_info(const ELFIO::section* section) ;
     void process_text_section(const ELFIO::section* section, std::shared_ptr<disassembler_state> state);

--- a/src/cpp/preprocessor/aie2ps/aie2ps_preprocessor.h
+++ b/src/cpp/preprocessor/aie2ps/aie2ps_preprocessor.h
@@ -44,7 +44,7 @@ public:
   {
     //auto keys = tinput->get_keys();
     const std::string prefix = "opt_level_";
-    std::shared_ptr<asm_parser> parser(new asm_parser(tinput->get_data(), tinput->get_include_paths()));
+    std::shared_ptr<asm_parser> parser(new asm_parser(tinput->get_ctrlcode_data(), tinput->get_include_paths()));
     parser->parse_lines();
     auto collist = parser->get_col_list();
     isa i;

--- a/src/cpp/preprocessor/aie2ps/aie2ps_preprocessor_input.h
+++ b/src/cpp/preprocessor/aie2ps/aie2ps_preprocessor_input.h
@@ -72,17 +72,9 @@ public:
     }
   }
 
-  const std::vector<std::string> get_keys()
+  std::vector<char> &get_ctrlcode_data()
   {
-    std::vector<std::string> keys(m_data.size());
-    auto key_selector = [](auto pair){return pair.first;};
-    transform(m_data.begin(), m_data.end(), keys.begin(), key_selector);
-    return keys;
-  }
-
-  std::vector<char>& get_data()
-  {
-    return m_data["control_code"];
+    return get_data("control_code");
   }
 };
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,9 +3,8 @@
 
 project(tests CXX C)
 
-if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-  add_subdirectory(aie2ps-ctrlcode)
-endif()
+add_subdirectory(aie2ps-ctrlcode)
+
 
 if (AIEBU_NATIVE_BUILD)
  add_subdirectory(aie2-ctrlcode)

--- a/test/aie2-ctrlcode/basic/CMakeLists.txt
+++ b/test/aie2-ctrlcode/basic/CMakeLists.txt
@@ -38,7 +38,7 @@ add_test(NAME "aie2_basic_txn_md5sum"
   COMMAND cmake -P "${AIEBU_SOURCE_DIR}/cmake/md5sum-compare.cmake" "${CMAKE_CURRENT_BINARY_DIR}/basic.elf" "${CMAKE_CURRENT_SOURCE_DIR}/gold.md5"
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
-# Test interdependencies use ful when running ctest with -j
+# Test interdependencies use full when running ctest with -j
 set_tests_properties("aie2_basic_asm_redo" PROPERTIES DEPENDS "aie2_basic_asm")
 set_tests_properties("aie2_basic_asm_compare" PROPERTIES DEPENDS "aie2_basic_asm;aie2_basic_asm_redo")
 set_tests_properties("aie2_basic_txn_md5sum" PROPERTIES DEPENDS "aie2_basic_txn")

--- a/test/aie2-ctrlcode/dma_txn_ctrlpkt_pmload/CMakeLists.txt
+++ b/test/aie2-ctrlcode/dma_txn_ctrlpkt_pmload/CMakeLists.txt
@@ -26,3 +26,6 @@ add_test(NAME "aie2_dma_txn_ctrlpkt_pmload_md5sum"
 
 # Set properties for the test
 set_tests_properties("aie2_dma_txn_ctrlpkt_pmload" PROPERTIES LABELS memcheck)
+
+# Test interdependencies use full when running ctest with -j
+set_tests_properties("aie2_dma_txn_ctrlpkt_pmload_md5sum" PROPERTIES DEPENDS "aie2_dma_txn_ctrlpkt_pmload")

--- a/test/aie2-ctrlcode/mladf_txn/CMakeLists.txt
+++ b/test/aie2-ctrlcode/mladf_txn/CMakeLists.txt
@@ -24,3 +24,6 @@ add_test(NAME "aie2_mladf_txn_md5sum"
 
 # Set properties for the test
 set_tests_properties("aie2_mladf_txn" PROPERTIES LABELS memcheck)
+
+# Test interdependencies use full when running ctest with -j
+set_tests_properties("aie2_mladf_txn_md5sum" PROPERTIES DEPENDS "aie2_mladf_txn")

--- a/test/aie2ps-ctrlcode/CMakeLists.txt
+++ b/test/aie2ps-ctrlcode/CMakeLists.txt
@@ -24,44 +24,45 @@ foreach(tfile ${tfiles})
     COMMAND aiebu-asm  -t aie2ps -c "${tfile}" -o "${samplecppelf}"
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
-  if (AIEBU_PYTHON STREQUAL "ON")
-    add_test(NAME ${sample}
-      COMMAND "${AIEBU_SOURCE_DIR}/src/python/aiebu/control_asm_disasm.py" --disable_dump_map "${tfile}" -o "${sampleelf}"
-      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+  if (NOT (AIEBU_PYTHON STREQUAL "ON"))
+    continue()
+  if (NOT (${CMAKE_SYSTEM_NAME} STREQUAL "Linux"))
+    continue()
 
-    add_test(NAME ${sample}_elftolegacy
-      COMMAND "${AIEBU_SOURCE_DIR}/src/python/aiebu/elf_to_legacy.py" "-o" "${sampleouttxt}" "-i" "${sampleelf}"
-      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+  add_test(NAME ${sample}
+    COMMAND "${AIEBU_SOURCE_DIR}/src/python/aiebu/control_asm_disasm.py" --disable_dump_map "${tfile}" -o "${sampleelf}"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
-    add_test(NAME ${sample}_elftolegacy_cpp
-      COMMAND "${AIEBU_SOURCE_DIR}/src/python/aiebu/elf_to_legacy.py" "-o" "${samplecppouttxt}" "-i" "${samplecppelf}"
-      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+  add_test(NAME ${sample}_elftolegacy
+    COMMAND "${AIEBU_SOURCE_DIR}/src/python/aiebu/elf_to_legacy.py" "-o" "${sampleouttxt}" "-i" "${sampleelf}"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
-    add_test(NAME "${sample}_compare"
-      COMMAND ${CMAKE_COMMAND} -E compare_files "${sampleouttxt}" "${CMAKE_CURRENT_SOURCE_DIR}/${sampletxt}"
-      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+  add_test(NAME ${sample}_elftolegacy_cpp
+    COMMAND "${AIEBU_SOURCE_DIR}/src/python/aiebu/elf_to_legacy.py" "-o" "${samplecppouttxt}" "-i" "${samplecppelf}"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
-    add_test(NAME "${sample}_compare_cpp"
-      COMMAND ${CMAKE_COMMAND} -E compare_files "${samplecppouttxt}" "${CMAKE_CURRENT_SOURCE_DIR}/${sampletxt}"
-      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+  add_test(NAME "${sample}_compare"
+    COMMAND ${CMAKE_COMMAND} -E compare_files "${sampleouttxt}" "${CMAKE_CURRENT_SOURCE_DIR}/${sampletxt}"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
-    if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-      add_test(NAME "${sample}_readelf"
-        COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/run-readelf.sh" "${sampleelf}" "${sampleelftext}"
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+  add_test(NAME "${sample}_compare_cpp"
+    COMMAND ${CMAKE_COMMAND} -E compare_files "${samplecppouttxt}" "${CMAKE_CURRENT_SOURCE_DIR}/${sampletxt}"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
-      add_test(NAME "${sample}_compareelf"
-        COMMAND ${CMAKE_COMMAND} -E compare_files "${sampleelftext}" "${CMAKE_CURRENT_SOURCE_DIR}/${samplegold}"
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-    endif()
+  add_test(NAME "${sample}_readelf"
+    COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/run-readelf.sh" "${sampleelf}" "${sampleelftext}"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
-    add_test(NAME "${sample}_disassemble"
-      COMMAND "${AIEBU_SOURCE_DIR}/src/python/aiebu/control_asm_disasm.py" "-d" "${sampleelf}" "-o" "${sampledisasm}"
-      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+  add_test(NAME "${sample}_compareelf"
+    COMMAND ${CMAKE_COMMAND} -E compare_files "${sampleelftext}" "${CMAKE_CURRENT_SOURCE_DIR}/${samplegold}"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
-    set_tests_properties(${sample} "${sample}_elftolegacy" "${sample}_disassemble" PROPERTIES ENVIRONMENT
-      "PYTHONPATH=${AIEBU_SOURCE_DIR}")
-  endif()
+  add_test(NAME "${sample}_disassemble"
+    COMMAND "${AIEBU_SOURCE_DIR}/src/python/aiebu/control_asm_disasm.py" "-d" "${sampleelf}" "-o" "${sampledisasm}"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+  set_tests_properties(${sample} "${sample}_elftolegacy" "${sample}_disassemble" PROPERTIES ENVIRONMENT
+    "PYTHONPATH=${AIEBU_SOURCE_DIR}")
 endforeach()
 
 # MD5 name-based uuid generation was corrected to be

--- a/test/aie2ps-ctrlcode/CMakeLists.txt
+++ b/test/aie2ps-ctrlcode/CMakeLists.txt
@@ -65,6 +65,14 @@ foreach(tfile ${tfiles})
 
   set_tests_properties(${sample} "${sample}_elftolegacy" "${sample}_disassemble" PROPERTIES ENVIRONMENT
     "PYTHONPATH=${AIEBU_SOURCE_DIR}")
+
+  set_tests_properties("${sample}_elftolegacy" PROPERTIES DEPENDS "${sample}")
+  set_tests_properties("${sample}_elftolegacy_cpp" PROPERTIES DEPENDS "${sample}_cpp")
+  set_tests_properties("${sample}_compare" PROPERTIES DEPENDS "${sample}_elftolegacy")
+  set_tests_properties("${sample}_compare_cpp" PROPERTIES DEPENDS "${sample}_elftolegacy_cpp")
+  set_tests_properties("${sample}_readelf" PROPERTIES DEPENDS "${sample}")
+  set_tests_properties("${sample}_compareelf" PROPERTIES DEPENDS "${sample}_readelf")
+  set_tests_properties("${sample}_disassemble" PROPERTIES DEPENDS "${sample}")
 endforeach()
 
 # MD5 name-based uuid generation was corrected to be

--- a/test/aie2ps-ctrlcode/CMakeLists.txt
+++ b/test/aie2ps-ctrlcode/CMakeLists.txt
@@ -45,13 +45,15 @@ foreach(tfile ${tfiles})
       COMMAND ${CMAKE_COMMAND} -E compare_files "${samplecppouttxt}" "${CMAKE_CURRENT_SOURCE_DIR}/${sampletxt}"
       WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
-    add_test(NAME "${sample}_readelf"
-      COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/run-readelf.sh" "${sampleelf}" "${sampleelftext}"
-      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+    if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+      add_test(NAME "${sample}_readelf"
+	COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/run-readelf.sh" "${sampleelf}" "${sampleelftext}"
+	WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
-    add_test(NAME "${sample}_compareelf"
-      COMMAND ${CMAKE_COMMAND} -E compare_files "${sampleelftext}" "${CMAKE_CURRENT_SOURCE_DIR}/${samplegold}"
-      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+      add_test(NAME "${sample}_compareelf"
+	COMMAND ${CMAKE_COMMAND} -E compare_files "${sampleelftext}" "${CMAKE_CURRENT_SOURCE_DIR}/${samplegold}"
+	WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+    endif()
 
     add_test(NAME "${sample}_disassemble"
       COMMAND "${AIEBU_SOURCE_DIR}/src/python/aiebu/control_asm_disasm.py" "-d" "${sampleelf}" "-o" "${sampledisasm}"

--- a/test/aie2ps-ctrlcode/CMakeLists.txt
+++ b/test/aie2ps-ctrlcode/CMakeLists.txt
@@ -47,12 +47,12 @@ foreach(tfile ${tfiles})
 
     if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
       add_test(NAME "${sample}_readelf"
-	COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/run-readelf.sh" "${sampleelf}" "${sampleelftext}"
-	WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+        COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/run-readelf.sh" "${sampleelf}" "${sampleelftext}"
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
       add_test(NAME "${sample}_compareelf"
-	COMMAND ${CMAKE_COMMAND} -E compare_files "${sampleelftext}" "${CMAKE_CURRENT_SOURCE_DIR}/${samplegold}"
-	WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+        COMMAND ${CMAKE_COMMAND} -E compare_files "${sampleelftext}" "${CMAKE_CURRENT_SOURCE_DIR}/${samplegold}"
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
     endif()
 
     add_test(NAME "${sample}_disassemble"

--- a/test/aie2ps-ctrlcode/CMakeLists.txt
+++ b/test/aie2ps-ctrlcode/CMakeLists.txt
@@ -26,8 +26,10 @@ foreach(tfile ${tfiles})
 
   if (NOT (AIEBU_PYTHON STREQUAL "ON"))
     continue()
+  endif()
   if (NOT (${CMAKE_SYSTEM_NAME} STREQUAL "Linux"))
     continue()
+  endif()
 
   add_test(NAME ${sample}
     COMMAND "${AIEBU_SOURCE_DIR}/src/python/aiebu/control_asm_disasm.py" --disable_dump_map "${tfile}" -o "${sampleelf}"

--- a/test/aie2ps-ctrlcode/dump/CMakeLists.txt
+++ b/test/aie2ps-ctrlcode/dump/CMakeLists.txt
@@ -30,3 +30,8 @@ set_tests_properties("aie2ps_disassemble" PROPERTIES LABELS memcheck)
 set_tests_properties("aie2ps_disassemble_compare" PROPERTIES LABELS memcheck)
 set_tests_properties("aie2ps_disassembled_elf" PROPERTIES LABELS memcheck)
 set_tests_properties("aie2ps_disassemble_elf_md5sum" PROPERTIES LABELS memcheck)
+
+# Test interdependencies use full when running ctest with -j
+set_tests_properties("aie2ps_disassemble_compare" PROPERTIES DEPENDS "aie2ps_disassemble")
+set_tests_properties("aie2ps_disassembled_elf" PROPERTIES DEPENDS "aie2ps_disassemble")
+set_tests_properties("aie2ps_disassemble_elf_md5sum" PROPERTIES DEPENDS "aie2ps_disassembled_elf;aie2ps_asm")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

1. Remove duplicate `asm_preprocessor_input:get_keys()` as it is already present in the base class, `preprocessor_input`
2. Remove `asm_preprocessor_input:get_data()` as it was masking the virtual function `preprocessor_input::get_data(const std::string& key)`
3. Update CMake to enable some aie2ps testing on Windows

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Code cleanup and CMake updates

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Build and ctest validated

#### Documentation impact (if any)
NA