### PR TITLE
Fix Boost_VERSION for the newly added test

### DIFF
--- a/test/aie4-ctrlcode/CMakeLists.txt
+++ b/test/aie4-ctrlcode/CMakeLists.txt
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2025 Advanced Micro Devices, Inc.
 
-# MD5 name-based uuid generation was corrected to be
-# identical on all endian systems in 1.71.0 only.
-if (${Boost_VERSION} VERSION_GREATER_EQUAL "1.84.0")
+if (${Boost_VERSION} VERSION_GREATER_EQUAL "1.71.0")
   add_subdirectory(multi_graph)
 endif()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Boost_VERSION 1.71.0 is sufficient to run full ELF aie4/aie2ps test.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
#171 

#### How problem was solved, alternative solutions (if any) and why they were rejected
Update CMakeLists.txt

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Validated on Ubuntu 24.04

#### Documentation impact (if any)
NA