### PR TITLE
Declare dependencies to fix parallel test runs

### DIFF
--- a/test/aie2ps-ctrlcode/dump/CMakeLists.txt
+++ b/test/aie2ps-ctrlcode/dump/CMakeLists.txt
@@ -32,6 +32,7 @@ set_tests_properties("aie2ps_disassembled_elf" PROPERTIES LABELS memcheck)
 set_tests_properties("aie2ps_disassemble_elf_md5sum" PROPERTIES LABELS memcheck)
 
 # Test interdependencies use full when running ctest with -j
+set_tests_properties("aie2ps_disassemble" PROPERTIES DEPENDS "aie2ps_asm")
 set_tests_properties("aie2ps_disassemble_compare" PROPERTIES DEPENDS "aie2ps_disassemble")
 set_tests_properties("aie2ps_disassembled_elf" PROPERTIES DEPENDS "aie2ps_disassemble")
-set_tests_properties("aie2ps_disassemble_elf_md5sum" PROPERTIES DEPENDS "aie2ps_disassembled_elf;aie2ps_asm")
+set_tests_properties("aie2ps_disassemble_elf_md5sum" PROPERTIES DEPENDS "aie2ps_disassembled_elf")

--- a/test/cpp_test/cpp_api/CMakeLists.txt
+++ b/test/cpp_test/cpp_api/CMakeLists.txt
@@ -44,6 +44,7 @@ if(Boost_VERSION VERSION_GREATER 1.70)
   add_test(NAME "aie2ps_cpp_eff_net_coal_md5sum"
     COMMAND cmake -P "${AIEBU_SOURCE_DIR}/cmake/md5sum-compare.cmake" "${CMAKE_CURRENT_BINARY_DIR}/eff_net_coal.elf" "${AIEBU_SOURCE_DIR}/test/cpp_test/aie2ps/eff_net_coal/gold.md5"
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+  set_tests_properties("aie2ps_cpp_eff_net_coal_md5sum" PROPERTIES DEPENDS "aie2ps_cpp_eff_net_coal")
 
 # add_test(NAME "aie2ps_cpp_eff_net_ctrlpacket_md5sum"
 #   COMMAND cmake -P "${AIEBU_SOURCE_DIR}/cmake/md5sum-compare.cmake" "${CMAKE_CURRENT_BINARY_DIR}/eff_net_ctrlpacket.elf" "${AIEBU_SOURCE_DIR}/test/cpp_test/aie2ps/eff_net_ctrlpacket/gold.md5"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Running tests in parallel on clean build always fail due to missing dependencies

How to reproduce:

```
rm -rf bld
mkdir bld
cd bld
cmake ..
make -j8
ctest --stop-on-failure --output-on-failure -j8
```

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
aie2ps_disassemble creates empty file when run before aie2ps_asm

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added missing dependencies

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
