### PR TITLE
Add support for Multi uc control packets

### DIFF
--- a/src/cpp/common/assembler_state.cpp
+++ b/src/cpp/common/assembler_state.cpp
@@ -15,10 +15,10 @@ assembler_state::
 assembler_state(std::shared_ptr<std::map<std::string, std::shared_ptr<isa_op>>> isa,
                 std::vector<std::shared_ptr<asm_data>>& data,
                 std::map<std::string, std::shared_ptr<scratchpad_info>>& scratchpad,
-                std::map<std::string, uint32_t>& labelpageindex, uint32_t control_packet_index,
+                std::map<std::string, uint32_t>& labelpageindex, std::map<uint32_t, std::string>& ctrlpkt_id_map,
                 uint32_t optimize_level, bool makeunique)
                 : m_isa(std::move(isa)), m_data(data), m_scratchpad(scratchpad),
-                  m_labelpageindex(labelpageindex), m_control_packet_index(control_packet_index)
+                  m_labelpageindex(labelpageindex), m_ctrlpkt_id_map(ctrlpkt_id_map)
 {
   process_optimization(optimize_level);
   process(makeunique);
@@ -121,7 +121,6 @@ process(bool makeunique)
       if (!name.compare("apply_offset_57") && makeunique)
         apply_label_map[data->get_file() + ":" + data->get_operation()->get_args()[0].substr(1)]
                  = std::stoul(data->get_operation()->get_args()[1]);
-
     } else {
       throw error(error::error_code::internal_error, "Unknown type found!!!");
     }

--- a/src/cpp/common/assembler_state.h
+++ b/src/cpp/common/assembler_state.h
@@ -113,7 +113,6 @@ protected:
   std::vector<std::string> m_labellist;
   std::map<std::string, std::vector<std::string>> m_dependent_labelmap;
   std::set<std::string> m_opt_opcodes;
-  ///std::map<uint32_t, std::string> m_ctrlpkt_id_map;
   inline std::string gen_label_name(bool makeunique, const std::shared_ptr<asm_data> data)
   {
     return makeunique ? data->get_file() + ":" + data->get_operation()->get_name() : data->get_operation()->get_name();

--- a/src/cpp/common/assembler_state.h
+++ b/src/cpp/common/assembler_state.h
@@ -113,7 +113,7 @@ protected:
   std::vector<std::string> m_labellist;
   std::map<std::string, std::vector<std::string>> m_dependent_labelmap;
   std::set<std::string> m_opt_opcodes;
-
+  ///std::map<uint32_t, std::string> m_ctrlpkt_id_map;
   inline std::string gen_label_name(bool makeunique, const std::shared_ptr<asm_data> data)
   {
     return makeunique ? data->get_file() + ":" + data->get_operation()->get_name() : data->get_operation()->get_name();
@@ -141,7 +141,7 @@ protected:
   assembler_state(std::shared_ptr<std::map<std::string, std::shared_ptr<isa_op>>> isa,
                   std::vector<std::shared_ptr<asm_data>>& data,
                   std::map<std::string, std::shared_ptr<scratchpad_info>>& scratchpad,
-                  std::map<std::string, uint32_t>& labelpageindex, uint32_t control_packet_index,
+                  std::map<std::string, uint32_t>& labelpageindex, std::map<uint32_t, std::string>& ctrlpkt_id_map,
                   uint32_t optimize_level, bool makeunique);
   assembler_state(const assembler_state& rhs) = default;
   assembler_state& operator=(const assembler_state& rhs) = default;
@@ -157,8 +157,7 @@ public:
   std::map<std::string, std::shared_ptr<scratchpad_info>>& m_scratchpad;
   std::map<std::string, std::vector<std::string>> m_patch;
   std::map<std::string, uint32_t>& m_labelpageindex;
-  uint32_t m_control_packet_index;
-  std::string m_controlpacket_padname;
+  std::map<uint32_t, std::string>& m_ctrlpkt_id_map;
 
   HEADER_ACCESS_GET_SET(offset_type, pos);
 
@@ -290,9 +289,9 @@ class assembler_state_aie2ps : public assembler_state
   assembler_state_aie2ps(std::shared_ptr<std::map<std::string, std::shared_ptr<isa_op>>> isa,
                          std::vector<std::shared_ptr<asm_data>>& data,
                          std::map<std::string, std::shared_ptr<scratchpad_info>>& scratchpad,
-                         std::map<std::string, uint32_t>& labelpageindex, uint32_t control_packet_index,
+                         std::map<std::string, uint32_t>& labelpageindex, std::map<uint32_t, std::string>& ctrlpkt_id_map,
                          uint32_t optimize_level, bool makeunique)
-                  : assembler_state(isa, data, scratchpad, labelpageindex, control_packet_index, optimize_level, makeunique)
+                  : assembler_state(isa, data, scratchpad, labelpageindex, ctrlpkt_id_map, optimize_level, makeunique)
   {
     //shim_dma_patching = symbol::patch_schema::shim_dma_57;
     //control_packet_patching = symbol::patch_schema::control_packet_57;
@@ -354,9 +353,9 @@ class assembler_state_aie4 : public assembler_state
   assembler_state_aie4(std::shared_ptr<std::map<std::string, std::shared_ptr<isa_op>>> isa,
                        std::vector<std::shared_ptr<asm_data>>& data,
                        std::map<std::string, std::shared_ptr<scratchpad_info>>& scratchpad,
-                       std::map<std::string, uint32_t>& labelpageindex, uint32_t control_packet_index,
+                       std::map<std::string, uint32_t>& labelpageindex, std::map<uint32_t, std::string>& ctrlpkt_id_map,
                        uint32_t optimize_level, bool makeunique)
-                  : assembler_state(isa, data, scratchpad, labelpageindex, control_packet_index, optimize_level, makeunique)
+                  : assembler_state(isa, data, scratchpad, labelpageindex, ctrlpkt_id_map, optimize_level, makeunique)
   {
     //shim_dma_patching = symbol::patch_schema::shim_dma_57_aie4;
     //control_packet_patching = symbol::patch_schema::control_packet_57_aie4;

--- a/src/cpp/elf/aie2ps/aie2ps_elfwriter.h
+++ b/src/cpp/elf/aie2ps/aie2ps_elfwriter.h
@@ -20,7 +20,7 @@ public:
 class aie2ps_config_elf_writer: public elf_writer
 {
   constexpr static unsigned char ob_abi = 0x46;
-  constexpr static unsigned char version = 0x03;
+  constexpr static unsigned char version = 0x04;
   const std::string const_configuration = "configuration";
   const std::string xrt_configuration = ".note.xrt.configuration";
   const std::string const_kernel_signature = "kernel.signature";

--- a/src/cpp/elf/aie2ps/aie2ps_elfwriter.h
+++ b/src/cpp/elf/aie2ps/aie2ps_elfwriter.h
@@ -20,7 +20,7 @@ public:
 class aie2ps_config_elf_writer: public elf_writer
 {
   constexpr static unsigned char ob_abi = 0x46;
-  constexpr static unsigned char version = 0x04;
+  constexpr static unsigned char version = 0x03;
   const std::string const_configuration = "configuration";
   const std::string xrt_configuration = ".note.xrt.configuration";
   const std::string const_kernel_signature = "kernel.signature";

--- a/src/cpp/encoder/aie2ps/aie2ps_encoder.cpp
+++ b/src/cpp/encoder/aie2ps/aie2ps_encoder.cpp
@@ -28,26 +28,19 @@ fill_scratchpad(std::shared_ptr<section_writer> padwriter, const std::map<std::s
 
 void
 aie2ps_encoder::
-fill_control_packet_symbols(std::shared_ptr<section_writer> padwriter,const uint32_t col,const std::string& controlpacket_padname,
-                            std::vector<symbol>& syms,
-                            const std::map<std::string, std::shared_ptr<scratchpad_info>>& scratchpads)
+fill_controlpkt(std::shared_ptr<section_writer> ctrlpktwriter, const std::vector<char>& ctrlpkt)
 {
-  if (controlpacket_padname.empty())
-    return;
+  for (auto& val : ctrlpkt)
+    ctrlpktwriter->write_byte(val);
+}
 
-  if (scratchpads.find(controlpacket_padname) == scratchpads.end())
-    throw error(error::error_code::invalid_asm, "controlpacket padname " +
-                 controlpacket_padname + " not present in scratchpads\n");
-
-  auto& pad = scratchpads.at(controlpacket_padname);
+void
+aie2ps_encoder::
+fill_control_packet_symbols(std::shared_ptr<section_writer> ctrlpktwriter,
+                            std::vector<symbol>& syms)
+{
   for (auto& sym : syms)
-  {
-    if (sym.get_colnum() != col)
-      continue;
-    sym.set_section_name(get_PadSectionName(col));
-    sym.set_pos(sym.get_pos() + pad->get_offset());
-    padwriter->add_symbol(sym);
-  }
+    ctrlpktwriter->add_symbol(sym);
 }
 
 std::vector<std::shared_ptr<writer>>
@@ -61,27 +54,28 @@ process(std::shared_ptr<preprocessed_output> input)
   auto& totalsyms = tinput->get_symbols();
   m_debug.set_annotations(tinput->get_annotations());
   uint32_t optimizatiom_level = tinput->get_optimization_level();
+  auto& ctrlpkt = tinput->get_ctrlpkt();
+  auto& ctrlpkt_id_map = tinput->get_ctrlpkt_id_map();
 
   // for each colnum encode each page
   for (auto coldata: totalcoldata) {
     auto colnum = coldata.first;
-    std::string controlpacket_padname;
     for (auto& lpage : coldata.second->m_pages)
-    {
-      auto cp_name = page_writer(lpage, coldata.second->m_scratchpad, coldata.second->m_labelpageindex,
-                                 coldata.second->m_control_packet_index, optimizatiom_level);
-      if (!cp_name.empty())
-        controlpacket_padname = cp_name.substr(1);
+      page_writer(lpage, coldata.second->m_scratchpad, coldata.second->m_labelpageindex,
+                                 ctrlpkt_id_map, optimizatiom_level);
+
+    if (coldata.second->m_scratchpad.size()) {
+      auto padwriter = std::make_shared<section_writer>(get_PadSectionName(colnum), code_section::data);
+      fill_scratchpad(padwriter, coldata.second->m_scratchpad);
+      twriter.push_back(padwriter); 
     }
 
-    if (!coldata.second->m_scratchpad.size())
-      continue;
-
-    auto padwriter = std::make_shared<section_writer>(get_PadSectionName(colnum), code_section::data);
-    fill_scratchpad(padwriter, coldata.second->m_scratchpad);
-    fill_control_packet_symbols(padwriter, colnum, controlpacket_padname, totalsyms, coldata.second->m_scratchpad);
-
-    twriter.push_back(padwriter);
+    for (const auto& pair : ctrlpkt_id_map) {
+      auto ctrlpktwriter = std::make_shared<section_writer>(pair.second, code_section::data);
+      fill_controlpkt(ctrlpktwriter, ctrlpkt[pair.second]);
+      fill_control_packet_symbols(ctrlpktwriter, totalsyms);
+      twriter.push_back(ctrlpktwriter); 
+    }
   }
 
   // Report
@@ -121,11 +115,10 @@ findKey(const std::map<std::string, std::vector<std::string>>& myMap, const std:
   throw error(error::error_code::invalid_asm, "No key found corresponding to value:" + value + "\n");
 }
 
-
-std::string
+void
 aie2ps_encoder::
 page_writer(page& lpage, std::map<std::string, std::shared_ptr<scratchpad_info>>& scratchpad,
-            std::map<std::string, uint32_t>& labelpageindex, uint32_t control_packet_index, uint32_t optimization_level)
+  std::map<std::string, uint32_t>& labelpageindex, std::map<uint32_t, std::string>& ctrlpkt_id_map, uint32_t optimization_level)
 {
   // encode page
   std::vector<uint8_t> page_header = { 0xFF, 0xFF, 0x00, 0x00,
@@ -149,7 +142,7 @@ page_writer(page& lpage, std::map<std::string, std::shared_ptr<scratchpad_info>>
   std::vector<std::shared_ptr<asm_data>> all;
   all.insert(all.end(), lpage.m_text.begin(), lpage.m_text.end());
   all.insert(all.end(), lpage.m_data.begin(), lpage.m_data.end());
-  std::shared_ptr<assembler_state> page_state = create_assembler_state(m_isa, all, scratchpad, labelpageindex, control_packet_index, optimization_level,false);
+  std::shared_ptr<assembler_state> page_state = create_assembler_state(m_isa, all, scratchpad, labelpageindex, ctrlpkt_id_map, optimization_level,false);
 
   auto textwriter = std::make_shared<section_writer>(get_TextSectionName(colnum, pagenum), code_section::text);
   auto datawriter = std::make_shared<section_writer>(get_DataSectionName(colnum, pagenum), code_section::data);
@@ -231,7 +224,6 @@ page_writer(page& lpage, std::map<std::string, std::shared_ptr<scratchpad_info>>
   twriter.push_back(datawriter);
   m_report.addpage(lpage, page_state, textwriter->tell(), datawriter->tell());
 
-  return page_state->m_controlpacket_padname;
   // TODO add size and generate report
 }
 
@@ -243,7 +235,6 @@ patch57(const std::shared_ptr<section_writer> textwriter, std::shared_ptr<sectio
   uint64_t bd1 = datawriter->read_word(offset + 1*4); // NOLINT
   uint64_t bd2 = datawriter->read_word(offset + 2*4); // NOLINT
   uint64_t bd8 = datawriter->read_word(offset + 8*4); // NOLINT
-
   uint64_t arg = ((bd8 & 0x1FF) << 48) + ((bd2 & 0xFFFF) << 32) + (bd1 & 0xFFFFFFFF); // NOLINT
   patch = arg + patch;
   datawriter->write_word_at(offset + 1*4, patch & 0xFFFFFFFF); // NOLINT

--- a/src/cpp/encoder/aie2ps/aie2ps_encoder.h
+++ b/src/cpp/encoder/aie2ps/aie2ps_encoder.h
@@ -32,10 +32,14 @@ public:
   virtual std::string get_TextSectionName(uint32_t colnum, pageid_type pagenum) {return ".ctrltext." + std::to_string(colnum) + "." + std::to_string(pagenum); }
   virtual std::string get_DataSectionName(uint32_t colnum, pageid_type pagenum) {return ".ctrldata." + std::to_string(colnum) + "." + std::to_string(pagenum); }
   virtual std::string get_PadSectionName(uint32_t colnum) {return ".pad." + std::to_string(colnum); }
-  std::string page_writer(page& lpage, std::map<std::string, std::shared_ptr<scratchpad_info>>& scratchpad, std::map<std::string, uint32_t>& labelpageindex, uint32_t control_packet_index, uint32_t optimization_level);
+  void page_writer(page& lpage, std::map<std::string, std::shared_ptr<scratchpad_info>>& scratchpad,
+  std::map<std::string, uint32_t>& labelpageindex, std::map<uint32_t, std::string>& ctrlpkt_id_map, uint32_t optimization_level);
+
   virtual void patch57(const std::shared_ptr<section_writer> textwriter, std::shared_ptr<section_writer> datawriter, offset_type offset, uint64_t patch);
   void fill_scratchpad(std::shared_ptr<section_writer> padwriter,const std::map<std::string, std::shared_ptr<scratchpad_info>>& scratchpads);
-  void fill_control_packet_symbols(std::shared_ptr<section_writer> padwriter,const uint32_t col, const std::string& controlpacket_padname, std::vector<symbol>& syms, const std::map<std::string, std::shared_ptr<scratchpad_info>>& scratchpads);
+  void fill_controlpkt(std::shared_ptr<section_writer> padwriter, const std::vector<char>& ctrlpkt);
+  void fill_control_packet_symbols(std::shared_ptr<section_writer> ctrlpktwriter, std::vector<symbol>& syms);
+ 
   std::string findKey(const std::map<std::string, std::vector<std::string>>& myMap, const std::string& value);
 
   virtual std::shared_ptr<assembler_state>
@@ -43,9 +47,9 @@ public:
                          std::vector<std::shared_ptr<asm_data>>& data,
                          std::map<std::string, std::shared_ptr<scratchpad_info>>& scratchpad,
                          std::map<std::string, uint32_t>& labelpageindex,
-                         uint32_t control_packet_index, uint32_t optimize_level, bool makeunique)
+                         std::map<uint32_t, std::string>& ctrlpkt_id_map, uint32_t optimize_level, bool makeunique)
   {
-    return std::make_shared<assembler_state_aie2ps>(isa, data, scratchpad, labelpageindex, control_packet_index, optimize_level, makeunique);
+    return std::make_shared<assembler_state_aie2ps>(isa, data, scratchpad, labelpageindex, ctrlpkt_id_map, optimize_level, makeunique);
   }
 
   std::vector<std::shared_ptr<writer>> get_writers() { return twriter; }

--- a/src/cpp/encoder/aie4/aie4_encoder.h
+++ b/src/cpp/encoder/aie4/aie4_encoder.h
@@ -26,9 +26,9 @@ public:
                          std::vector<std::shared_ptr<asm_data>>& data,
                          std::map<std::string, std::shared_ptr<scratchpad_info>>& scratchpad,
                          std::map<std::string, uint32_t>& labelpageindex,
-                         uint32_t control_packet_index, uint32_t optimize_level, bool makeunique) override
+                         std::map<uint32_t, std::string>& ctrlpkt_id_map, uint32_t optimize_level, bool makeunique) override
   {
-    return std::make_shared<assembler_state_aie4>(isa, data, scratchpad, labelpageindex, control_packet_index, optimize_level, makeunique);
+    return std::make_shared<assembler_state_aie4>(isa, data, scratchpad, labelpageindex, ctrlpkt_id_map, optimize_level, makeunique);
   }
 
   void
@@ -37,7 +37,6 @@ public:
     offset = offset - textwriter->tell();
     uint64_t bd0 = datawriter->read_word(offset);
     uint64_t bd1 = datawriter->read_word(offset + 1*4);             // NOLINT
-
     uint64_t arg = (bd1 & 0xFFFFFFFF) + ((bd0 & 0x1FFFFFF) << 32); // NOLINT
     patch = arg + patch;
     datawriter->write_word_at(offset + 1*4, patch & 0xFFFFFFFF);    // NOLINT

--- a/src/cpp/ops/ops.cpp
+++ b/src/cpp/ops/ops.cpp
@@ -96,9 +96,10 @@ serialize(std::shared_ptr<assembler_state> state, std::vector<symbol>& symbols,
         // For opcode is 'apply_offset_57' and arg is 'offset',
         // if val is 0xFFFF means we need to patch the host address of 1st page of controlcode
         // and we can patch in host and firmware, we send "control-code-X" as symbol name and 0xFFFF in apply_offset_57
-        // if val == self.state->control_packet_index, we add "control-code-X" as symbol name and 0xFFFF in apply_offset_57
-        // if val is not 0xFFFF or self.state->control_packet_index, we can do patching in cert or host so add symbol info in elf
-        //    we send "arg index" as symbol name and arg offset in apply_offset_57
+        // if val == 0xFFFF, we add "control-code-X" as symbol name and 0xFFFF in apply_offset_57
+        // if val is not 0xFFFF , we can do patching in cert or host so add symbol info in elf
+        // we send "arg index" as symbol name and arg offset in apply_offset_57
+        // m_ctrlpkt_id_map contains control packet id (xrt_id) as key and symbol name as value
         if (!m_opcode->get_code_name().compare("apply_offset_57") && !arg.get_name().compare("offset"))
         {
           if (state->m_ctrlpkt_id_map.find(val) != state->m_ctrlpkt_id_map.end())
@@ -116,9 +117,7 @@ serialize(std::shared_ptr<assembler_state> state, std::vector<symbol>& symbols,
                                  + "." + std::to_string(pagenum),
                                  state->get_shim_dma_patching());
             ++index;
-
           }
-
 
           // arg 0 to 6 and be patched in CERT.
           // Beyond that its elfloader/host responsibility to patch mandatorily

--- a/src/cpp/ops/ops.cpp
+++ b/src/cpp/ops/ops.cpp
@@ -101,7 +101,9 @@ serialize(std::shared_ptr<assembler_state> state, std::vector<symbol>& symbols,
         //    we send "arg index" as symbol name and arg offset in apply_offset_57
         if (!m_opcode->get_code_name().compare("apply_offset_57") && !arg.get_name().compare("offset"))
         {
-          if (val == state->m_control_packet_index || val == offset_type_marker)       // NOLINT
+          if (state->m_ctrlpkt_id_map.find(val) != state->m_ctrlpkt_id_map.end())
+            sval = state->m_ctrlpkt_id_map[val];
+          else if (val == offset_type_marker)
             sval = "control-code-" + std::to_string(colnum);
 
           size_t index = state->find_label_entry(m_args[0].substr(1));
@@ -114,16 +116,14 @@ serialize(std::shared_ptr<assembler_state> state, std::vector<symbol>& symbols,
                                  + "." + std::to_string(pagenum),
                                  state->get_shim_dma_patching());
             ++index;
+
           }
-          if (val == state->m_control_packet_index && !arg.get_name().compare("offset") && m_args.size() == 4)
-            state->m_controlpacket_padname = m_args[3];
+
 
           // arg 0 to 6 and be patched in CERT.
           // Beyond that its elfloader/host responsibility to patch mandatorily
           if (val > 6 && val != offset_type_marker)
             std::cout <<"WARNING: Apply_offset_57 has arg index " << val << " > 6, Should be mandatorily patched in host!!!\n";
-          if (val == state->m_control_packet_index)
-            val = offset_type_marker;
           else if (val != offset_type_marker)
           {
             // val is arg index, to get offset x2
@@ -131,21 +131,6 @@ serialize(std::shared_ptr<assembler_state> state, std::vector<symbol>& symbols,
           }
 
           index = state->find_label_entry(m_args[0].substr(1));
-          if (!arg.get_name().compare("offset") && m_args.size() == 4)
-          {
-            auto usymbo = m_args[3].substr(1);
-            if (state->m_scratchpad.find(usymbo) != state->m_scratchpad.end())
-            {
-              auto num_entries = state->parse_num_arg(m_args[1]);
-              for (uint32_t numbd = 0; numbd < num_entries; ++numbd)
-              {
-                auto label = state->get_label_at(index);
-                state->m_patch[m_args[3]].emplace_back(label);
-                ++index;
-              }
-            }
-          }
-
         }
         if (!state->is_optimization_enabled_for_op(m_opcode->get_code_name())){
           ret.push_back(val & BYTE_MASK);

--- a/src/cpp/ops/ops.cpp
+++ b/src/cpp/ops/ops.cpp
@@ -131,6 +131,20 @@ serialize(std::shared_ptr<assembler_state> state, std::vector<symbol>& symbols,
           }
 
           index = state->find_label_entry(m_args[0].substr(1));
+          if (!arg.get_name().compare("offset") && m_args.size() == 4)
+          {
+            auto usymbo = m_args[3].substr(1);
+            if (state->m_scratchpad.find(usymbo) != state->m_scratchpad.end())
+            {
+              auto num_entries = state->parse_num_arg(m_args[1]);
+              for (uint32_t numbd = 0; numbd < num_entries; ++numbd)
+              {
+                auto label = state->get_label_at(index);
+                state->m_patch[m_args[3]].emplace_back(label);
+                ++index;
+              }
+            }
+          }
         }
         if (!state->is_optimization_enabled_for_op(m_opcode->get_code_name())){
           ret.push_back(val & BYTE_MASK);

--- a/src/cpp/preprocessor/aie2ps/aie2ps_preprocessed_output.h
+++ b/src/cpp/preprocessor/aie2ps/aie2ps_preprocessed_output.h
@@ -28,6 +28,8 @@ class aie2ps_preprocessed_output : public preprocessed_output
   bool isdebug = true;
   uint32_t m_optimization_level = 0;
   std::shared_ptr<const partition_info> m_partition;
+  std::map<std::string, std::vector<char>> m_ctrlpkt;
+  std::map<uint32_t, std::string> m_ctrlpkt_id_map;
 public:
 
   explicit aie2ps_preprocessed_output(std::shared_ptr<const partition_info> partition): m_partition(std::move(partition)) {}
@@ -77,6 +79,26 @@ public:
   uint32_t get_optimization_level()
   {
     return m_optimization_level;
+  }
+
+  void set_ctrlpkt(std::map<std::string, std::vector<char>>& ctrlpkt)
+  {
+    m_ctrlpkt = ctrlpkt;
+  }
+
+  std::map<std::string, std::vector<char>>& get_ctrlpkt()
+  {
+    return m_ctrlpkt;
+  }
+
+  std::map<uint32_t, std::string>& get_ctrlpkt_id_map()
+  {
+    return m_ctrlpkt_id_map;
+  }
+
+  void set_ctrlpkt_id_map( std::map<uint32_t, std::string>& ctrlpkt_id_map)
+  {
+    m_ctrlpkt_id_map = ctrlpkt_id_map;
   }
 };
 

--- a/src/cpp/preprocessor/aie2ps/aie2ps_preprocessor.h
+++ b/src/cpp/preprocessor/aie2ps/aie2ps_preprocessor.h
@@ -25,9 +25,9 @@ public:
                                                  std::vector<std::shared_ptr<asm_data>>& data,
                                                  std::map<std::string, std::shared_ptr<scratchpad_info>>& scratchpad,
                                                  std::map<std::string, uint32_t>& labelpageindex,
-                                                 uint32_t control_packet_index, uint32_t optimize_level, bool makeunique)
+                                                 std::map<uint32_t, std::string>& ctrlpkt_id_map, uint32_t optimize_level, bool makeunique)
   {
-    return std::make_shared<assembler_state_aie2ps>(isa, data, scratchpad, labelpageindex, control_packet_index, optimize_level, makeunique);
+    return std::make_shared<assembler_state_aie2ps>(isa, data, scratchpad, labelpageindex, ctrlpkt_id_map, optimize_level, makeunique);
   }
 
   virtual std::shared_ptr<preprocessed_output>
@@ -61,9 +61,11 @@ public:
       else
         std::cout << "Invalid flag: " << flag << ", ignored !!!" << std::endl;
     }
-
+    auto& controlpkts = tinput->get_controlpkt();
+    auto& ctrlpkt_id_map = tinput->get_ctrlpkt_id_map();
     toutput->set_optmization(optimize);
-
+    toutput->set_ctrlpkt(controlpkts);
+    toutput->set_ctrlpkt_id_map(ctrlpkt_id_map);
     toutput->set_annotations(parser->get_annotations());
 
     for (auto col: collist)
@@ -78,8 +80,8 @@ public:
       {
         // create state
         std::vector<std::shared_ptr<asm_data>> data = coldata.get_label_asmdata(label);
-        std::shared_ptr<assembler_state> state = create_assembler_state(m_isa, data, scratchpad, label_page_index, 0, optimize, true);
-        // create pages
+        std::shared_ptr<assembler_state> state = create_assembler_state(m_isa, data, scratchpad, label_page_index, ctrlpkt_id_map, optimize, true);  
+      // create pages
         pager(PAGE_SIZE).pagify(*state, col, pages, relative_page_index);
         label_page_index[get_pagelabel(label)] = relative_page_index;
         relative_page_index = pages.size();

--- a/src/cpp/preprocessor/aie2ps/aie2ps_preprocessor.h
+++ b/src/cpp/preprocessor/aie2ps/aie2ps_preprocessor.h
@@ -80,7 +80,7 @@ public:
       {
         // create state
         std::vector<std::shared_ptr<asm_data>> data = coldata.get_label_asmdata(label);
-        std::shared_ptr<assembler_state> state = create_assembler_state(m_isa, data, scratchpad, label_page_index, ctrlpkt_id_map, optimize, true);  
+        std::shared_ptr<assembler_state> state = create_assembler_state(m_isa, data, scratchpad, label_page_index, ctrlpkt_id_map, optimize, true);
       // create pages
         pager(PAGE_SIZE).pagify(*state, col, pages, relative_page_index);
         label_page_index[get_pagelabel(label)] = relative_page_index;

--- a/src/cpp/preprocessor/aie2ps/aie2ps_preprocessor_input.cpp
+++ b/src/cpp/preprocessor/aie2ps/aie2ps_preprocessor_input.cpp
@@ -70,19 +70,20 @@ namespace aiebu {
     if (!control_packet_patch_pt)
       return;
     const auto patchs = control_packet_patch_pt.get();
+
     for (auto pat : patchs)
     {
       auto patch = pat.second;
-      uint32_t control_packet_size = m_data[".ctrldata"].size();
+      auto ctrlpkt_id = get_32_bit_property(patch, "xrt_id");
+      auto ctrpkt_buf = m_ctrlpkt_id_map.at(ctrlpkt_id);
+      uint32_t control_packet_size = m_controlpkt[ctrpkt_buf].size(); 
       uint32_t control_packet_offset = get_32_bit_property(patch, "offset");
       // Check if the control packet offset is within the control packet size
       validate_json(control_packet_offset, control_packet_size, arg_index, offset_type::CONTROL_PACKET);
       // move 8 bytes(header) up for unifying the patching scheme between DPU sequence and transaction-buffer
       uint32_t offset = control_packet_offset - m_control_packet_offset_correction;
 
-      // TODO added symbols name hardcoded to ".pad.0" and col 0
-      // this will change once compiler decide on how to generate multi col control packet design
-      add_symbol({name, offset, 0, 0, addend, 0, ".pad.0", control_packet_patching});
+      add_symbol({name, offset, 0, 0, addend, 0, ctrpkt_buf, control_packet_patching});
     }
   }
 
@@ -97,12 +98,31 @@ namespace aiebu {
     const auto external_buffers = pt_external_buffers.get();
     for (auto& external_buffer : external_buffers)
     {
+      // added ARG_OFFSET to argidx to match with kernel argument index in xclbin
+      auto arg = get_32_bit_property(external_buffer.second, "xrt_id");
+      std::string name = std::to_string(arg + ARG_OFFSET);
+      if (external_buffer.second.get<bool>("ctrl_pkt_buffer", false)) {
+        m_control_packet_index = arg;
+        std::string path = external_buffer.second.get<std::string>("path", "default_path");
+        std::string ctrl_pkt_name = "." + external_buffer.second.get<std::string>("name", "default_name");
+        std::vector<char> ctrl_pkt_code;
+        auto paths = get_include_paths();
+        auto filepath = findFilePath(path, paths);
+        ctrl_pkt_code = readfile(filepath);
+        m_controlpkt[ctrl_pkt_name] = ctrl_pkt_code;
+        m_ctrlpkt_id_map.insert({arg, ctrl_pkt_name});
+      }
+
+    }
+
+    for (auto& external_buffer : external_buffers)
+    {
       const auto pt_coalesed_buffers = external_buffer.second.get_child_optional("coalesed_buffers");
       // added ARG_OFFSET to argidx to match with kernel argument index in xclbin
       auto arg = get_32_bit_property(external_buffer.second, "xrt_id");
       std::string name = std::to_string(arg + ARG_OFFSET);
-      if (external_buffer.second.get<bool>("ctrl_pkt_buffer", false))
-        m_control_packet_index = arg;
+      if (external_buffer.second.get<bool>("ctrl_pkt_buffer", false)) 
+        continue;
 
       if (pt_coalesed_buffers)
         extract_coalesed_buffers(name, external_buffer.second);
@@ -135,6 +155,8 @@ namespace aiebu {
       auto patch = pat.second;
       uint32_t control_packet_offset = get_32_bit_property(patch, "offset");
       uint32_t control_packet_size = m_data[".ctrldata"].size();
+
+
       uint32_t arg_index = get_32_bit_property(patch, "xrt_arg_id");
       // check if the offset is less than the size of the control packet
       validate_json(control_packet_offset, control_packet_size, arg_index, offset_type::CONTROL_PACKET);

--- a/src/cpp/preprocessor/aie2ps/aie2ps_preprocessor_input.cpp
+++ b/src/cpp/preprocessor/aie2ps/aie2ps_preprocessor_input.cpp
@@ -104,7 +104,7 @@ namespace aiebu {
       if (external_buffer.second.get<bool>("ctrl_pkt_buffer", false)) {
         m_control_packet_index = arg;
         std::string path = external_buffer.second.get<std::string>("path", "default_path");
-        std::string ctrl_pkt_name = "." + external_buffer.second.get<std::string>("name", "default_name");
+        std::string ctrl_pkt_name = ".ctrlpkt-" + std::to_string(m_control_packet_index);
         std::vector<char> ctrl_pkt_code;
         auto paths = get_include_paths();
         auto filepath = findFilePath(path, paths);

--- a/src/cpp/preprocessor/aie2ps/aie2ps_preprocessor_input.cpp
+++ b/src/cpp/preprocessor/aie2ps/aie2ps_preprocessor_input.cpp
@@ -82,7 +82,6 @@ namespace aiebu {
       validate_json(control_packet_offset, control_packet_size, arg_index, offset_type::CONTROL_PACKET);
       // move 8 bytes(header) up for unifying the patching scheme between DPU sequence and transaction-buffer
       uint32_t offset = control_packet_offset - m_control_packet_offset_correction;
-
       add_symbol({name, offset, 0, 0, addend, 0, ctrpkt_buf, control_packet_patching});
     }
   }
@@ -112,7 +111,6 @@ namespace aiebu {
         m_controlpkt[ctrl_pkt_name] = ctrl_pkt_code;
         m_ctrlpkt_id_map.insert({arg, ctrl_pkt_name});
       }
-
     }
 
     for (auto& external_buffer : external_buffers)
@@ -155,8 +153,6 @@ namespace aiebu {
       auto patch = pat.second;
       uint32_t control_packet_offset = get_32_bit_property(patch, "offset");
       uint32_t control_packet_size = m_data[".ctrldata"].size();
-
-
       uint32_t arg_index = get_32_bit_property(patch, "xrt_arg_id");
       // check if the offset is less than the size of the control packet
       validate_json(control_packet_offset, control_packet_size, arg_index, offset_type::CONTROL_PACKET);

--- a/src/cpp/preprocessor/aie2ps/aie2ps_preprocessor_input.h
+++ b/src/cpp/preprocessor/aie2ps/aie2ps_preprocessor_input.h
@@ -34,7 +34,8 @@ protected:
   };
 
   symbol::patch_schema control_packet_patching = symbol::patch_schema::control_packet_57;
-
+  std::map<uint32_t, std::string> m_ctrlpkt_id_map;
+ 
   void aiecompiler_json_parser(const boost::property_tree::ptree& pt);
   void dmacompiler_json_parser(const boost::property_tree::ptree& pt);
   void readmetajson(std::istream& patch_json);
@@ -76,6 +77,17 @@ public:
   {
     return get_data("control_code");
   }
+
+  std::map<std::string, std::vector<char>>& get_controlpkt()
+  {
+    return m_controlpkt;
+  }
+
+ std::map<uint32_t, std::string>& get_ctrlpkt_id_map()
+ {
+   return m_ctrlpkt_id_map;
+ }
+
 };
 
 
@@ -90,9 +102,8 @@ class asm_config_preprocessor_input : public preprocessor_input
 {
 protected: // NOLINT
   std::map<std::string, std::map<std::string, std::shared_ptr<asm_preprocessor_input>>> m_preprocessor_input;
-
+//  std::map<uint32_t, std::string> ctrlpkt_map_id;
 public:
-
   const std::map<std::string, std::map<std::string, std::shared_ptr<asm_preprocessor_input>>>&
   get_kernel_map() const { return m_preprocessor_input; }
 
@@ -101,6 +112,7 @@ public:
                     const std::vector<std::string>& flags,
                     const std::vector<std::string>& paths)
   {
+
     for (const auto& [unused, pic] : pinstance)
     {
       auto tname = pic.get<std::string>("id");

--- a/src/cpp/preprocessor/aie2ps/aie2ps_preprocessor_input.h
+++ b/src/cpp/preprocessor/aie2ps/aie2ps_preprocessor_input.h
@@ -83,13 +83,11 @@ public:
     return m_controlpkt;
   }
 
- std::map<uint32_t, std::string>& get_ctrlpkt_id_map()
- {
-   return m_ctrlpkt_id_map;
- }
-
+  std::map<uint32_t, std::string>& get_ctrlpkt_id_map()
+  {
+    return m_ctrlpkt_id_map;
+  }
 };
-
 
 class aie2ps_preprocessor_input : public asm_preprocessor_input
 {
@@ -102,7 +100,6 @@ class asm_config_preprocessor_input : public preprocessor_input
 {
 protected: // NOLINT
   std::map<std::string, std::map<std::string, std::shared_ptr<asm_preprocessor_input>>> m_preprocessor_input;
-//  std::map<uint32_t, std::string> ctrlpkt_map_id;
 public:
   const std::map<std::string, std::map<std::string, std::shared_ptr<asm_preprocessor_input>>>&
   get_kernel_map() const { return m_preprocessor_input; }

--- a/src/cpp/preprocessor/aie4/aie4_preprocessor.h
+++ b/src/cpp/preprocessor/aie4/aie4_preprocessor.h
@@ -27,9 +27,9 @@ public:
                                          std::vector<std::shared_ptr<asm_data>>& data,
                                          std::map<std::string, std::shared_ptr<scratchpad_info>>& scratchpad,
                                          std::map<std::string, uint32_t>& labelpageindex,
-                                         uint32_t control_packet_index, uint32_t optimize_level, bool makeunique) override
+                                         std::map<uint32_t, std::string>& ctrlpkt_id_map, uint32_t optimize_level, bool makeunique) override
   {
-    return std::make_shared<assembler_state_aie4>(isa, data, scratchpad, labelpageindex, control_packet_index, optimize_level, makeunique);
+    return std::make_shared<assembler_state_aie4>(isa, data, scratchpad, labelpageindex, ctrlpkt_id_map, optimize_level, makeunique);
   }
 };
 

--- a/src/cpp/preprocessor/preprocessor_input.h
+++ b/src/cpp/preprocessor/preprocessor_input.h
@@ -18,6 +18,7 @@ class preprocessor_input
 {
 protected:
   std::map<std::string, std::vector<char>> m_data;
+  std::map<std::string, std::vector<char>> m_controlpkt;
   std::vector<symbol> m_sym;
 
   class argument {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://amd.atlassian.net/wiki/spaces/AIE/pages/1099675323/Multi+uc+control+packet+design#Changes-in-external_buffer_id.json-(Interface-aiecompiler-%E2%86%94%EF%B8%8E-aiebu)

sample ELF:
```
ELF Header:
  Magic:   7f 45 4c 46 01 01 01 46 04 00 00 00 00 00 00 00
  Class:                             ELF32
  Data:                              2's complement, little endian
  Version:                           1 (current)
  OS/ABI:                            <unknown: 46>
  ABI Version:                       4
  Type:                              EXEC (Executable file)
  Machine:                           WE32100
  Version:                           0x1
  Entry point address:               0x0
  Start of program headers:          52 (bytes into file)
  Start of section headers:          65344 (bytes into file)
  Flags:                             0x0
  Size of this header:               52 (bytes)
  Size of program headers:           32 (bytes)
  Number of program headers:         10
  Size of section headers:           40 (bytes)
  Number of section headers:         19
  Section header string table index: 1

Section Headers:
  [Nr] Name              Type            Addr     Off    Size   ES Flg Lk Inf Al
  [ 0]                   NULL            00000000 000000 000000 00      0   0  0
  [ 1] .shstrtab         STRTAB          00000000 00fd48 0000e2 00      0   0  1
  [ 2] .strtab           STRTAB          00000000 00fe2a 000023 00      0   0  0
  [ 3] .symtab           SYMTAB          00000000 00fe50 000030 10      2   1  4
  [ 4] .ctrltext.0.0.0   PROGBITS        00000000 000180 00002c 00  AX  0   0 16
  [ 5] .ctrldata.0.0.0   PROGBITS        00000000 0001b0 001fd4 00  WA  0   0 16
  [ 6] .ctrltext.0.1.0   PROGBITS        00000000 002190 0000f0 00  AX  0   0 16
  [ 7] .ctrldata.0.1.0   PROGBITS        00000000 002280 001f10 00  WA  0   0 16
  [ 8] .ctrltext.0.2.0   PROGBITS        00000000 004190 000030 00  AX  0   0 16
  [ 9] .ctrldata.0.2.0   PROGBITS        00000000 0041c0 001fd0 00  WA  0   0 16
  [10] .ctrlpkt-3.0      PROGBITS        00000000 006190 000030 00  WA  0   0 16
  [11] .dump.0           PROGBITS        00000000 0061c0 009b72 00  WA  0   0 16
  [12] .dynstr           STRTAB          00000000 00fe80 00000e 00      0   0  0
  [13] .dynsym           DYNSYM          00000000 00fe90 000030 10   A 12   1  8
  [14] .rela.dyn         RELA            00000000 00fec0 000018 0c   A 13   0  8
  [15] .group.0          GROUP           00000000 00fee0 000024 04   A  3   2 16
  [16] .dynamic          DYNAMIC         00000000 00fd38 000010 08   A 12   0  8
  [17] .note.xrt.co[...] NOTE            00000000 00ff04 000014 00      0   0  1
  [18] .note.xrt.UID     NOTE            00000000 00ff18 000020 00      0   0  1
Key to Flags:
  W (write), A (alloc), X (execute), M (merge), S (strings), I (info),
  L (link order), O (extra OS processing required), G (group), T (TLS),
  C (compressed), x (unknown), o (OS specific), E (exclude),
  p (processor specific)

COMDAT group section [   15] `.group.0' [move_ddr_memtile_ctrlpkt] contains 8 sections:
   [Index]    Name
   [    4]   .ctrltext.0.0.0
   [    5]   .ctrldata.0.0.0
   [    6]   .ctrltext.0.1.0
   [    7]   .ctrldata.0.1.0
   [    8]   .ctrltext.0.2.0
   [    9]   .ctrldata.0.2.0
   [   10]   .ctrlpkt-3.0
   [   11]   .dump.0

Program Headers:
  Type           Offset   VirtAddr   PhysAddr   FileSiz MemSiz  Flg Align
  PHDR           0x000034 0x00000000 0x00000000 0x00140 0x00140 R   0
  LOAD           0x000180 0x00000000 0x00000000 0x0002c 0x0002c R E 0x10
  LOAD           0x0001b0 0x00000000 0x00000000 0x01fd4 0x01fd4 RW  0x10
  LOAD           0x002190 0x00000000 0x00000000 0x000f0 0x000f0 R E 0x10
  LOAD           0x002280 0x00000000 0x00000000 0x01f10 0x01f10 RW  0x10
  LOAD           0x004190 0x00000000 0x00000000 0x00030 0x00030 R E 0x10
  LOAD           0x0041c0 0x00000000 0x00000000 0x01fd0 0x01fd0 RW  0x10
  LOAD           0x006190 0x00000000 0x00000000 0x00030 0x00030 RW  0x10
  LOAD           0x0061c0 0x00000000 0x00000000 0x09b72 0x09b72 RW  0x10
  DYNAMIC        0x00fd38 0x00000000 0x00000000 0x00010 0x00010 RW  0x8

 Section to Segment mapping:
  Segment Sections...
   00
   01     .ctrltext.0.0.0
   02     .ctrldata.0.0.0
   03     .ctrltext.0.1.0
   04     .ctrldata.0.1.0
   05     .ctrltext.0.2.0
   06     .ctrldata.0.2.0
   07     .ctrlpkt-3.0
   08     .dump.0
   09     .dynamic

Dynamic section at offset 0xfd38 contains 2 entries:
  Tag        Type                         Name/Value
 0x00000007 (RELA)                       0xe
 0x00000008 (RELASZ)                     24 (bytes)

Relocation section '.rela.dyn' at offset 0xfec0 contains 2 entries:
 Offset     Info    Type            Sym.Value  Sym. Name + Addend
00000170  00000106 unrecognized: 6       00000000   .ctrlpkt-3 + 0
00000000  00000209 unrecognized: 9       00000000   0 + 0

The decoding of unwind sections for machine type WE32100 is not currently supported.

Symbol table '.symtab' contains 3 entries:
   Num:    Value  Size Type    Bind   Vis      Ndx Name
     0: 00000000     0 NOTYPE  LOCAL  DEFAULT  UND
     1: 00000000     0 FUNC    WEAK   DEFAULT  UND _Z3DPUPc
     2: 00000000     0 OBJECT  WEAK   DEFAULT    1 move_ddr_memtile[...]

Symbol table '.dynsym' contains 3 entries:
   Num:    Value  Size Type    Bind   Vis      Ndx Name
     0: 00000000     0 NOTYPE  LOCAL  DEFAULT  UND
     1: 00000000     0 OBJECT  GLOBAL DEFAULT    6 .ctrlpkt-3
     2: 00000000     0 OBJECT  GLOBAL DEFAULT   10 0

No version information found in this file.

Displaying notes found in: .note.xrt.configuration
  Owner                Data size        Description
  XRT                  0x00000004       Unknown note type: (0x00000006)
   description data: 01 00 00 00

Displaying notes found in: .note.xrt.UID
  Owner                Data size        Description
  XRT                  0x00000010       GO BUILDID
   description data: 64 b1 2e f3 11 b9 ad 03 5a 00 ae 8c a9 84 5e f1
```
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
