### PR TITLE
Add min supported version for Ubuntu and Boost

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ Build Dependencies
 
  * cmake 3.18 or above
  * c++17 compiler
- * Boost (header only)
+ * Boost (header only) minimum version supported is 1.76
  * cxxopts (included as submodule)
  * ELFIO (included as submodule)
  * AMD aie-rt (included as submodule)
@@ -39,6 +39,7 @@ Build Instruction
 =================
 Linux
 -----
+Ubuntu minimum supported version is 24.04
 
 ::
 

--- a/cmake/boost.cmake
+++ b/cmake/boost.cmake
@@ -1,18 +1,46 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#if(POLICY CMP0144)
+#  cmake_policy(SET CMP0144 NEW)
+#endif()
+
+# We use header only libraries
+#if(${CMAKE_VERSION} VERSION_LESS "3.30")
+#  find_package(Boost REQUIRED)
+#else()
+#  find_package(Boost CONFIG REQUIRED)
+#endif()
+
+#message("-- Boost version: ${Boost_VERSION}")
+#message("-- Boost include dir:${Boost_INCLUDE_DIRS}")
+
+# Some later versions of boost spews warnings form property_tree
+# but can be disabled with this setting
+#add_compile_options("-DBOOST_BIND_GLOBAL_PLACEHOLDERS")
+#include_directories(${Boost_INCLUDE_DIRS})
+
+
+###################################################################################
+
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
 if(POLICY CMP0144)
   cmake_policy(SET CMP0144 NEW)
 endif()
 
-# We use header only libraries
+# We use header only libraries for most components
+# Boost.Regex is header-only from 1.76.0+ (when using C++11 or later)
+# Require minimum Boost 1.76.0 for header-only Boost.Regex support
 if(${CMAKE_VERSION} VERSION_LESS "3.30")
-  find_package(Boost REQUIRED)
+  find_package(Boost 1.76.0 REQUIRED COMPONENTS regex)
 else()
-  find_package(Boost CONFIG REQUIRED)
+  find_package(Boost 1.76.0 CONFIG REQUIRED COMPONENTS regex)
 endif()
 
-message("-- Boost version: ${Boost_VERSION}")
-message("-- Boost include dir:${Boost_INCLUDE_DIRS}")
+message(STATUS "Boost version: ${Boost_VERSION}")
+message(STATUS "Boost include dir: ${Boost_INCLUDE_DIRS}")
+message(STATUS "Boost libraries: ${Boost_LIBRARIES}")
+message(STATUS "Boost.Regex: using header-only mode (Boost >= 1.76.0)")
 
 # Some later versions of boost spews warnings form property_tree
 # but can be disabled with this setting

--- a/cmake/boost.cmake
+++ b/cmake/boost.cmake
@@ -1,29 +1,5 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
-#if(POLICY CMP0144)
-#  cmake_policy(SET CMP0144 NEW)
-#endif()
-
-# We use header only libraries
-#if(${CMAKE_VERSION} VERSION_LESS "3.30")
-#  find_package(Boost REQUIRED)
-#else()
-#  find_package(Boost CONFIG REQUIRED)
-#endif()
-
-#message("-- Boost version: ${Boost_VERSION}")
-#message("-- Boost include dir:${Boost_INCLUDE_DIRS}")
-
-# Some later versions of boost spews warnings form property_tree
-# but can be disabled with this setting
-#add_compile_options("-DBOOST_BIND_GLOBAL_PLACEHOLDERS")
-#include_directories(${Boost_INCLUDE_DIRS})
-
-
-###################################################################################
-
-# SPDX-License-Identifier: MIT
-# Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
 if(POLICY CMP0144)
   cmake_policy(SET CMP0144 NEW)
 endif()


### PR DESCRIPTION
#### Problem solved by the commit
Post std::regex to boost::regex migration, Boost 1.76 or above is needed as per below documentation. https://www.boost.org/releases/1.76.0/

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
N/A

#### How problem was solved, alternative solutions (if any) and why they were rejected
Adding minimum boost and Ubuntu version needed in Readme.rst

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
Used readme_renderer to convert to html and validate the changes.

#### Documentation impact (if any)
Readme.rst