### PR TITLE
Migrate std::regex to boost::regex

### DIFF
--- a/src/cpp/common/utils.cpp
+++ b/src/cpp/common/utils.cpp
@@ -3,7 +3,7 @@
 
 #include <map>
 #include <string>
-#include <regex>
+#include <boost/regex.hpp>
 
 #include "utils.h"
 #include "version.h"
@@ -26,14 +26,14 @@ static const std::map<fragment, std::string> fragment_table = { // NOLINT
     {fragment::row, "[[:space:]]*r\\[([[:digit:]]+)\\][[:space:]]*"},
 };
 
-std::regex
+boost::regex
 get_regex(const std::vector<fragment>& pattern)
 {
   std::string composite;
   for (auto frag : pattern) {
     composite += fragment_table.at(frag);
   }
-  return std::regex(composite);
+  return boost::regex(composite);
 }
 
 std::string

--- a/src/cpp/common/utils.h
+++ b/src/cpp/common/utils.h
@@ -7,7 +7,7 @@
 #include <cassert>
 #include <cstdint>
 #include <limits>
-#include <regex>
+#include <boost/regex.hpp>
 #include <sstream>
 #include <string>
 #include <string_view>
@@ -192,7 +192,7 @@ enum class fragment {
   dma,
 };
 
-std::regex get_regex(const std::vector<fragment>& pattern);
+boost::regex get_regex(const std::vector<fragment>& pattern);
 
 constexpr unsigned hexbase = 0x10;
 

--- a/src/cpp/dtrace/action/action_control.h
+++ b/src/cpp/dtrace/action/action_control.h
@@ -14,7 +14,7 @@
 
 #include <cstdint>
 #include <map>
-#include <regex>
+#include <boost/regex.hpp>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -96,25 +96,29 @@ public:
  * @details
  * This class provides a set of static inline regular expressions that can be used
  * to match specific action patterns in script file.
+ *
+ * @note All regex patterns are hardcoded and guaranteed valid at compile time.
+ * NOLINT comments suppress warnings about potential exceptions during static initialization.
  */
 class action_name
 {
 public:
-    static inline const std::regex timestamp_regex = std::regex(R"(timestamp\()");
-    static inline const std::regex timestamp32_regex = std::regex(R"(timestamp32\()");
-    static inline const std::regex read_reg_regex = std::regex(R"(read_reg\()");
-    static inline const std::regex write_reg_regex = std::regex(R"(\bwrite_reg\()");
-    static inline const std::regex mask_write_reg_regex = std::regex(R"(\bmask_write_reg\()");
-    static inline const std::regex profile_regex = std::regex(R"(opcode\(\))");
-    static inline const std::regex print_regex = std::regex(R"(print\()");
-    static inline const std::regex printa_regex = std::regex(R"(printa\()");
-    static inline const std::regex read_mem_regex = std::regex(R"(read_mem\()");
-    static inline const std::regex write_mem_regex = std::regex(R"(write_mem\()");
-    static inline const std::regex break_regex = std::regex(R"(break\()");
-    static inline const std::regex timestamps_regex = std::regex(R"(timestamps\()");
-    static inline const std::regex timestamps32_regex = std::regex(R"(timestamps32\()");
-    static inline const std::regex operation_regex = std::regex(R"(^(\w+)\s*=\s*(.+)$)");
-    static inline const std::regex action_regex = std::regex(R"((\w+)\((.*)\))");
+    // NOLINT: Hardcoded pattern is guaranteed valid
+    static inline const boost::regex timestamp_regex = boost::regex(R"(timestamp\()");  // NOLINT(cert-err58-cpp,bugprone-throwing-static-initialization)
+    static inline const boost::regex timestamp32_regex = boost::regex(R"(timestamp32\()");  // NOLINT(cert-err58-cpp,bugprone-throwing-static-initialization)
+    static inline const boost::regex read_reg_regex = boost::regex(R"(read_reg\()");  // NOLINT(cert-err58-cpp,bugprone-throwing-static-initialization)
+    static inline const boost::regex write_reg_regex = boost::regex(R"(\bwrite_reg\()");  // NOLINT(cert-err58-cpp,bugprone-throwing-static-initialization)
+    static inline const boost::regex mask_write_reg_regex = boost::regex(R"(\bmask_write_reg\()");  // NOLINT(cert-err58-cpp,bugprone-throwing-static-initialization)
+    static inline const boost::regex profile_regex = boost::regex(R"(opcode\(\))");  // NOLINT(cert-err58-cpp,bugprone-throwing-static-initialization)
+    static inline const boost::regex print_regex = boost::regex(R"(print\()");  // NOLINT(cert-err58-cpp,bugprone-throwing-static-initialization)
+    static inline const boost::regex printa_regex = boost::regex(R"(printa\()");  // NOLINT(cert-err58-cpp,bugprone-throwing-static-initialization)
+    static inline const boost::regex read_mem_regex = boost::regex(R"(read_mem\()");  // NOLINT(cert-err58-cpp,bugprone-throwing-static-initialization)
+    static inline const boost::regex write_mem_regex = boost::regex(R"(write_mem\()");  // NOLINT(cert-err58-cpp,bugprone-throwing-static-initialization)
+    static inline const boost::regex break_regex = boost::regex(R"(break\()");  // NOLINT(cert-err58-cpp,bugprone-throwing-static-initialization)
+    static inline const boost::regex timestamps_regex = boost::regex(R"(timestamps\()");  // NOLINT(cert-err58-cpp,bugprone-throwing-static-initialization)
+    static inline const boost::regex timestamps32_regex = boost::regex(R"(timestamps32\()");  // NOLINT(cert-err58-cpp,bugprone-throwing-static-initialization)
+    static inline const boost::regex operation_regex = boost::regex(R"(^(\w+)\s*=\s*(.+)$)");  // NOLINT(cert-err58-cpp,bugprone-throwing-static-initialization)
+    static inline const boost::regex action_regex = boost::regex(R"((\w+)\((.*)\))");  // NOLINT(cert-err58-cpp,bugprone-throwing-static-initialization)
 };
 
 //-------------------------Action Control-------------------------//

--- a/src/cpp/dtrace/action/mask_write_register.cpp
+++ b/src/cpp/dtrace/action/mask_write_register.cpp
@@ -28,8 +28,8 @@ mask_write_reg_action(std::string token, uint32_t probe_type, const std::string&
     while (std::getline(token_stream, item, '='))
         fields.push_back(strip(item));
 
-    std::smatch action;
-    if (!std::regex_match(fields[0], action, action_name::action_regex))
+    boost::smatch action;
+    if (!boost::regex_match(fields[0], action, action_name::action_regex))
         DTRACE_ERROR("DTRACE_ACTION_INVALID_TOKEN_FORMAT", 
             "Invalid token: '" << token << "' Expected 'mask_write_reg(addr, mask, val)'");
 

--- a/src/cpp/dtrace/action/profile.cpp
+++ b/src/cpp/dtrace/action/profile.cpp
@@ -35,8 +35,8 @@ profile_action(std::string token, uint32_t probe_type, const std::string& probe_
 
     m_result = fields[0];
 
-    std::smatch action;
-    if (!std::regex_match(fields[1], action, action_name::action_regex))
+    boost::smatch action;
+    if (!boost::regex_match(fields[1], action, action_name::action_regex))
         DTRACE_ERROR("DTRACE_ACTION_INVALID_TOKEN", 
             "Invalid token: '" << m_token << "' Expected 'opcode()'");
 

--- a/src/cpp/dtrace/action/read_mem.cpp
+++ b/src/cpp/dtrace/action/read_mem.cpp
@@ -38,8 +38,8 @@ read_mem_action(std::string token, uint32_t probe_type, const std::string& probe
 
     m_result = fields[0];
 
-    std::smatch action;
-    if (!std::regex_match(fields[1], action, action_name::action_regex))
+    boost::smatch action;
+    if (!boost::regex_match(fields[1], action, action_name::action_regex))
         DTRACE_ERROR("DTRACE_ACTION_INVALID_TOKEN", 
             "Invalid token: '" << token << "' Expected 'read_mem(addr, length)'");
 

--- a/src/cpp/dtrace/action/read_register.cpp
+++ b/src/cpp/dtrace/action/read_register.cpp
@@ -34,8 +34,8 @@ read_reg_action(std::string token, uint32_t probe_type, const std::string& probe
 
     m_result = fields[0];
 
-    std::smatch action;
-    if (!std::regex_match(fields[1], action, action_name::action_regex))
+    boost::smatch action;
+    if (!boost::regex_match(fields[1], action, action_name::action_regex))
         DTRACE_ERROR("DTRACE_ACTION_INVALID_TOKEN", 
             "Invalid token: '" << token << "' Expected 'read_reg(addr)'");
 

--- a/src/cpp/dtrace/action/timestamp.cpp
+++ b/src/cpp/dtrace/action/timestamp.cpp
@@ -34,8 +34,8 @@ timestamp_action(std::string token, uint32_t probe_type, const std::string& prob
 
     m_result = fields[0];
 
-    std::smatch action;
-    if (!std::regex_match(fields[1], action, action_name::action_regex))
+    boost::smatch action;
+    if (!boost::regex_match(fields[1], action, action_name::action_regex))
         DTRACE_ERROR("DTRACE_ACTION_INVALID_TOKEN", 
             "Invalid token: '" << token << "' Expected 'timestamp()'");
 

--- a/src/cpp/dtrace/action/timestamp32.cpp
+++ b/src/cpp/dtrace/action/timestamp32.cpp
@@ -34,8 +34,8 @@ timestamp32_action(std::string token, uint32_t probe_type, const std::string& pr
     
     m_result = fields[0];
 
-    std::smatch action;
-    if (!std::regex_match(fields[1], action, action_name::action_regex))
+    boost::smatch action;
+    if (!boost::regex_match(fields[1], action, action_name::action_regex))
         DTRACE_ERROR("DTRACE_ACTION_INVALID_TOKEN", 
             "Invalid token: '" << token << "' Expected 'timestamp32()'");
 

--- a/src/cpp/dtrace/action/timestamps.cpp
+++ b/src/cpp/dtrace/action/timestamps.cpp
@@ -33,17 +33,17 @@ timestamps_action(std::string token, uint32_t probe_type, const std::string& pro
             "Invalid token: '" << token << "' Expected 'name[length] = timestamps()'");
 
     // Regex pattern to match '<name>[<length>]' format
-    std::regex buffer_regex(R"(^(.+)\[(.+)\]$)");
-    std::smatch buffer;
-    if (!std::regex_match(fields[0], buffer, buffer_regex))
+    boost::regex buffer_regex(R"(^(.+)\[(.+)\]$)");
+    boost::smatch buffer;
+    if (!boost::regex_match(fields[0], buffer, buffer_regex))
         DTRACE_ERROR("DTRACE_ACTION_INVALID_TOKEN", 
             "Invalid token: '" << token << "' Expected 'name[length]'");
 
     m_result = buffer[1];
     std::string length = buffer[2];
 
-    std::smatch action;
-    if (!std::regex_match(fields[1], action, action_name::action_regex))
+    boost::smatch action;
+    if (!boost::regex_match(fields[1], action, action_name::action_regex))
         DTRACE_ERROR("DTRACE_ACTION_INVALID_TOKEN", 
             "Invalid token: '" << token << "' Expected 'timestamps()'");
 

--- a/src/cpp/dtrace/action/timestamps32.cpp
+++ b/src/cpp/dtrace/action/timestamps32.cpp
@@ -33,17 +33,17 @@ timestamps32_action(std::string token, uint32_t probe_type, const std::string& p
             "Invalid token: '" << token << "' Expected 'name[length] = timestamps32()'");
     
     // Regex pattern to match '<name>[<length>]' format
-    std::regex buffer_regex(R"(^(.+)\[(.+)\]$)");
-    std::smatch buffer;
-    if (!std::regex_match(fields[0], buffer, buffer_regex))
+    boost::regex buffer_regex(R"(^(.+)\[(.+)\]$)");
+    boost::smatch buffer;
+    if (!boost::regex_match(fields[0], buffer, buffer_regex))
         DTRACE_ERROR("DTRACE_ACTION_INVALID_TOKEN", 
             "Invalid token: '" << token << "' Expected 'name[length]'");
 
     m_result = buffer[1];
     std::string length = buffer[2];
 
-    std::smatch action;
-    if (!std::regex_match(fields[1], action, action_name::action_regex))
+    boost::smatch action;
+    if (!boost::regex_match(fields[1], action, action_name::action_regex))
         DTRACE_ERROR("DTRACE_ACTION_INVALID_TOKEN", 
             "Invalid token: '" << token << "' Expected 'timestamps32()'");
 

--- a/src/cpp/dtrace/action/write_mem.cpp
+++ b/src/cpp/dtrace/action/write_mem.cpp
@@ -32,8 +32,8 @@ write_mem_action(std::string token, uint32_t probe_type, const std::string& prob
     while (std::getline(token_stream, item, '='))
         fields.push_back(strip(item));
 
-    std::smatch action;
-    if (!std::regex_match(fields[0], action, action_name::action_regex))
+    boost::smatch action;
+    if (!boost::regex_match(fields[0], action, action_name::action_regex))
         DTRACE_ERROR("DTRACE_ACTION_INVALID_TOKEN", 
             "Invalid token: '" << token << "' Expected 'write_mem(addr, length, buffer)'");
 

--- a/src/cpp/dtrace/action/write_register.cpp
+++ b/src/cpp/dtrace/action/write_register.cpp
@@ -28,8 +28,8 @@ write_reg_action(std::string token, uint32_t probe_type, const std::string& prob
     while (std::getline(token_stream, item, '='))
         fields.push_back(strip(item));
 
-    std::smatch action;
-    if (!std::regex_match(fields[0], action, action_name::action_regex))
+    boost::smatch action;
+    if (!boost::regex_match(fields[0], action, action_name::action_regex))
         DTRACE_ERROR("DTRACE_ACTION_INVALID_TOKEN", 
             "Invalid token: '" << token << "' Expected 'write_reg(addr, val)'");
 

--- a/src/cpp/dtrace/parser/parser.cpp
+++ b/src/cpp/dtrace/parser/parser.cpp
@@ -345,9 +345,9 @@ parser::
 expand_write_buffer(const std::string& write_buffer)
 {
     // Regex to extract buffer name and values
-    std::regex buffer_regex(R"(^(\w+)\[(0x[a-fA-F0-9]+|\d+)\]\s*=\s*\[(.*)\]\s*$)");
-    std::smatch buffer;
-    if (!std::regex_match(write_buffer, buffer, buffer_regex)) 
+    boost::regex buffer_regex(R"(^(\w+)\[(0x[a-fA-F0-9]+|\d+)\]\s*=\s*\[(.*)\]\s*$)");
+    boost::smatch buffer;
+    if (!boost::regex_match(write_buffer, buffer, buffer_regex)) 
     {
         DTRACE_ERROR("DTRACE_PARSER_INVALID_WRITE_BUFFER",
             "Invalid write buffer format: " << write_buffer);
@@ -441,60 +441,60 @@ create_action(const std::string& action_string, uint32_t probe_type,
     const std::string& probe_name, uint32_t uC_index)
 {
     std::shared_ptr<dtrace::action::action> action;
-    if (std::regex_search(action_string, dtrace::action::action_name::read_reg_regex))
+    if (boost::regex_search(action_string, dtrace::action::action_name::read_reg_regex))
     {   // Read register action
         action = std::make_shared<dtrace::action::read_reg_action>(
             action_string, probe_type, probe_name
         );
         m_actions[uC_index].push_back(action);
     }
-    else if (std::regex_search(action_string, dtrace::action::action_name::mask_write_reg_regex))
+    else if (boost::regex_search(action_string, dtrace::action::action_name::mask_write_reg_regex))
     {   // Mask write register action
         action = std::make_shared<dtrace::action::mask_write_reg_action>(
             action_string, probe_type, probe_name
         );
     }
-    else if (std::regex_search(action_string, dtrace::action::action_name::write_reg_regex))
+    else if (boost::regex_search(action_string, dtrace::action::action_name::write_reg_regex))
     {   // Write register action
         action = std::make_shared<dtrace::action::write_reg_action>(
             action_string, probe_type, probe_name
         );
     }
-    else if (std::regex_search(action_string, dtrace::action::action_name::timestamp_regex))
+    else if (boost::regex_search(action_string, dtrace::action::action_name::timestamp_regex))
     {   // Timestamp action
         action = std::make_shared<dtrace::action::timestamp_action>(
             action_string, probe_type, probe_name
         );
         m_actions[uC_index].push_back(action);
     }
-    else if (std::regex_search(action_string, dtrace::action::action_name::timestamp32_regex))
+    else if (boost::regex_search(action_string, dtrace::action::action_name::timestamp32_regex))
     {   // Timestamp32 action
         action = std::make_shared<dtrace::action::timestamp32_action>(
             action_string, probe_type, probe_name
         );
         m_actions[uC_index].push_back(action);
     }
-    else if (std::regex_search(action_string, dtrace::action::action_name::profile_regex))
+    else if (boost::regex_search(action_string, dtrace::action::action_name::profile_regex))
     {   // Profile action
         action = std::make_shared<dtrace::action::profile_action>(
             action_string, probe_type, probe_name
         );
     }
-    else if (std::regex_search(action_string, dtrace::action::action_name::print_regex))
+    else if (boost::regex_search(action_string, dtrace::action::action_name::print_regex))
     {   // Print action
         action = std::make_shared<dtrace::action::print_action>(
             action_string, probe_type, probe_name, m_maps
         );
         m_actions[uC_index].push_back(action);
     }
-    else if (std::regex_search(action_string, dtrace::action::action_name::printa_regex))
+    else if (boost::regex_search(action_string, dtrace::action::action_name::printa_regex))
     {   // Profile print action
         action = std::make_shared<dtrace::action::printa_action>(
             action_string, probe_type, probe_name, m_maps
         );
         m_actions[uC_index].push_back(action);
     }
-    else if (std::regex_search(action_string, dtrace::action::action_name::read_mem_regex))
+    else if (boost::regex_search(action_string, dtrace::action::action_name::read_mem_regex))
     {   // Read memory action
         action = std::make_shared<dtrace::action::read_mem_action>(
             action_string, probe_type, probe_name, m_mem_host_addr_map[uC_index]
@@ -502,7 +502,7 @@ create_action(const std::string& action_string, uint32_t probe_type,
         m_actions[uC_index].push_back(action);
         m_mem_host_addr_map[uC_index] = action->get_mem_host_addr();
     }
-    else if (std::regex_search(action_string, dtrace::action::action_name::write_mem_regex))
+    else if (boost::regex_search(action_string, dtrace::action::action_name::write_mem_regex))
     {   // Write memory action
         action = std::make_shared<dtrace::action::write_mem_action>(
             action_string, probe_type, probe_name, m_mem_host_addr_map[uC_index], m_buffer_map
@@ -510,28 +510,28 @@ create_action(const std::string& action_string, uint32_t probe_type,
         m_actions[uC_index].push_back(action);
         m_mem_host_addr_map[uC_index] = action->get_mem_host_addr();
     }
-    else if (std::regex_search(action_string, dtrace::action::action_name::break_regex))
+    else if (boost::regex_search(action_string, dtrace::action::action_name::break_regex))
     {   // Break action
         action = std::make_shared<dtrace::action::break_action>(
             action_string, probe_type, probe_name
         );
         m_actions[uC_index].push_back(action);
     }
-    else if (std::regex_search(action_string, dtrace::action::action_name::timestamps_regex))
+    else if (boost::regex_search(action_string, dtrace::action::action_name::timestamps_regex))
     {   // Timestamps action
         action = std::make_shared<dtrace::action::timestamps_action>(
             action_string, probe_type, probe_name
         );
         m_actions[uC_index].push_back(action);
     }
-    else if (std::regex_search(action_string, dtrace::action::action_name::timestamps32_regex))
+    else if (boost::regex_search(action_string, dtrace::action::action_name::timestamps32_regex))
     {   // Timestamps32 action
         action = std::make_shared<dtrace::action::timestamps32_action>(
             action_string, probe_type, probe_name
         );
         m_actions[uC_index].push_back(action);
     }
-    else if (std::regex_search(action_string, dtrace::action::action_name::operation_regex))
+    else if (boost::regex_search(action_string, dtrace::action::action_name::operation_regex))
     {   // Operation action
         action = std::make_shared<dtrace::action::operation_action>(
             action_string, probe_type, probe_name
@@ -573,13 +573,13 @@ parse_line(const std::string& parse_line)
         return;
 
     // Skip comments
-    std::regex comment_regex(R"(^#(.*)$)");
-    if (std::regex_match(line, comment_regex))
+    boost::regex comment_regex(R"(^#(.*)$)");
+    if (boost::regex_match(line, comment_regex))
         return;
 
     // Parse the line for begin probe
-    std::regex begin_regex(R"(^begin\s*\{?$)");
-    if (std::regex_match(line, begin_regex))
+    boost::regex begin_regex(R"(^begin\s*\{?$)");
+    if (boost::regex_match(line, begin_regex))
     {
         if (m_state != state_type::probe || m_begin_exist)
             DTRACE_ERROR("DTRACE_PARSER_INVALID_LINE", "Invalid line " << m_position << ": " << line);
@@ -603,8 +603,8 @@ parse_line(const std::string& parse_line)
     }
 
     // Parse the line for end probe
-    std::regex end_regex(R"(^end\s*\{?$)");
-    if (std::regex_match(line, end_regex))
+    boost::regex end_regex(R"(^end\s*\{?$)");
+    if (boost::regex_match(line, end_regex))
     {
         if (m_state != state_type::probe || m_end_exist)
             DTRACE_ERROR("DTRACE_PARSER_INVALID_LINE", "Invalid line " << m_position << ": " << line);
@@ -650,8 +650,8 @@ parse_line(const std::string& parse_line)
     }
 
     // Parse the line for jprobe
-    std::regex jprobe_regex(R"(^jprobe:([a-zA-Z0-9_\.\/]*)\:(uc[0-9,-]+)\:((line|annotation)[0-9,-]+)\s*\{?$)");
-    if (std::regex_match(line, jprobe_regex))
+    boost::regex jprobe_regex(R"(^jprobe:([a-zA-Z0-9_\.\/]*)\:(uc[0-9,-]+)\:((line|annotation)[0-9,-]+)\s*\{?$)");
+    if (boost::regex_match(line, jprobe_regex))
     {
         if (m_state != state_type::probe)
             DTRACE_ERROR("DTRACE_PARSER_INVALID_LINE", "Invalid line " << m_position << ": " << line);
@@ -669,8 +669,8 @@ parse_line(const std::string& parse_line)
     }
  
     // Parse the line for tracepoint probe
-    std::regex tracepoint_regex(R"(^tracepoint:(uc[0-9,-]+)\:(id[0-9,-]+)\s*\{?$)");
-    if (std::regex_match(line, tracepoint_regex))
+    boost::regex tracepoint_regex(R"(^tracepoint:(uc[0-9,-]+)\:(id[0-9,-]+)\s*\{?$)");
+    if (boost::regex_match(line, tracepoint_regex))
     {
         if (m_state != state_type::probe)
             DTRACE_ERROR("DTRACE_PARSER_INVALID_LINE", "Invalid line " << m_position << ": " << line);
@@ -688,8 +688,8 @@ parse_line(const std::string& parse_line)
     }
 
     // Parse the line for profile probe
-    std::regex profile_regex(R"(^profile:(uc[0-9,-]+)\:([0-9]+)hz\s*\{?$)");
-    if (std::regex_match(line, profile_regex))
+    boost::regex profile_regex(R"(^profile:(uc[0-9,-]+)\:([0-9]+)hz\s*\{?$)");
+    if (boost::regex_match(line, profile_regex))
     {
         if (m_state != state_type::probe)
             DTRACE_ERROR("DTRACE_PARSER_INVALID_LINE", "Invalid line " << m_position << ": " << line);
@@ -707,9 +707,9 @@ parse_line(const std::string& parse_line)
     }
 
     // Parse the line for action and operation
-    std::regex action_regex(R"(^(.+\(.*\).*\)?)$)");
-    std::regex operation_regex(R"(^(\w+)\s*=\s*(.+)$)");
-    if ((std::regex_match(line, action_regex) || std::regex_match(line, operation_regex))
+    boost::regex action_regex(R"(^(.+\(.*\).*\)?)$)");
+    boost::regex operation_regex(R"(^(\w+)\s*=\s*(.+)$)");
+    if ((boost::regex_match(line, action_regex) || boost::regex_match(line, operation_regex))
         && m_state == state_type::action)
     {
         m_state = state_type::action;
@@ -725,15 +725,15 @@ parse_line(const std::string& parse_line)
     }
 
     // Parse the line for write buffer for memory action
-    std::regex buffer_open_regex(R"(^(\w+\[(0x[a-fA-F0-9]+|\d+)\])(?:\s*=\s*(\[.*)?)?$)");
-    std::regex buffer_regex(R"(^(\w+)\[(0x[a-fA-F0-9]+|\d+)\]\s*=\s*\[(.*)\]\s*$)");
-    if (std::regex_match(line, buffer_open_regex) && m_state == state_type::action)
+    boost::regex buffer_open_regex(R"(^(\w+\[(0x[a-fA-F0-9]+|\d+)\])(?:\s*=\s*(\[.*)?)?$)");
+    boost::regex buffer_regex(R"(^(\w+)\[(0x[a-fA-F0-9]+|\d+)\]\s*=\s*\[(.*)\]\s*$)");
+    if (boost::regex_match(line, buffer_open_regex) && m_state == state_type::action)
     {  
         m_state = state_type::buffer_open;
         m_open_buffer = true;
         m_write_buffer += line;
         // single line buffer
-        if (std::regex_match(m_write_buffer, buffer_regex))
+        if (boost::regex_match(m_write_buffer, buffer_regex))
             expand_write_buffer(m_write_buffer);
             
         return;

--- a/src/cpp/dtrace/parser/parser.h
+++ b/src/cpp/dtrace/parser/parser.h
@@ -16,7 +16,7 @@
 #include <cstdint>
 #include <map>
 #include <memory>
-#include <regex>
+#include <boost/regex.hpp>
 #include <set>
 #include <string>
 #include <unordered_map>

--- a/src/cpp/preprocessor/aie2/aie2_asm_preprocessor_input.cpp
+++ b/src/cpp/preprocessor/aie2/aie2_asm_preprocessor_input.cpp
@@ -191,10 +191,10 @@ public:
     std::string regoff = args[idx++].substr(1);
     // Determine the total size including extended storage by counting the number of writes
 
-    static const std::regex index_regex = get_regex({fragment::index_re});
+    static const boost::regex index_regex = get_regex({fragment::index_re});
 
-    std::smatch matches;
-    if (!std::regex_match(args[idx], matches, index_regex))
+    boost::smatch matches;
+    if (!boost::regex_match(args[idx], matches, index_regex))
         throw error(error::error_code::invalid_asm, args[idx]);
 
     if (matches.size() != 2)
@@ -250,11 +250,11 @@ public:
 
     auto op = reinterpret_cast<XAie_MaskWrite32Hdr *>(m_op);
     op->RegOff = to_uinteger<uint64_t>(regoff);
-    static const std::regex mask_regex = get_regex({fragment::begin_anchor_re, fragment::hex_re, fragment::l_brack_re,
+    static const boost::regex mask_regex = get_regex({fragment::begin_anchor_re, fragment::hex_re, fragment::l_brack_re,
         fragment::r_brack_re, fragment::end_anchor_re});
 
-    std::smatch matches;
-    if (!std::regex_match(args[1], matches, mask_regex))
+    boost::smatch matches;
+    if (!boost::regex_match(args[1], matches, mask_regex))
         throw error(error::error_code::invalid_asm, args[1]);
 
     if (matches.size() != 2)
@@ -283,11 +283,11 @@ public:
     auto op = reinterpret_cast<XAie_MaskPoll32Hdr *>(m_op);
     op->RegOff = to_uinteger<uint64_t>(regoff);
 
-    static const std::regex mask_poll_regex = get_regex({fragment::begin_anchor_re, fragment::hex_re, fragment::l_brack_re,
+    static const boost::regex mask_poll_regex = get_regex({fragment::begin_anchor_re, fragment::hex_re, fragment::l_brack_re,
         fragment::r_brack_re, fragment::equal_re, fragment::hex_re, fragment::end_anchor_re});
 
-    std::smatch matches;
-    if (!std::regex_match(args[idx], matches, mask_poll_regex))
+    boost::smatch matches;
+    if (!boost::regex_match(args[idx], matches, mask_poll_regex))
         throw error(error::error_code::invalid_asm, args[idx]);
 
     if (matches.size() != 3)
@@ -388,9 +388,9 @@ public:
 
 class XAIE_IO_CUSTOM_OP_TCT_op : public aie2_isa_op {
 private:
-  std::pair<uint8_t, uint8_t> parse_index(const std::regex &regx, const std::string &token) const {
-    std::smatch cmatches;
-    if (!std::regex_match(token, cmatches, regx))
+  std::pair<uint8_t, uint8_t> parse_index(const boost::regex &regx, const std::string &token) const {
+    boost::smatch cmatches;
+    if (!boost::regex_match(token, cmatches, regx))
         throw error(error::error_code::invalid_asm, token);
 
     if (cmatches.size() !=3)
@@ -409,8 +409,8 @@ public:
 
     auto values = get_extended_storage<tct_op_t>();
     unsigned int idx = 0;
-    static const std::regex row_regex = get_regex({fragment::row, fragment::add_dec_re});
-    static const std::regex col_regex = get_regex({fragment::column, fragment::add_dec_re});
+    static const boost::regex row_regex = get_regex({fragment::row, fragment::add_dec_re});
+    static const boost::regex col_regex = get_regex({fragment::column, fragment::add_dec_re});
 
     std::pair<uint8_t, uint8_t> row_val = parse_index(row_regex, args[idx++]);
     std::pair<uint8_t, uint8_t> col_val = parse_index(col_regex, args[idx++]);
@@ -449,9 +449,9 @@ public:
 
     auto values = get_extended_storage<tct_op_t>();
 
-    static const std::regex regx = get_regex({fragment::column, fragment::equal_re, fragment::dec_re});
-    std::smatch cmatches;
-    if (!std::regex_match(args[0], cmatches, regx))
+    static const boost::regex regx = get_regex({fragment::column, fragment::equal_re, fragment::dec_re});
+    boost::smatch cmatches;
+    if (!boost::regex_match(args[0], cmatches, regx))
         throw error(error::error_code::invalid_asm, args[0]);
 
     if (cmatches.size() !=3)

--- a/src/cpp/preprocessor/asm/asm_parser.cpp
+++ b/src/cpp/preprocessor/asm/asm_parser.cpp
@@ -114,10 +114,10 @@ asm_parser::
 parse_lines(const std::vector<char>& data, std::string& file)
 {
   //parse asm code
-  const static std::regex COMMENT_REGEX("^;(.*)$");
-  const static std::regex LABEL_REGEX("^([a-zA-Z0-9_]+)\\:$");
-  const static std::regex OP_REGEX("^([.a-zA-Z0-9_]+)(?:\\s+(.+)+)?$");
-  const static std::regex DIRCETIVE_REGEX(".^([a-zA-Z0-9_]+)(?:\\s+(.+)+)?$");
+  const static boost::regex COMMENT_REGEX("^;(.*)$");
+  const static boost::regex LABEL_REGEX("^([a-zA-Z0-9_]+):$");
+  const static boost::regex OP_REGEX("^([.a-zA-Z0-9_]+)(?:[ \\t]+(.+))?$");
+  const static boost::regex DIRCETIVE_REGEX(".^([a-zA-Z0-9_]+)(?:[ \\t]+(.+))?$");
 
   std::string str(data.begin(), data.end());
   std::istringstream isstr(str);
@@ -130,13 +130,13 @@ parse_lines(const std::vector<char>& data, std::string& file)
     if(line.empty())
       continue;
 
-    if (std::regex_match(line, COMMENT_REGEX))
+    if (boost::regex_match(line, COMMENT_REGEX))
       continue;
 
-    std::smatch sm;
+    boost::smatch sm;
 
     // Check for Directive
-    std::regex_match(line, sm, DIRCETIVE_REGEX);
+    boost::regex_match(line, sm, DIRCETIVE_REGEX);
     if (operate_directive(line))
     {
       if (!get_annotation_state())
@@ -164,8 +164,7 @@ parse_lines(const std::vector<char>& data, std::string& file)
     }
 
     // check for label
-    std::regex_match(line, sm, LABEL_REGEX);
-    if (sm.size())
+    if (boost::regex_match(line, sm, LABEL_REGEX))
     {
       if (!get_data_state())
         m_current_label = m_current_label + ":" + sm[1].str();
@@ -173,12 +172,13 @@ parse_lines(const std::vector<char>& data, std::string& file)
         insert_col_asmdata(std::make_shared<asm_data>(std::make_shared<operation>(sm[1].str(), ""),
                                                       operation_type::label, code_section::unknown, 0,
                                                       (uint32_t)-1, linenumber, line, file));
+      continue;
     }
     // check for operation
-    std::regex_match(line, sm, OP_REGEX);
-    if (sm.size())
+    else if (boost::regex_match(line, sm, OP_REGEX))
     {
-      insert_col_asmdata(std::make_shared<asm_data>(std::make_shared<operation>(sm[1].str(), sm[2].str()),
+      std::string arg_str = (sm.size() > 2 && sm[2].matched) ? sm[2].str() : "";
+      insert_col_asmdata(std::make_shared<asm_data>(std::make_shared<operation>(sm[1].str(), arg_str),
                                                     operation_type::op, code_section::unknown, 0, (uint32_t)-1,
                                                     linenumber, line, file));
       std::string op_name = sm[1].str();
@@ -192,11 +192,10 @@ parse_lines(const std::vector<char>& data, std::string& file)
 
 void
 attach_to_group_directive::
-operate(std::shared_ptr<asm_parser> parserptr, const std::smatch& sm)
+operate(std::shared_ptr<asm_parser> parserptr, const boost::smatch& sm)
 {
   m_parserptr = parserptr;
-  if (sm.size() < 3)
-    throw error(error::error_code::invalid_asm, "Invalid attach_to_group directive argument\n");
+  verify_match(sm, error::error_code::invalid_asm, "Invalid attach_to_group directive argument\n");
 
   // dummy eof added if col change happens before eof
   m_parserptr->insert_col_asmdata(std::make_shared<asm_data>(std::make_shared<operation>("eof", ""),
@@ -208,9 +207,11 @@ operate(std::shared_ptr<asm_parser> parserptr, const std::smatch& sm)
 
 void
 section_directive::
-operate(std::shared_ptr<asm_parser> parserptr, const std::smatch& sm)
+operate(std::shared_ptr<asm_parser> parserptr, const boost::smatch& sm)
 {
   m_parserptr = parserptr;
+  verify_match(sm, error::error_code::invalid_asm, ".section directive requires arguments\n");
+
   std::vector<std::string> args = splitoption(sm[2].str().c_str(), ',');
   if (is_test_section(args[0]))
     m_parserptr->set_data_state(false);
@@ -224,14 +225,14 @@ operate(std::shared_ptr<asm_parser> parserptr, const std::smatch& sm)
 
 void
 partition_directive::
-operate(std::shared_ptr<asm_parser> parserptr, const std::smatch& sm)
+operate(std::shared_ptr<asm_parser> parserptr, const boost::smatch& sm)
 {
   m_parserptr = parserptr;
-  static const std::regex pattern(R"(\.partition\s+(\d+)(column|core:(\d+)mem))");
-  std::smatch match;
+  static const boost::regex pattern(R"(\.partition\s+(\d+)(column|core:(\d+)mem))");
+  boost::smatch match;
   std::cout << "PARTITION:" << sm[0].str() << "\n";
   std::string line = sm[0].str();
-  if (std::regex_match(line, match, pattern)) {
+  if (boost::regex_match(line, match, pattern)) {
     if (match[2] == "column") {
       std::cout << "Column count: " << match[1] << std::endl;
       m_parserptr->set_numcolumn(to_uinteger<uint32_t>(match[1]));
@@ -253,7 +254,7 @@ read_include_file(std::string filename)
   if (!file.is_open()) {
     return false;
   }
-  std::cout << "Reading file:" << filename << std::endl;
+//  std::cout << "Reading file:" << filename << std::endl;
   std::string line;
   m_parserptr->set_data_state(false);
 
@@ -266,7 +267,7 @@ read_include_file(std::string filename)
 
 void
 include_directive::
-operate(std::shared_ptr<asm_parser> parserptr, const std::smatch& sm)
+operate(std::shared_ptr<asm_parser> parserptr, const boost::smatch& sm)
 {
   m_parserptr = parserptr;
   //std::vector<std::string> args = splitoption(sm[2].str().c_str(), ',');
@@ -293,12 +294,14 @@ operate(std::shared_ptr<asm_parser> parserptr, const std::smatch& sm)
 
 void
 end_of_label_directive::
-operate(std::shared_ptr<asm_parser> parserptr, const std::smatch& sm)
+operate(std::shared_ptr<asm_parser> parserptr, const boost::smatch& sm)
 {
   m_parserptr = parserptr;
 
   std::string label = m_parserptr->top_label();
   m_parserptr->pop_label();
+
+  verify_match(sm, error::error_code::invalid_asm, ".endl directive requires a label argument\n");
 
   std::vector<std::string> args = splitoption(sm[2].str().c_str(), ',');
   if (label.compare(args[0]))
@@ -307,9 +310,11 @@ operate(std::shared_ptr<asm_parser> parserptr, const std::smatch& sm)
 
 void
 pad_directive::
-operate(std::shared_ptr<asm_parser> parserptr, const std::smatch& sm)
+operate(std::shared_ptr<asm_parser> parserptr, const boost::smatch& sm)
 {
   m_parserptr = parserptr;
+  verify_match(sm, error::error_code::invalid_asm, ".setpad directive requires arguments\n");
+
   std::vector<std::string> args = splitoption(sm[2].str().c_str(), ',');
 
   add_scratchpad(args[0], args[1]);
@@ -326,8 +331,8 @@ add_scratchpad(std::string& name, std::string& str) {
     return;
   }
   // Check if the string is a hexadecimal number
-  static const std::regex hex_regex("0[xX][0-9a-fA-F]+");
-  if (std::regex_match(str, hex_regex)) {
+  static const boost::regex hex_regex("0[xX][0-9a-fA-F]+");
+  if (boost::regex_match(str, hex_regex)) {
     std::vector<char> empty_vector;
     m_parserptr->insert_scratchpad(name, convert2int(str) * WORD_SIZE, empty_vector);
     return;
@@ -364,7 +369,7 @@ read_pad_file(std::string& name, std::string& filename)
     return false;
   }
 
-  std::cout << "Reading file:" << filename << std::endl;
+//  std::cout << "Reading file:" << filename << std::endl;
   std::string line;
   m_parserptr->set_data_state(false);
 

--- a/src/cpp/preprocessor/asm/asm_parser.h
+++ b/src/cpp/preprocessor/asm/asm_parser.h
@@ -9,7 +9,7 @@
 
 #include <map>
 #include <memory>
-#include <regex>
+#include <boost/regex.hpp>
 #include <stack>
 #include <sstream>
 #include <string>
@@ -25,6 +25,12 @@ inline std::string trim(const std::string& line)
     std::size_t start = line.find_first_not_of(WhiteSpace);
     std::size_t end = line.find_last_not_of(WhiteSpace);
     return (start == end && start == std::string::npos) ? std::string() : line.substr(start, end - start + 1);
+}
+
+inline void verify_match(const boost::smatch& sm, error::error_code ecode, const char* msg)
+{
+  if (sm.size() < 3 || !sm[2].matched || sm[2].length() == 0)
+    throw error(ecode, msg);
 }
 
 enum class operation_type: uint8_t
@@ -71,7 +77,7 @@ public:
   std::shared_ptr<asm_parser> m_parserptr;
 public:
   directive() {}
-  virtual void operate(std::shared_ptr<asm_parser> parserptr, const std::smatch& sm) = 0;
+  virtual void operate(std::shared_ptr<asm_parser> parserptr, const boost::smatch& sm) = 0;
   virtual ~directive() = default;
 };
 
@@ -79,7 +85,7 @@ class attach_to_group_directive: public directive
 {
 public:
   attach_to_group_directive() = default;
-  void operate(std::shared_ptr<asm_parser> parserptr, const std::smatch& sm) override;
+  void operate(std::shared_ptr<asm_parser> parserptr, const boost::smatch& sm) override;
   ~attach_to_group_directive() override = default;
 };
 
@@ -89,7 +95,7 @@ class include_directive: public directive
   bool read_include_file(std::string filename);
 public:
   include_directive() = default;
-  void operate(std::shared_ptr<asm_parser> parserptr, const std::smatch& sm) override;
+  void operate(std::shared_ptr<asm_parser> parserptr, const boost::smatch& sm) override;
   ~include_directive() override = default;
 };
 
@@ -97,7 +103,7 @@ class end_of_label_directive: public directive
 {
 public:
   end_of_label_directive() = default;
-  void operate(std::shared_ptr<asm_parser> parserptr, const std::smatch& sm) override;
+  void operate(std::shared_ptr<asm_parser> parserptr, const boost::smatch& sm) override;
   ~end_of_label_directive() override = default;
 };
 
@@ -123,7 +129,7 @@ public:
   }
   void add_scratchpad(std::string& name, std::string& str);
   pad_directive() = default;
-  void operate(std::shared_ptr<asm_parser> parserptr, const std::smatch& sm) override;
+  void operate(std::shared_ptr<asm_parser> parserptr, const boost::smatch& sm) override;
   ~pad_directive() override = default;
 };
 
@@ -134,7 +140,7 @@ class section_directive: public directive
   bool is_annotation_section(const std::string& str) {return !str.substr(0,10).compare("annotation"); }
 public:
   section_directive() = default;
-  void operate(std::shared_ptr<asm_parser> parserptr, const std::smatch& sm) override;
+  void operate(std::shared_ptr<asm_parser> parserptr, const boost::smatch& sm) override;
   ~section_directive() override = default;
 };
 
@@ -142,7 +148,7 @@ class partition_directive: public directive
 {
 public:
   partition_directive() = default;
-  void operate(std::shared_ptr<asm_parser> parserptr, const std::smatch& sm) override;
+  void operate(std::shared_ptr<asm_parser> parserptr, const boost::smatch& sm) override;
   ~partition_directive() override = default;
   partition_directive(const partition_directive&) = default;
   partition_directive& operator=(const partition_directive&) = default;
@@ -377,9 +383,9 @@ public:
 
   bool operate_directive(const std::string& line)
   {
-    std::smatch sm;
-    const static std::regex DIRCETIVE_REGEX("^([.a-zA-Z0-9_]+)(?:\\s+(.+)+)?$");
-    std::regex_match(line, sm, DIRCETIVE_REGEX);
+    boost::smatch sm;
+    const static boost::regex DIRCETIVE_REGEX("^([.a-zA-Z0-9_]+)(?:[ \\t]+(.+))?$");
+    boost::regex_match(line, sm, DIRCETIVE_REGEX);
     if (sm.size() == 0)
       return false;
 


### PR DESCRIPTION
#### Problem solved by the commit
ELF generation was slow due to std::regex operations present in the codebase to parse the ASM files.
This was figured out during aiebu-asm profiling that std::regex DFS is the slowest in aiebu execution.
std::regex is not OS independent and MSVC has its own implementation which is very inefficient and Linux GCC/CLang has its libstdc++ implementation for std::regex. 


#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
N/A

#### How problem was solved, alternative solutions (if any) and why they were rejected
1> Migrate codebase from std::regex to boost::regex
2> Note - Boost::regex is platform independent unlike std::regex and has consistent implementation for Windows and Linux and is very efficient as compared to std::regex

#### Risks (if any) associated the changes in the commit
Backward compatibility.

#### What has been tested and how, request additional testing if necessary
1> AIEBU ctests on Windows -
Some tests have become around 20 times (from 1280secs to 46.82 secs) faster after using boost::regex 

boost::regex
18/64 Test #18: aie2_rich_asm .........................   Passed   **46.82 sec**
        Start 19: aie2_rich_asm_redo
19/64 Test #19: aie2_rich_asm_redo ....................   Passed   **54.00 sec**
        Start 20: aie2_rich_asm_compare


std::regex -

Start 18: aie2_rich_asm
       18/61 Test #18 aie2_rich_asm ......................... Passed **1278.68 sec**
Start 19: aie2_rich_asm_redo
       19/61 Test #19: aie2_rich_asm_redo ....................   Passed  **1058.41 sec**

2> DMA Compiler test for aie4
Tested DMA compiler test which took approx. 26 mins on Windows is now taking 8mins 20secs. This test has become around 3 times faster.

#### Documentation impact (if any)
N/A