### PR TITLE
Make AIEBU use parent submodules of aie-rt and ELFIO if necessary

### DIFF
--- a/cmake/settings.cmake
+++ b/cmake/settings.cmake
@@ -92,27 +92,20 @@ set(AIEBU_GEN_DIR                   ${AIEBU_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}/
 # parents copy of ELFIO and/or AIE-RT. For example, XRT parent
 # repository can set the following in its CMake for aiebu to inherit
 # it:
-# set(AIEBU_AIE_RT_BIN_DIR ${XRT_BINARY_DIR})
-# set(AIEBU_ELFIO_SRC_DIR"${XRT_SOURCE_DIR}/src/runtime_src/core/common/elf")
-
-# These variables may be defined by the parent project as it may also
-# include AIE-RT and or ELFIO as a submodule AIEBU_AIE_RT_BIN_DIR,
-# AIEBU_AIE_RT_HEADER_DIR and AIEBU_ELFIO_SRC_DIR
-if (NOT (DEFINED AIEBU_AIE_RT_BIN_DIR))
-  set(AIEBU_AIE_RT_BIN_DIR ${AIEBU_BINARY_DIR})
+# set(AIEBU_AIE-RT_SRC_DIR ${XRT_SOURCE_DIR}/src/runtime_src/aie-rt)
+# set(AIEBU_ELFIO_SRC_DIR ${XRT_SOURCE_DIR}/src/runtime_src/core/common/elf)
+if (NOT DEFINED AIEBU_AIE-RT_SRC_DIR)
+  set(AIEBU_AIE-RT_SRC_DIR ${AIEBU_SOURCE_DIR}/lib/aie-rt)
 endif()
+message("-- AIEBU is using aie-rt from ${AIEBU_AIE-RT_SRC_DIR}")
 
-if (NOT (DEFINED AIEBU_AIE_RT_HEADER_DIR))
-  set(AIEBU_AIE_RT_HEADER_DIR "${AIEBU_BINARY_DIR}/lib/aie-rt/driver/driver-src/include")
-endif()
+# At configuration tine aie-rt installs header in binary dir
+# AIEBU needs aie-rt header include dir
+set(AIEBU_AIE-RT_HEADER_DIR ${AIEBU_BINARY_DIR}/lib/aie-rt/driver/driver-src/include)
 
-message("-- AIEBU is using aie-rt headers from ${AIEBU_AIE_RT_HEADER_DIR}")
-message("-- AIEBU is using aie-rt build from ${AIEBU_AIE_RT_BIN_DIR}")
-
-if (NOT (DEFINED AIEBU_ELFIO_SRC_DIR))
+if (NOT DEFINED AIEBU_ELFIO_SRC_DIR)
   set(AIEBU_ELFIO_SRC_DIR "${AIEBU_SOURCE_DIR}/src/cpp/ELFIO")
 endif()
-
 message("-- AIEBU is using ELFIO from ${AIEBU_ELFIO_SRC_DIR}")
 ################################################################
 # Global compile options

--- a/cmake/settings.cmake
+++ b/cmake/settings.cmake
@@ -89,8 +89,9 @@ set(AIEBU_GEN_DIR                   ${AIEBU_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}/
 
 # If this repository is used as a submodule, the parent repository may
 # set the following variables in CMake to make aiebu point to the
-# parents copy of ELFIO and/or AIE-RT. e.g, XRT parent repository can
-# set the following in its CMake for aiebu to inherit it:
+# parents copy of ELFIO and/or AIE-RT. For example, XRT parent
+# repository can set the following in its CMake for aiebu to inherit
+# it:
 # set(AIEBU_AIE_RT_BIN_DIR ${XRT_BINARY_DIR})
 # set(AIEBU_ELFIO_SRC_DIR"${XRT_SOURCE_DIR}/src/runtime_src/core/common/elf")
 
@@ -105,14 +106,14 @@ if (NOT (DEFINED AIEBU_AIE_RT_HEADER_DIR))
   set(AIEBU_AIE_RT_HEADER_DIR "${AIEBU_BINARY_DIR}/lib/aie-rt/driver/driver-src/include")
 endif()
 
-message("-- Using aie-rt headers from ${AIEBU_AIE_RT_HEADER_DIR}")
-message("-- Using aie-rt build from ${AIEBU_AIE_RT_BIN_DIR}")
+message("-- AIEBU is using aie-rt headers from ${AIEBU_AIE_RT_HEADER_DIR}")
+message("-- AIEBU is using aie-rt build from ${AIEBU_AIE_RT_BIN_DIR}")
 
 if (NOT (DEFINED AIEBU_ELFIO_SRC_DIR))
   set(AIEBU_ELFIO_SRC_DIR "${AIEBU_SOURCE_DIR}/src/cpp/ELFIO")
 endif()
 
-message("-- Using ELFIO from ${AIEBU_ELFIO_SRC_DIR}")
+message("-- AIEBU is using ELFIO from ${AIEBU_ELFIO_SRC_DIR}")
 ################################################################
 # Global compile options
 ################################################################

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -10,10 +10,10 @@
 # unfortunately doesn't prevent CMake from still wanting to include
 # subdir/cmake_install.cmake.  This function just creates an empty
 # subdir/cmake_install.cmake file.
-function(aiebu_add_subdirectory_disable_install_target subdir)
+function(aiebu_add_subdirectory_disable_install_target subdir bindir)
   set(CMAKE_SKIP_INSTALL_RULES TRUE)
-  file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${subdir})
-  file(TOUCH ${CMAKE_CURRENT_BINARY_DIR}/${subdir}/cmake_install.cmake)
+  file(MAKE_DIRECTORY ${bindir})
+  file(TOUCH ${bindir}/cmake_install.cmake)
   add_subdirectory(${ARGV})
   set(CMAKE_SKIP_INSTALL_RULES FALSE)
 endfunction()

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,13 +1,10 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024-2025 Advanced Micro Devices, Inc.
-if (${AIEBU_AIE_RT_BIN_DIR} STREQUAL ${AIEBU_BINARY_DIR})
-  message("-- Enabling build of aie-rt as submodule of aiebu")
-  set(XAIENGINE_BUILD_SHARED OFF CACHE BOOL "Force static build of xaiengine library" FORCE)
-  if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-    add_compile_options("-Wno-error=unused-parameter")
-  endif()
-  aiebu_add_subdirectory_disable_install_target(aie-rt/driver)
+set(XAIENGINE_BUILD_SHARED OFF CACHE BOOL "Force static build of xaiengine library" FORCE)
+if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+  add_compile_options("-Wno-error=unused-parameter")
 endif()
+aiebu_add_subdirectory_disable_install_target(${AIEBU_AIE-RT_SRC_DIR}/driver ${AIEBU_BINARY_DIR}/lib/aie-rt/driver)
 
 if (AIEBU_NATIVE_BUILD)
   add_subdirectory(src)

--- a/lib/src/CMakeLists.txt
+++ b/lib/src/CMakeLists.txt
@@ -34,7 +34,7 @@ if (NOT MSVC)
   target_compile_options(${AIEBU_PREEMPTION_EXE} PRIVATE -Wno-missing-field-initializers)
 endif()
 
-target_include_directories(${AIEBU_PREEMPTION_EXE} PRIVATE ${AIEBU_AIE_RT_HEADER_DIR})
+target_include_directories(${AIEBU_PREEMPTION_EXE} PRIVATE ${AIEBU_AIE-RT_HEADER_DIR})
 target_link_libraries(${AIEBU_PREEMPTION_EXE} xaiengine)
 
 # Create the working directory for custom command generated files
@@ -68,7 +68,7 @@ endif()
 
 target_include_directories(${AIEBU_COPY_EXE}
   PRIVATE
-  ${AIEBU_AIE_RT_HEADER_DIR}
+  ${AIEBU_AIE-RT_HEADER_DIR}
   ${AIEBU_SOURCE_DIR}/src/cpp/include
 )
 

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -37,7 +37,7 @@ target_include_directories(aiebu_library_objects
   ${CMAKE_CURRENT_SOURCE_DIR}/include
   ${AIEBU_SOURCE_DIR}
   ${AIEBU_ELFIO_SRC_DIR}
-  ${AIEBU_AIE_RT_HEADER_DIR}
+  ${AIEBU_AIE-RT_HEADER_DIR}
   ${AIEBU_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}
   ${Boost_INCLUDE_DIRS}
 

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -36,12 +36,12 @@ target_include_directories(aiebu_library_objects
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_CURRENT_SOURCE_DIR}/include
   ${AIEBU_SOURCE_DIR}
+  ${AIEBU_ELFIO_SRC_DIR}
   ${AIEBU_AIE_RT_HEADER_DIR}
   ${AIEBU_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}
   ${Boost_INCLUDE_DIRS}
 
   # The following should be spelled out in code
-  ${CMAKE_CURRENT_SOURCE_DIR}/ELFIO
   ${CMAKE_CURRENT_SOURCE_DIR}/preprocessor
   ${CMAKE_CURRENT_SOURCE_DIR}/preprocessor/aie2
   ${CMAKE_CURRENT_SOURCE_DIR}/encoder

--- a/src/cpp/utils/dump/CMakeLists.txt
+++ b/src/cpp/utils/dump/CMakeLists.txt
@@ -13,10 +13,10 @@ set_target_properties(aiebu_dump_objects PROPERTIES
 
 target_include_directories(aiebu_dump_objects
   PRIVATE
+  ${AIEBU_ELFIO_SRC_DIR}
   ${AIEBU_SOURCE_DIR}/src/cpp/include
   ${AIEBU_SOURCE_DIR}/src/cpp/cxxopts/include
   ${AIEBU_SOURCE_DIR}/src/cpp
-  ${AIEBU_SOURCE_DIR}/src/cpp/ELFIO
   ${AIEBU_SOURCE_DIR}/src/cpp/disassembler
   ${AIEBU_SOURCE_DIR}/src/cpp/common
   ${AIEBU_SOURCE_DIR}/src/cpp/ops


### PR DESCRIPTION
#### Problem solved by the commit
- When including AIEBU as a submodule in a parent project, AIEBU can use parent's version of aie-rt.
- When including AIEBU as a submodule in a parent project, AIEBU can use parent's version of ELFIO.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Earlier logic did not work at all.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Adjust CMake variables to point at parent submodules if directed to do so.

If aie-rt repository is used as a submodule, the parent repository may set the following variables in CMake to make aiebu point to the parents copy of ELFIO and/or AIE-RT. For example, XRT parent repository can set the following in its CMake for aiebu to inherit it:
- `set(AIEBU_AIE-RT_SRC_DIR ${XRT_SOURCE_DIR}/src/runtime_src/aie-rt)`
- `set(AIEBU_ELFIO_SRC_DIR ${XRT_SOURCE_DIR}/src/runtime_src/core/common/elf)`

