### PR TITLE
Add "Qspectre" option only in case of MSVC

### DIFF
--- a/cmake/windows.cmake
+++ b/cmake/windows.cmake
@@ -20,10 +20,14 @@ add_compile_options(
   /W2           # warning level
   /Zi           # generate pdb files even in release mode
   /sdl          # enable security checks
-  /Qspectre     # compile with the Spectre mitigations switch
   /ZH:SHA_256   # enable secure source code hashing
   /guard:cf     # enable compiler control guard feature (CFG) to prevent attackers from redirecting execution to unsafe locations
   )
+
+if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+  add_compile_options(/Qspectre>)  # compile with the Spectre mitigations switch
+endif()
+
 add_link_options(
   /DEBUG      # instruct linker to create debugging info
   /guard:cf   # enable linker control guard feature (CFG) to prevent attackers from redirecting execution to unsafe locations


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
In case of using clang compiler, we see below error because clang doesnt recognize 'Qspectre' argument
clang-cl: error: argument unused during compilation: '/Qspectre' [-Werror,-Wunused-command-line-argument]

#### How problem was solved, alternative solutions (if any) and why they were rejected
Add "Qspectre" option only in case of MSVC

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Tested windows build and unit tests by running build/build22.bat

#### Documentation impact (if any)
