### PR TITLE
"Do Not Review" Add loglevels to aiebu

### DIFF
--- a/src/cpp/common/logger.h
+++ b/src/cpp/common/logger.h
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+
+#ifndef AIEBU_COMMON_LOGGER_H
+#define AIEBU_COMMON_LOGGER_H
+
+#include <iostream>
+#include <sstream>
+
+namespace aiebu {
+
+// Log Levels
+enum class log_level {
+  error = 0,   // Always shown
+  warn = 1,    // Warnings
+  info = 2,    // Informational messages (shown with verbose)
+  debug = 3    // Debug messages (shown with verbose)
+};
+
+// Global log level (default: errors and warnings)
+inline log_level g_log_level = log_level::warn;
+
+// Set log level
+inline void set_log_level(log_level level) {
+  g_log_level = level;
+}
+
+// Get log level
+inline log_level get_log_level() {
+  return g_log_level;
+}
+
+// Enable verbose mode (shows info and debug messages)
+inline void enable_verbose_logging() {
+  g_log_level = log_level::debug;
+}
+
+// Disable verbose mode (back to default: errors and warnings)
+inline void disable_verbose_logging() {
+  g_log_level = log_level::warn;
+}
+
+} // namespace aiebu
+
+// Logging macros
+#define LOG_ERROR(msg) \
+  do { \
+    std::cerr << "[ERROR] " << msg << std::endl; \
+  } while (0)
+
+#define LOG_WARN(msg) \
+  do { \
+    if (aiebu::g_log_level >= aiebu::log_level::warn) { \
+      std::cout << "[WARN] " << msg << std::endl; \
+    } \
+  } while (0)
+
+#define LOG_INFO(msg) \
+  do { \
+    if (aiebu::g_log_level >= aiebu::log_level::info) { \
+      std::cout << msg << std::endl; \
+    } \
+  } while (0)
+
+#define LOG_DEBUG(msg) \
+  do { \
+    if (aiebu::g_log_level >= aiebu::log_level::debug) { \
+      std::cout << "[DEBUG] " << msg << std::endl; \
+    } \
+  } while (0)
+
+#endif // AIEBU_COMMON_LOGGER_H
+

--- a/src/cpp/elf/elfwriter.cpp
+++ b/src/cpp/elf/elfwriter.cpp
@@ -2,6 +2,7 @@
 // Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
 #include "elfwriter.h"
+#include "logger.h"
 
 namespace aiebu {
 
@@ -118,7 +119,7 @@ elf_writer::
 finalize()
 {
   add_note(NT_XRT_UID, ".note.xrt.UID", m_uid.calculate());
-  std::cout << "UID:" << m_uid.str() << "\n";
+  LOG_INFO("UID:" << m_uid.str());
   std::stringstream stream;
   stream << std::noskipws;
   //m_elfio.save( "hello_32" );

--- a/src/cpp/encoder/aie2ps/aie2ps_encoder.cpp
+++ b/src/cpp/encoder/aie2ps/aie2ps_encoder.cpp
@@ -3,6 +3,7 @@
 #include "aie2ps_encoder.h"
 
 #include "aiebu/aiebu_error.h"
+#include "logger.h"
 
 #include <cassert>
 
@@ -12,18 +13,17 @@ void
 aie2ps_encoder::
 fill_scratchpad(std::shared_ptr<section_writer> padwriter, const std::map<std::string, std::shared_ptr<scratchpad_info>>& scratchpads)
 {
-  for (const auto& pad : scratchpads)
+  for (auto& pad : scratchpads)
   {
-    const auto& content = pad.second->get_content();
+    auto& content = pad.second->get_content();
     if (content.size())
     {
       assert((void("Pad content size and size doesnt match\n"), content.size() == pad.second->get_size()));
-      padwriter->write_bytes(content);
-    } else {
-      auto size = pad.second->get_size();
-      std::vector<uint8_t> zeros(size, 0x00);
-      padwriter->write_bytes(zeros);
-    }
+      for (auto& val : content)
+        padwriter->write_byte(val);
+    } else
+      for (auto i = 0ul; i < pad.second->get_size(); ++i)
+        padwriter->write_byte(0x00);
   }
 }
 
@@ -31,15 +31,16 @@ void
 aie2ps_encoder::
 fill_controlpkt(std::shared_ptr<section_writer> ctrlpktwriter, const std::vector<char>& ctrlpkt)
 {
-  ctrlpktwriter->write_bytes(ctrlpkt);
+  for (auto& val : ctrlpkt)
+    ctrlpktwriter->write_byte(val);
 }
 
 void
 aie2ps_encoder::
 fill_control_packet_symbols(std::shared_ptr<section_writer> ctrlpktwriter,
-                            const std::vector<symbol>& syms)
+                            std::vector<symbol>& syms)
 {
-  for (const auto& sym : syms)
+  for (auto& sym : syms)
     ctrlpktwriter->add_symbol(sym);
 }
 
@@ -59,7 +60,7 @@ process(std::shared_ptr<preprocessed_output> input)
   m_dump_flag = tinput->get_debug();
 
   // for each colnum encode each page
-  for (const auto& coldata: totalcoldata) {
+  for (auto coldata: totalcoldata) {
     auto colnum = coldata.first;
     for (auto& lpage : coldata.second->m_pages)
       page_writer(lpage, coldata.second->m_scratchpad, coldata.second->m_labelpageindex,
@@ -79,23 +80,24 @@ process(std::shared_ptr<preprocessed_output> input)
     }
   }
 
+  // Report (only if verbose flag is set)
+  if (get_log_level() >= log_level::info)
+    m_report.summary(std::cout);
+
   // Debug JSON serialization
   json dbg_json = m_debug.to_json();
 
-  if (m_dump_flag == asm_dump_flag::full) {
-    // Report
-    m_report.summary(std::cout);
-    // Write to debug_map.json
-    std::ofstream file("debug_map.json");
-    file << dbg_json.dump(4);  // pretty print with 4-space indent
-    file.close();
-  }
+  // Write to debug_map.json
+  std::ofstream file("debug_map.json");
+  file << dbg_json.dump(4);  // pretty print with 4-space indent
+  file.close();
 
   // Optional binary dump if debug flag is not disabled.
   if (m_dump_flag != asm_dump_flag::disable) {
     auto dumpwriter = std::make_shared<section_writer>(".dump", code_section::data);
     std::string dbg_str = dbg_json.dump(); // no indent for compact output
-    dumpwriter->write_bytes(dbg_str);
+    for (char c : dbg_str)
+      dumpwriter->write_byte(c);
     twriter.push_back(dumpwriter);
   }
   return twriter;
@@ -148,13 +150,14 @@ page_writer(page& lpage, std::map<std::string, std::shared_ptr<scratchpad_info>>
   auto textwriter = std::make_shared<section_writer>(get_TextSectionName(colnum, pagenum), code_section::text);
   auto datawriter = std::make_shared<section_writer>(get_DataSectionName(colnum, pagenum), code_section::data);
 
-  textwriter->write_bytes(page_header);
+  for (auto byte : page_header)
+    textwriter->write_byte(byte);
 
   // encode text section
   offset_type offset = textwriter->tell();
   std::vector<symbol> tsym;
   std::string fid;
-  for (const auto& text : lpage.m_text)
+  for (auto text : lpage.m_text)
   {
     //TODO add debug info
     std::string name = text->get_operation()->get_name();
@@ -175,14 +178,16 @@ page_writer(page& lpage, std::map<std::string, std::shared_ptr<scratchpad_info>>
       page_state->set_pos(textwriter->tell() - offset);
       std::vector<uint8_t> ret = (*m_isa)[name]->serializer(text->get_operation()->get_args())
                                                ->serialize(page_state, tsym, colnum, pagenum);
-      textwriter->write_bytes(ret);
+      for (uint8_t byte : ret) {
+        textwriter->write_byte(byte);
+      }
     } else 
       throw error(error::error_code::internal_error, "Invalid operation: " + name + " in TEXT section !!!");
   }
 
   std::vector<symbol> dsym;
   // encode data section
-  for (const auto& data : lpage.m_data)
+  for (auto data : lpage.m_data)
   {
     page_state->set_pos(datawriter->tell() + textwriter->tell() - offset);
     std::string name = data->get_operation()->get_name();
@@ -201,7 +206,9 @@ page_writer(page& lpage, std::map<std::string, std::shared_ptr<scratchpad_info>>
       }
       std::vector<uint8_t> ret = (*m_isa)[name]->serializer(data->get_operation()->get_args())
                                                ->serialize(page_state, dsym, colnum, pagenum);
-      datawriter->write_bytes(ret);
+      for (auto byte : ret) {
+        datawriter->write_byte(byte);
+      }
     } else 
       throw error(error::error_code::internal_error, "Invalid operation: " + name + " in DATA section !!!");
   }

--- a/src/cpp/preprocessor/aie2/aie2_blob_preprocessor_input.h
+++ b/src/cpp/preprocessor/aie2/aie2_blob_preprocessor_input.h
@@ -9,6 +9,7 @@
 #include "utils.h"
 #include "file_utils.h"
 #include "preprocessor_input.h"
+#include "asm/asm_parser.h"
 #include <boost/format.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
@@ -105,6 +106,8 @@ public:
     {
       if (lib == legacydpuxclbin)
         arg_offset = 1;
+      else if (lib == "verbose")
+        enable_verbose_logging();
       else
         std::cout << "Invalid flag: " << lib << ", ignored !!!" << std::endl;
     }

--- a/src/cpp/preprocessor/aie2ps/aie2ps_preprocessor.h
+++ b/src/cpp/preprocessor/aie2ps/aie2ps_preprocessor.h
@@ -19,6 +19,7 @@ class aie2ps_preprocessor: public preprocessor
 {
   const std::string disable_dump_map = "disabledump";
   const std::string full_dump_map = "fulldump";
+  const std::string verbose_asm = "verbose";
   std::shared_ptr<std::map<std::string, std::shared_ptr<isa_op>>> m_isa;
 public:
   aie2ps_preprocessor() {}
@@ -45,25 +46,32 @@ public:
   {
     //auto keys = tinput->get_keys();
     const std::string prefix = "opt_level_";
-    std::shared_ptr<asm_parser> parser(new asm_parser(tinput->get_ctrlcode_data(), tinput->get_include_paths()));
-    parser->parse_lines();
-    auto collist = parser->get_col_list();
-    isa i;
-    uint32_t optimize = 0;
-    m_isa = i.get_isamap();
-    auto toutput = std::make_shared<aie2ps_preprocessed_output>(parser->get_partition_info());
+    
+    // Process flags before parsing to set global verbose flag
     auto flags = tinput->get_flags();
+    uint32_t optimize = 0;
+    asm_dump_flag debug_flag = asm_dump_flag::text;
     for (const auto& flag: flags)
     {
       if (flag == disable_dump_map)
-        toutput->set_debug(asm_dump_flag::disable);
+        debug_flag = asm_dump_flag::disable;
       else if (flag == full_dump_map)
-        toutput->set_debug(asm_dump_flag::full);
+        debug_flag = asm_dump_flag::full;
+      else if (flag == verbose_asm)
+        enable_verbose_logging();
       else if (flag.find(prefix) == 0)
         optimize = std::stoi(flag.substr(prefix.size()));
       else
         std::cout << "Invalid flag: " << flag << ", ignored !!!" << std::endl;
     }
+    
+    std::shared_ptr<asm_parser> parser(new asm_parser(tinput->get_ctrlcode_data(), tinput->get_include_paths()));
+    parser->parse_lines();
+    auto collist = parser->get_col_list();
+    isa i;
+    m_isa = i.get_isamap();
+    auto toutput = std::make_shared<aie2ps_preprocessed_output>(parser->get_partition_info());
+    toutput->set_debug(debug_flag);
     auto& controlpkts = tinput->get_controlpkt();
     auto& ctrlpkt_id_map = tinput->get_ctrlpkt_id_map();
     toutput->set_optmization(optimize);

--- a/src/cpp/preprocessor/asm/asm_parser.cpp
+++ b/src/cpp/preprocessor/asm/asm_parser.cpp
@@ -130,13 +130,14 @@ parse_lines(const std::vector<char>& data, std::string& file)
     if(line.empty())
       continue;
 
-    if (line[0] == ';') //boost::regex_match(line, COMMENT_REGEX))
+    if (boost::regex_match(line, COMMENT_REGEX))
       continue;
 
     boost::smatch sm;
 
-    // Check for Directive (starts with .) - only check regex if prefix matches
-    if (line[0] == '.' && operate_directive(line))
+    // Check for Directive
+    boost::regex_match(line, sm, DIRCETIVE_REGEX);
+    if (operate_directive(line))
     {
       if (!get_annotation_state())
         continue;
@@ -162,8 +163,8 @@ parse_lines(const std::vector<char>& data, std::string& file)
       continue;
     }
 
-    // check for label - fast check for ':' at end before regex
-    if (line.back() == ':' && boost::regex_match(line, sm, LABEL_REGEX))
+    // check for label
+    if (boost::regex_match(line, sm, LABEL_REGEX))
     {
       if (!get_data_state())
         m_current_label = m_current_label + ":" + sm[1].str();
@@ -219,7 +220,7 @@ operate(std::shared_ptr<asm_parser> parserptr, const boost::smatch& sm)
   else if (is_annotation_section(args[0]))
     m_parserptr->set_annotation_state();
   else
-    std::cout << "section directive with unknown section found:" << args[0] << std::endl;
+    LOG_WARN("section directive with unknown section found:" << args[0]);
 }
 
 void
@@ -229,17 +230,17 @@ operate(std::shared_ptr<asm_parser> parserptr, const boost::smatch& sm)
   m_parserptr = parserptr;
   static const boost::regex pattern(R"(\.partition\s+(\d+)(column|core:(\d+)mem))");
   boost::smatch match;
-  std::cout << "PARTITION:" << sm[0].str() << "\n";
+  LOG_INFO("PARTITION:" << sm[0].str());
   std::string line = sm[0].str();
   if (boost::regex_match(line, match, pattern)) {
     if (match[2] == "column") {
-      std::cout << "Column count: " << match[1] << std::endl;
+      LOG_INFO("Column count: " << match[1]);
       m_parserptr->set_numcolumn(to_uinteger<uint32_t>(match[1]));
     } else {
       m_parserptr->set_numcore(to_uinteger<uint32_t>(match[1]));
       m_parserptr->set_nummem(to_uinteger<uint32_t>(match[3]));
-      std::cout << "Core count: " << match[1] << std::endl;
-      std::cout << "Memory size: " << match[3] << std::endl;
+      LOG_INFO("Core count: " << match[1]);
+      LOG_INFO("Memory size: " << match[3]);
     }
   } else
     throw error(error::error_code::invalid_asm, "Invalid format!! " + line + "\n");
@@ -253,7 +254,7 @@ read_include_file(std::string filename)
   if (!file.is_open()) {
     return false;
   }
-//  std::cout << "Reading file:" << filename << std::endl;
+  LOG_INFO("Reading file:" << filename);
   std::string line;
   m_parserptr->set_data_state(false);
 
@@ -368,7 +369,7 @@ read_pad_file(std::string& name, std::string& filename)
     return false;
   }
 
-//  std::cout << "Reading file:" << filename << std::endl;
+  LOG_INFO("Reading file:" << filename);
   std::string line;
   m_parserptr->set_data_state(false);
 

--- a/src/cpp/preprocessor/asm/asm_parser.h
+++ b/src/cpp/preprocessor/asm/asm_parser.h
@@ -6,6 +6,7 @@
 #include "code_section.h"
 #include "utils.h"
 #include "file_utils.h"
+#include "logger.h"
 
 #include <map>
 #include <memory>

--- a/src/cpp/utils/target/target.cpp
+++ b/src/cpp/utils/target/target.cpp
@@ -10,6 +10,7 @@
 #include "target.h"
 #include "utils.h"
 #include "file_utils.h"
+#include "logger.h"
 
 std::map<uint32_t, std::vector<char> >
 aiebu::utilities::
@@ -338,13 +339,15 @@ target_aie4::assemble(const sub_cmd_options &_options)
 
   cxxopts::Options all_options("Target aie4 Options", m_description);
 
+  std::string log_level_str;
   try {
     all_options.add_options()
             ("outputelf,o", "ELF output file name", cxxopts::value<decltype(output_elffile)>())
             ("asm,c", "ASM File", cxxopts::value<decltype(input_file)>())
             ("j,json", "control packet Patching json file", cxxopts::value<decltype(external_buffers_file)>())
             ("L,libpath", "libs path", cxxopts::value<decltype(libpaths)>())
-            ("f,flag", "flags", cxxopts::value<decltype(flags)>())
+            ("f,flag", "flags (e.g., 'verbose' for detailed output, 'disabledump', 'fulldump')", cxxopts::value<decltype(flags)>())
+            ("log-level", "log level: error, warn, info, debug (default: warn)", cxxopts::value<decltype(log_level_str)>())
             ("help,h", "show help message and exit", cxxopts::value<bool>()->default_value("false"))
     ;
 
@@ -379,6 +382,22 @@ target_aie4::assemble(const sub_cmd_options &_options)
     if (result.count("json"))
       external_buffers_file = result["json"].as<decltype(external_buffers_file)>();
 
+    if (result.count("log-level")) {
+      log_level_str = result["log-level"].as<decltype(log_level_str)>();
+      if (log_level_str == "error")
+        aiebu::set_log_level(aiebu::log_level::error);
+      else if (log_level_str == "warn")
+        aiebu::set_log_level(aiebu::log_level::warn);
+      else if (log_level_str == "info")
+        aiebu::set_log_level(aiebu::log_level::info);
+      else if (log_level_str == "debug")
+        aiebu::set_log_level(aiebu::log_level::debug);
+      else {
+        auto errMsg = boost::format("Invalid log level: %s. Valid options: error, warn, info, debug\n") % log_level_str;
+        throw std::runtime_error(errMsg.str());
+      }
+    }
+
   }
   catch (const cxxopts::exceptions::exception& e) {
     std::cout << all_options.help({"", "Target aie4 Options"});
@@ -408,6 +427,7 @@ aiebu::utilities::
 asm_config_parser::parser(const sub_cmd_options &options)
 {
   std::string json_file;
+  std::string log_level_str;
   cxxopts::Options all_options("Target config Options", m_description);
   uint32_t optimization_level =0;
 
@@ -415,8 +435,9 @@ asm_config_parser::parser(const sub_cmd_options &options)
     all_options.add_options()
             ("o,outputelf", "ELF output file name", cxxopts::value<decltype(output_elffile)>())
             ("j,json", "control packet Patching json file", cxxopts::value<decltype(json_file)>())
-            ("f,flag", "flags", cxxopts::value<decltype(flags)>())
+            ("f,flag", "flags (e.g., 'verbose' for detailed output, 'disabledump', 'fulldump')", cxxopts::value<decltype(flags)>())
             ("O,optimization", "optimization level (1-4)", cxxopts::value<int>()->default_value("0"))
+            ("log-level", "log level: error, warn, info, debug (default: warn)", cxxopts::value<decltype(log_level_str)>())
             ("h,help", "show help message and exit", cxxopts::value<bool>()->default_value("false"))
     ;
 
@@ -449,6 +470,22 @@ asm_config_parser::parser(const sub_cmd_options &options)
     if (result.count("flag")) {
        auto extra_flags = result["flag"].as<std::vector<std::string>>();
        flags.insert(flags.end(), extra_flags.begin(), extra_flags.end());
+    }
+
+    if (result.count("log-level")) {
+      log_level_str = result["log-level"].as<decltype(log_level_str)>();
+      if (log_level_str == "error")
+        aiebu::set_log_level(aiebu::log_level::error);
+      else if (log_level_str == "warn")
+        aiebu::set_log_level(aiebu::log_level::warn);
+      else if (log_level_str == "info")
+        aiebu::set_log_level(aiebu::log_level::info);
+      else if (log_level_str == "debug")
+        aiebu::set_log_level(aiebu::log_level::debug);
+      else {
+        auto errMsg = boost::format("Invalid log level: %s. Valid options: error, warn, info, debug\n") % log_level_str;
+        throw std::runtime_error(errMsg.str());
+      }
     }
 
   }

--- a/src/cpp/utils/target/target.h
+++ b/src/cpp/utils/target/target.h
@@ -5,6 +5,7 @@
 
 #include "aiebu/aiebu_assembler.h"
 #include "aiebu/aiebu_error.h"
+#include "logger.h"
 
 #include <filesystem>
 #include <fstream>
@@ -41,7 +42,7 @@ class target
   inline void write_elf(const aiebu::aiebu_assembler& as, const std::string& outfile)
   {
     auto e = as.get_elf();
-    std::cout << "elf size:" << e.size() << "\n";
+    LOG_INFO("elf size:" << e.size());
     std::ofstream output_file(outfile, std::ios_base::binary);
     output_file.write(e.data(), e.size());
   }


### PR DESCRIPTION
#### Problem solved by the commit
aiebu-asm was printing information to console output while assembling. This could reduce aiebu-asm performance.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
N/A

#### How problem was solved, alternative solutions (if any) and why they were rejected
1> Added a verbose flag to aiebu-asm utility to enable verbose logs on cout.
2> To further enhance logging, added log levels for logging, enabled by aiebu-asm flags. "warn" is the default level.
Added --log-level option to both aie4 and config targets: 
("log-level", "log level: error, warn, info, debug (default: warn)"

**The flag accepts 4 values:**
```
error - Only errors
warn - Errors and warnings (default)
info - Errors, warnings, and info messages
debug - All messages (same as -f verbose)
```

**Below are Log levels and its contents.**

```
Levels	     Contents
---------------------------------------------------------------
error        LOG_ERROR only
warn         (default) LOG_ERROR, LOG_WARN
info	     LOG_ERROR, LOG_WARN, LOG_INFO
debug	     LOG_ERROR, LOG_WARN, LOG_INFO, LOG_DEBUG
```


**Example Usage -**

```
# Default: show errors and warnings
aiebu-asm -c input.asm -o output.elf

# Only show errors
aiebu-asm -c input.asm -o output.elf --log-level error

# Show errors, warnings, and info (verbose output)
aiebu-asm -c input.asm -o output.elf --log-level info

# Show everything (debug mode)
aiebu-asm -c input.asm -o output.elf --log-level debug

# Alternative: -f verbose still works (sets to debug)
aiebu-asm -c input.asm -o output.elf -f verbose
```

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
1> Tested on Windows aiebu-asm utility

#### Documentation impact (if any)
