### PR TITLE
spec/build: Don't specify version controlled header as BYPRODUCTS.

### DIFF
--- a/specification/aie2ps/CMakeLists.txt
+++ b/specification/aie2ps/CMakeLists.txt
@@ -8,7 +8,6 @@ add_custom_target(cpp-assembler-stubs
   ${AIEBU_SOURCE_DIR}/specification/aie2ps/isa-spec.yaml
   ${AIEBU_SOURCE_DIR}/templates/aie2ps generate_cpp_assembler_stubs
   > ${AIEBU_SOURCE_DIR}/specification/aie2ps/isa.h
-  BYPRODUCTS ${AIEBU_SOURCE_DIR}/specification/aie2ps/isa.h
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   SOURCES ${AIEBU_SOURCE_DIR}/specification/spec_tool.py
   ${AIEBU_SOURCE_DIR}/specification/aie2ps/isa-spec.yaml


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

This resolves an issue of the `isa.h` header being unintendedly regenerated when invoking the build a second time using the Ninja generator.

This resulted in a broken build due to isa_disassembler being undefined in the regenerated header.

Due to differences in CMake generators regarding to BYPRODUCS, the issue was not reproducible using the Unix Makefile generator

https://cmake.org/cmake/help/latest/command/add_custom_target.html

In general BYPRODUCTS is not intended to overwrite version controlled source files.


#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

This patch addresses the symptom of issue #144.

#### How problem was solved, alternative solutions (if any) and why they were rejected

Don't specify version controlled header as BYPRODUCTS.
A proper solution would be either not regenerating this header by the build system but by manually invoking the Python script and committing the result or not having the generated header in version control in case a regeneration is needed for every build. The current expected behavior did not require a regeneration for every build though.

More details can be found in #144.

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
