### PR TITLE
remove dtrace test for aiebu submodule

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,10 +10,10 @@ if (AIEBU_NATIVE_BUILD)
  add_subdirectory(aie2-ctrlcode)
 endif()
 add_subdirectory(cpp_test)
-add_subdirectory(dtrace_test)
 
 # Whomever added this test, please make it work when
 # AIEBU is built as a submodule from XRT
 if (NOT AIEBU_SUBMODULE)
   add_subdirectory(cmake-test)
+  add_subdirectory(dtrace_test)
 endif()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

when AIEBU is built as submodule, skip dtrace test

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
