### PR TITLE
Add loglevels to aiebu

### DIFF
--- a/src/cpp/assembler/aiebu_assembler.cpp
+++ b/src/cpp/assembler/aiebu_assembler.cpp
@@ -200,19 +200,19 @@ aiebu_assembler_get_elf(enum aiebu_assembler_buffer_type type,
 
   if (buffer1 == nullptr && buffer1_size != 0)
   {
-    aiebu::LOG_ERROR() << "Invalid buffer1 size";
+    aiebu::log_error() << "Invalid buffer1 size";
     return -(static_cast<int>(aiebu::error::error_code::invalid_input));
   }
 
   if (buffer2 == nullptr && buffer2_size != 0)
   {
-    aiebu::LOG_ERROR() << "Invalid buffer2 size";
+    aiebu::log_error() << "Invalid buffer2 size";
     return -(static_cast<int>(aiebu::error::error_code::invalid_input));
   }
 
   if (patch_json == nullptr && patch_json_size !=0)
   {
-    aiebu::LOG_ERROR() << "Invalid patch json size";
+    aiebu::log_error() << "Invalid patch json size";
     return -(static_cast<int>(aiebu::error::error_code::invalid_input));
   }
 
@@ -249,12 +249,12 @@ aiebu_assembler_get_elf(enum aiebu_assembler_buffer_type type,
   }
   catch (aiebu::error &ex)
   {
-    aiebu::LOG_ERROR() << ex.what();
+    aiebu::log_error() << ex.what();
     ret = -(ex.get_code());
   }
   catch (std::exception &ex)
   {
-    aiebu::LOG_ERROR() << ex.what();
+    aiebu::log_error() << ex.what();
     ret = -(static_cast<int>(aiebu::error::error_code::internal_error));
   }
   return ret;

--- a/src/cpp/assembler/aiebu_assembler.cpp
+++ b/src/cpp/assembler/aiebu_assembler.cpp
@@ -200,19 +200,19 @@ aiebu_assembler_get_elf(enum aiebu_assembler_buffer_type type,
 
   if (buffer1 == nullptr && buffer1_size != 0)
   {
-    LOG_ERROR("Invalid buffer1 size");
+    aiebu::LOG_ERROR() << "Invalid buffer1 size";
     return -(static_cast<int>(aiebu::error::error_code::invalid_input));
   }
 
   if (buffer2 == nullptr && buffer2_size != 0)
   {
-    LOG_ERROR("Invalid buffer2 size");
+    aiebu::LOG_ERROR() << "Invalid buffer2 size";
     return -(static_cast<int>(aiebu::error::error_code::invalid_input));
   }
 
   if (patch_json == nullptr && patch_json_size !=0)
   {
-    LOG_ERROR("Invalid patch json size");
+    aiebu::LOG_ERROR() << "Invalid patch json size";
     return -(static_cast<int>(aiebu::error::error_code::invalid_input));
   }
 
@@ -249,12 +249,12 @@ aiebu_assembler_get_elf(enum aiebu_assembler_buffer_type type,
   }
   catch (aiebu::error &ex)
   {
-    LOG_ERROR(ex.what());
+    aiebu::LOG_ERROR() << ex.what();
     ret = -(ex.get_code());
   }
   catch (std::exception &ex)
   {
-    LOG_ERROR(ex.what());
+    aiebu::LOG_ERROR() << ex.what();
     ret = -(static_cast<int>(aiebu::error::error_code::internal_error));
   }
   return ret;

--- a/src/cpp/assembler/aiebu_assembler.cpp
+++ b/src/cpp/assembler/aiebu_assembler.cpp
@@ -10,6 +10,7 @@
 #include "utils.h"
 #include "file_utils.h"
 #include "transform_manager.h"
+#include "logger.h"
 #include "aiebu/aiebu.h"
 #include "aiebu/aiebu_assembler.h"
 #include "aiebu/aiebu_error.h"
@@ -199,19 +200,19 @@ aiebu_assembler_get_elf(enum aiebu_assembler_buffer_type type,
 
   if (buffer1 == nullptr && buffer1_size != 0)
   {
-    std::cout << "ERROR: Invalid buffer1 size" << std::endl;
+    LOG_ERROR("Invalid buffer1 size");
     return -(static_cast<int>(aiebu::error::error_code::invalid_input));
   }
 
   if (buffer2 == nullptr && buffer2_size != 0)
   {
-    std::cout << "ERROR: Invalid buffer2 size" << std::endl;
+    LOG_ERROR("Invalid buffer2 size");
     return -(static_cast<int>(aiebu::error::error_code::invalid_input));
   }
 
   if (patch_json == nullptr && patch_json_size !=0)
   {
-    std::cout << "ERROR: Invalid patch json size" << std::endl;
+    LOG_ERROR("Invalid patch json size");
     return -(static_cast<int>(aiebu::error::error_code::invalid_input));
   }
 
@@ -248,12 +249,12 @@ aiebu_assembler_get_elf(enum aiebu_assembler_buffer_type type,
   }
   catch (aiebu::error &ex)
   {
-    std::cout << "ERROR: " <<  ex.what() << std::endl;
+    LOG_ERROR(ex.what());
     ret = -(ex.get_code());
   }
   catch (std::exception &ex)
   {
-    std::cout << "ERROR: " <<  ex.what() << std::endl;
+    LOG_ERROR(ex.what());
     ret = -(static_cast<int>(aiebu::error::error_code::internal_error));
   }
   return ret;

--- a/src/cpp/common/logger.h
+++ b/src/cpp/common/logger.h
@@ -6,72 +6,114 @@
 
 #include <iostream>
 #include <sstream>
+#include <string>
 
 namespace aiebu {
 
-// Log Levels
 enum class log_level {
-  error = 0,   // Always shown
-  warn = 1,    // Warnings
-  info = 2,    // Informational messages (shown with verbose)
-  debug = 3    // Debug messages (shown with verbose)
+    error = 0,
+    warn = 1,
+    info = 2,
+    debug = 3
 };
 
-// Internal function to access log level (thread-safe singleton pattern)
 inline log_level& get_log_level_ref() {
-  static log_level level = log_level::warn;
+    static log_level level = log_level::warn;  // default
   return level;
 }
 
-// Set log level
 inline void set_log_level(log_level level) {
   get_log_level_ref() = level;
 }
 
-// Get log level
 inline log_level get_log_level() {
   return get_log_level_ref();
 }
 
-// Enable verbose mode (shows info and debug messages)
+// functions for verbose mode if needed for future use
 inline void enable_verbose_logging() {
-  get_log_level_ref() = log_level::debug;
+    set_log_level(log_level::debug);
 }
 
-// Disable verbose mode (back to default: errors and warnings)
 inline void disable_verbose_logging() {
-  get_log_level_ref() = log_level::warn;
+    set_log_level(log_level::warn);
+}
+
+// check if level is enabled
+inline bool is_enabled(log_level level) noexcept {
+    return static_cast<int>(level) <= static_cast<int>(get_log_level_ref());
+}
+
+// Logger stream class that supports << operator
+class log_stream {
+private:
+    log_level level;
+    std::ostringstream oss;
+    bool enabled;
+
+    void output() {
+        if (!enabled) return;
+
+        std::string msg = oss.str();
+        switch (level) {
+            case log_level::error:
+                std::cerr << "[ERROR] " << msg << std::endl;
+                break;
+            case log_level::warn:
+                std::cout << "[WARN ] " << msg << std::endl;
+                break;
+            case log_level::info:
+                std::cout << "[INFO ] " << msg << std::endl;
+                break;
+            case log_level::debug:
+                std::cout << "[DEBUG] " << msg << std::endl;
+                break;
+        }
+    }
+
+public:
+    log_stream(log_level lvl)
+        : level(lvl), enabled(is_enabled(lvl)) {}
+
+    // Destructor outputs the message
+    ~log_stream() {
+        output();
+    }
+
+    // Overload << operator to support streaming
+    template<typename T>
+    log_stream& operator<<(const T& value) {
+        if (enabled) {
+            oss << value;
+        }
+        return *this;
+    }
+
+    // Special handling for std::endl and other manipulators
+    log_stream& operator<<(std::ostream& (*manip)(std::ostream&)) {
+        if (enabled) {
+            oss << manip;
+        }
+        return *this;
+    }
+};
+
+inline log_stream LOG_ERROR() {
+    return log_stream(log_level::error);
+}
+
+inline log_stream LOG_WARN() {
+    return log_stream(log_level::warn);
+}
+
+inline log_stream LOG_INFO() {
+    return log_stream(log_level::info);
+}
+
+inline log_stream LOG_DEBUG() {
+    return log_stream(log_level::debug);
 }
 
 } // namespace aiebu
 
-// NOLINTBEGIN(cppcoreguidelines-avoid-do-while)
-#define LOG_ERROR(msg) \
-  do { \
-    std::cerr << "[ERROR] " << msg << std::endl; \
-  } while (0)
-
-#define LOG_WARN(msg) \
-  do { \
-    if (aiebu::get_log_level_ref() >= aiebu::log_level::warn) { \
-      std::cout << "[WARN] " << msg << std::endl; \
-    } \
-  } while (0)
-
-#define LOG_INFO(msg) \
-  do { \
-    if (aiebu::get_log_level_ref() >= aiebu::log_level::info) { \
-      std::cout << "[INFO] " << msg << std::endl; \
-    } \
-  } while (0)
-
-#define LOG_DEBUG(msg) \
-  do { \
-    if (aiebu::get_log_level_ref() >= aiebu::log_level::debug) { \
-      std::cout << "[DEBUG] " << msg << std::endl; \
-    } \
-  } while (0)
-// NOLINTEND(cppcoreguidelines-avoid-do-while)
-
 #endif // AIEBU_COMMON_LOGGER_H
-

--- a/src/cpp/common/logger.h
+++ b/src/cpp/common/logger.h
@@ -98,10 +98,10 @@ private:
     buf_type buf;
 };
 
-// Optimized Logger using array-based storage
-class Logger {
+// Optimized logger using array-based storage
+class logger {
 public:
-    Logger() {
+    logger() {
         // Create one log_stream per level (error uses cerr, others use cout)
         streams[to_index(log_level::error)] = std::make_unique<log_stream>(std::cerr, log_level::error);
         streams[to_index(log_level::warn)]  = std::make_unique<log_stream>(std::cout, log_level::warn);
@@ -132,9 +132,9 @@ private:
 };
 
 // Global logger instance
-inline Logger& get_logger() {
-    static Logger logger;
-    return logger;
+inline std::ostream& get_logger(log_level lvl) {
+    static logger instance;
+    return instance(lvl);
 }
 
 // Public API functions
@@ -154,25 +154,21 @@ inline void disable_verbose_logging() noexcept {
     set_log_level(log_level::warn);
 }
 
-// Optimized log functions with static logger reference
-inline std::ostream& LOG_ERROR() noexcept {
-    static Logger& logger = get_logger();
-    return logger(log_level::error);
+// Log functions
+inline std::ostream& log_error() noexcept {
+    return get_logger(log_level::error);
 }
 
-inline std::ostream& LOG_WARN() noexcept {
-    static Logger& logger = get_logger();
-    return logger(log_level::warn);
+inline std::ostream& log_warn() noexcept {
+    return get_logger(log_level::warn);
 }
 
-inline std::ostream& LOG_INFO() noexcept {
-    static Logger& logger = get_logger();
-    return logger(log_level::info);
+inline std::ostream& log_info() noexcept {
+    return get_logger(log_level::info);
 }
 
-inline std::ostream& LOG_DEBUG() noexcept {
-    static Logger& logger = get_logger();
-    return logger(log_level::debug);
+inline std::ostream& log_debug() noexcept {
+    return get_logger(log_level::debug);
 }
 
 } // namespace aiebu

--- a/src/cpp/common/logger.h
+++ b/src/cpp/common/logger.h
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+
+#ifndef AIEBU_COMMON_LOGGER_H
+#define AIEBU_COMMON_LOGGER_H
+
+#include <iostream>
+#include <sstream>
+
+namespace aiebu {
+
+// Log Levels
+enum class log_level {
+  error = 0,   // Always shown
+  warn = 1,    // Warnings
+  info = 2,    // Informational messages (shown with verbose)
+  debug = 3    // Debug messages (shown with verbose)
+};
+
+// Global log level (default: errors and warnings)
+inline log_level g_log_level = log_level::warn;
+
+// Set log level
+inline void set_log_level(log_level level) {
+  g_log_level = level;
+}
+
+// Get log level
+inline log_level get_log_level() {
+  return g_log_level;
+}
+
+// Enable verbose mode (shows info and debug messages)
+inline void enable_verbose_logging() {
+  g_log_level = log_level::debug;
+}
+
+// Disable verbose mode (back to default: errors and warnings)
+inline void disable_verbose_logging() {
+  g_log_level = log_level::warn;
+}
+
+} // namespace aiebu
+
+// Logging macros
+#define LOG_ERROR(msg) \
+  do { \
+    std::cerr << "[ERROR] " << msg << std::endl; \
+  } while (0)
+
+#define LOG_WARN(msg) \
+  do { \
+    if (aiebu::g_log_level >= aiebu::log_level::warn) { \
+      std::cout << "[WARN] " << msg << std::endl; \
+    } \
+  } while (0)
+
+#define LOG_INFO(msg) \
+  do { \
+    if (aiebu::g_log_level >= aiebu::log_level::info) { \
+      std::cout << msg << std::endl; \
+    } \
+  } while (0)
+
+#define LOG_DEBUG(msg) \
+  do { \
+    if (aiebu::g_log_level >= aiebu::log_level::debug) { \
+      std::cout << "[DEBUG] " << msg << std::endl; \
+    } \
+  } while (0)
+
+#endif // AIEBU_COMMON_LOGGER_H
+

--- a/src/cpp/common/logger.h
+++ b/src/cpp/common/logger.h
@@ -17,32 +17,35 @@ enum class log_level {
   debug = 3    // Debug messages (shown with verbose)
 };
 
-// Global log level (default: errors and warnings)
-inline log_level g_log_level = log_level::warn;
+// Internal function to access log level (thread-safe singleton pattern)
+inline log_level& get_log_level_ref() {
+  static log_level level = log_level::warn;
+  return level;
+}
 
 // Set log level
 inline void set_log_level(log_level level) {
-  g_log_level = level;
+  get_log_level_ref() = level;
 }
 
 // Get log level
 inline log_level get_log_level() {
-  return g_log_level;
+  return get_log_level_ref();
 }
 
 // Enable verbose mode (shows info and debug messages)
 inline void enable_verbose_logging() {
-  g_log_level = log_level::debug;
+  get_log_level_ref() = log_level::debug;
 }
 
 // Disable verbose mode (back to default: errors and warnings)
 inline void disable_verbose_logging() {
-  g_log_level = log_level::warn;
+  get_log_level_ref() = log_level::warn;
 }
 
 } // namespace aiebu
 
-// Logging macros
+// NOLINTBEGIN(cppcoreguidelines-avoid-do-while)
 #define LOG_ERROR(msg) \
   do { \
     std::cerr << "[ERROR] " << msg << std::endl; \
@@ -50,24 +53,25 @@ inline void disable_verbose_logging() {
 
 #define LOG_WARN(msg) \
   do { \
-    if (aiebu::g_log_level >= aiebu::log_level::warn) { \
+    if (aiebu::get_log_level_ref() >= aiebu::log_level::warn) { \
       std::cout << "[WARN] " << msg << std::endl; \
     } \
   } while (0)
 
 #define LOG_INFO(msg) \
   do { \
-    if (aiebu::g_log_level >= aiebu::log_level::info) { \
-      std::cout << msg << std::endl; \
+    if (aiebu::get_log_level_ref() >= aiebu::log_level::info) { \
+      std::cout << "[INFO]" << msg << std::endl; \
     } \
   } while (0)
 
 #define LOG_DEBUG(msg) \
   do { \
-    if (aiebu::g_log_level >= aiebu::log_level::debug) { \
+    if (aiebu::get_log_level_ref() >= aiebu::log_level::debug) { \
       std::cout << "[DEBUG] " << msg << std::endl; \
     } \
   } while (0)
+// NOLINTEND(cppcoreguidelines-avoid-do-while)
 
 #endif // AIEBU_COMMON_LOGGER_H
 

--- a/src/cpp/common/logger.h
+++ b/src/cpp/common/logger.h
@@ -40,7 +40,7 @@ inline bool is_enabled(log_level lvl) noexcept {
 // Null buffer that discards all output for disabled log levels
 class null_buffer : public std::streambuf {
 protected:
-    virtual int_type overflow(int_type c) override {
+    int_type overflow(int_type c) override {
         return traits_type::not_eof(c);
     }
 };
@@ -57,12 +57,12 @@ private:
     class buf_type : public std::streambuf {
     public:
         buf_type(std::ostream& out, log_level lvl)
-            : sink(out), level(lvl), begun(false) {}
+            : sink(out), level(lvl) {}
 
         void set_level(log_level lvl) { level = lvl; }
 
     protected:
-        virtual int_type overflow(int_type ch) override {
+        int_type overflow(int_type ch) override {
             if (!begun) {
                 sink << '[' << to_string(level) << "] ";
                 begun = true;
@@ -73,7 +73,7 @@ private:
             return traits_type::not_eof(ch);
         }
 
-        virtual int sync() override {
+        int sync() override {
             sink.flush();
             begun = false;  // New message next time
             return 0;
@@ -92,7 +92,7 @@ private:
 
         std::ostream& sink;
         log_level level;
-        bool begun;
+        bool begun{false};
     };
 
     buf_type buf;

--- a/src/cpp/common/logger.h
+++ b/src/cpp/common/logger.h
@@ -61,7 +61,7 @@ inline void disable_verbose_logging() {
 #define LOG_INFO(msg) \
   do { \
     if (aiebu::get_log_level_ref() >= aiebu::log_level::info) { \
-      std::cout << "[INFO]" << msg << std::endl; \
+      std::cout << "[INFO] " << msg << std::endl; \
     } \
   } while (0)
 

--- a/src/cpp/common/logger.h
+++ b/src/cpp/common/logger.h
@@ -5,8 +5,9 @@
 #define AIEBU_COMMON_LOGGER_H
 
 #include <iostream>
-#include <sstream>
-#include <string>
+#include <streambuf>
+#include <memory>
+#include <array>
 
 namespace aiebu {
 
@@ -17,103 +18,164 @@ enum class log_level {
     debug = 3
 };
 
-inline log_level& get_log_level_ref() {
-    static log_level level = log_level::warn;  // default
-  return level;
+// constexpr helpers
+constexpr int to_int(log_level lvl) noexcept {
+    return static_cast<int>(lvl);
 }
 
-inline void set_log_level(log_level level) {
-  get_log_level_ref() = level;
+constexpr std::size_t to_index(log_level lvl) noexcept {
+    return static_cast<std::size_t>(lvl);
 }
 
-inline log_level get_log_level() {
-  return get_log_level_ref();
+// Global minimum log level (singleton pattern)
+inline log_level& get_log_level_ref() noexcept {
+    static log_level min_level = log_level::warn;
+    return min_level;
 }
 
-// functions for verbose mode if needed for future use
-inline void enable_verbose_logging() {
-    set_log_level(log_level::debug);
+inline bool is_enabled(log_level lvl) noexcept {
+    return to_int(lvl) <= to_int(get_log_level_ref());
 }
 
-inline void disable_verbose_logging() {
-    set_log_level(log_level::warn);
-}
-
-// check if level is enabled
-inline bool is_enabled(log_level level) noexcept {
-    return static_cast<int>(level) <= static_cast<int>(get_log_level_ref());
-}
-
-// Logger stream class that supports << operator
-class log_stream {
-private:
-    log_level level;
-    std::ostringstream oss;
-    bool enabled;
-
-    void output() {
-        if (!enabled) return;
-
-        std::string msg = oss.str();
-        switch (level) {
-            case log_level::error:
-                std::cerr << "[ERROR] " << msg << std::endl;
-                break;
-            case log_level::warn:
-                std::cout << "[WARN ] " << msg << std::endl;
-                break;
-            case log_level::info:
-                std::cout << "[INFO ] " << msg << std::endl;
-                break;
-            case log_level::debug:
-                std::cout << "[DEBUG] " << msg << std::endl;
-                break;
-        }
-    }
-
-public:
-    log_stream(log_level lvl)
-        : level(lvl), enabled(is_enabled(lvl)) {}
-
-    // Destructor outputs the message
-    ~log_stream() {
-        output();
-    }
-
-    // Overload << operator to support streaming
-    template<typename T>
-    log_stream& operator<<(const T& value) {
-        if (enabled) {
-            oss << value;
-        }
-        return *this;
-    }
-
-    // Special handling for std::endl and other manipulators
-    log_stream& operator<<(std::ostream& (*manip)(std::ostream&)) {
-        if (enabled) {
-            oss << manip;
-        }
-        return *this;
+// Null buffer that discards all output for disabled log levels
+class null_buffer : public std::streambuf {
+protected:
+    virtual int_type overflow(int_type c) override {
+        return traits_type::not_eof(c);
     }
 };
 
-inline log_stream LOG_ERROR() {
-    return log_stream(log_level::error);
+// Optimized log_stream with nested buffer
+class log_stream : public std::ostream {
+public:
+    log_stream(std::ostream& out, log_level lvl)
+        : std::ostream(&buf), buf(out, lvl) {}
+
+    void set_level(log_level lvl) { buf.set_level(lvl); }
+
+private:
+    class buf_type : public std::streambuf {
+    public:
+        buf_type(std::ostream& out, log_level lvl)
+            : sink(out), level(lvl), begun(false) {}
+
+        void set_level(log_level lvl) { level = lvl; }
+
+    protected:
+        virtual int_type overflow(int_type ch) override {
+            if (!begun) {
+                sink << '[' << to_string(level) << "] ";
+                begun = true;
+            }
+            if (!traits_type::eq_int_type(ch, traits_type::eof())) {
+                sink.put(static_cast<char>(ch));
+            }
+            return traits_type::not_eof(ch);
+        }
+
+        virtual int sync() override {
+            sink.flush();
+            begun = false;  // New message next time
+            return 0;
+        }
+
+    private:
+        static constexpr const char* to_string(log_level l) noexcept {
+            switch (l) {
+                case log_level::error: return "ERROR";
+                case log_level::warn:  return "WARN ";
+                case log_level::info:  return "INFO ";
+                case log_level::debug: return "DEBUG";
+            }
+            return "?";
+        }
+
+        std::ostream& sink;
+        log_level level;
+        bool begun;
+    };
+
+    buf_type buf;
+};
+
+// Optimized Logger using array-based storage
+class Logger {
+public:
+    Logger() {
+        // Create one log_stream per level (error uses cerr, others use cout)
+        streams[to_index(log_level::error)] = std::make_unique<log_stream>(std::cerr, log_level::error);
+        streams[to_index(log_level::warn)]  = std::make_unique<log_stream>(std::cout, log_level::warn);
+        streams[to_index(log_level::info)]  = std::make_unique<log_stream>(std::cout, log_level::info);
+        streams[to_index(log_level::debug)] = std::make_unique<log_stream>(std::cout, log_level::debug);
+    }
+
+    inline std::ostream& operator()(log_level lvl) noexcept {
+        if (is_enabled(lvl)) {
+            return *streams[to_index(lvl)];
+        }
+        // Lazily init null stream for disabled levels
+        if (!null_stream) {
+            null_stream = std::make_unique<std::ostream>(&null_buf);
+        }
+        return *null_stream;
+    }
+
+    // Convenience method (same as operator())
+    inline std::ostream& get_stream(log_level lvl) noexcept {
+        return (*this)(lvl);
+    }
+
+private:
+    std::array<std::unique_ptr<log_stream>, 4> streams;
+    null_buffer null_buf;
+    std::unique_ptr<std::ostream> null_stream;
+};
+
+// Global logger instance
+inline Logger& get_logger() {
+    static Logger logger;
+    return logger;
 }
 
-inline log_stream LOG_WARN() {
-    return log_stream(log_level::warn);
+// Public API functions
+inline void set_log_level(log_level lvl) noexcept {
+    get_log_level_ref() = lvl;
 }
 
-inline log_stream LOG_INFO() {
-    return log_stream(log_level::info);
+inline log_level get_log_level() noexcept {
+    return get_log_level_ref();
 }
 
-inline log_stream LOG_DEBUG() {
-    return log_stream(log_level::debug);
+inline void enable_verbose_logging() noexcept {
+    set_log_level(log_level::debug);
+}
+
+inline void disable_verbose_logging() noexcept {
+    set_log_level(log_level::warn);
+}
+
+// Optimized log functions with static logger reference
+inline std::ostream& LOG_ERROR() noexcept {
+    static Logger& logger = get_logger();
+    return logger(log_level::error);
+}
+
+inline std::ostream& LOG_WARN() noexcept {
+    static Logger& logger = get_logger();
+    return logger(log_level::warn);
+}
+
+inline std::ostream& LOG_INFO() noexcept {
+    static Logger& logger = get_logger();
+    return logger(log_level::info);
+}
+
+inline std::ostream& LOG_DEBUG() noexcept {
+    static Logger& logger = get_logger();
+    return logger(log_level::debug);
 }
 
 } // namespace aiebu
 
 #endif // AIEBU_COMMON_LOGGER_H
+

--- a/src/cpp/elf/elfwriter.cpp
+++ b/src/cpp/elf/elfwriter.cpp
@@ -2,6 +2,7 @@
 // Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
 #include "elfwriter.h"
+#include "logger.h"
 
 namespace aiebu {
 
@@ -118,7 +119,7 @@ elf_writer::
 finalize()
 {
   add_note(NT_XRT_UID, ".note.xrt.UID", m_uid.calculate());
-  std::cout << "UID:" << m_uid.str() << "\n";
+  LOG_INFO("UID:" << m_uid.str());
   std::stringstream stream;
   stream << std::noskipws;
   //m_elfio.save( "hello_32" );

--- a/src/cpp/elf/elfwriter.cpp
+++ b/src/cpp/elf/elfwriter.cpp
@@ -119,7 +119,7 @@ elf_writer::
 finalize()
 {
   add_note(NT_XRT_UID, ".note.xrt.UID", m_uid.calculate());
-  LOG_INFO() << "UID:" << m_uid.str();
+  log_info() << "UID:" << m_uid.str();
   std::stringstream stream;
   stream << std::noskipws;
   //m_elfio.save( "hello_32" );

--- a/src/cpp/elf/elfwriter.cpp
+++ b/src/cpp/elf/elfwriter.cpp
@@ -119,7 +119,7 @@ elf_writer::
 finalize()
 {
   add_note(NT_XRT_UID, ".note.xrt.UID", m_uid.calculate());
-  LOG_INFO("UID:" << m_uid.str());
+  LOG_INFO() << "UID:" << m_uid.str();
   std::stringstream stream;
   stream << std::noskipws;
   //m_elfio.save( "hello_32" );

--- a/src/cpp/encoder/aie2ps/aie2ps_encoder.cpp
+++ b/src/cpp/encoder/aie2ps/aie2ps_encoder.cpp
@@ -80,7 +80,7 @@ process(std::shared_ptr<preprocessed_output> input)
     }
   }
 
-  // Report (only if verbose flag is set or log level is info or higher)
+  // Report (only if log level is info or higher)
   if (get_log_level() >= log_level::info)
     m_report.summary(std::cout);
 

--- a/src/cpp/encoder/aie2ps/aie2ps_encoder.cpp
+++ b/src/cpp/encoder/aie2ps/aie2ps_encoder.cpp
@@ -3,6 +3,7 @@
 #include "aie2ps_encoder.h"
 
 #include "aiebu/aiebu_error.h"
+#include "logger.h"
 
 #include <cassert>
 
@@ -78,6 +79,10 @@ process(std::shared_ptr<preprocessed_output> input)
       twriter.push_back(ctrlpktwriter); 
     }
   }
+
+  // Report (only if verbose flag is set or log level is info or higher)
+  if (get_log_level() >= log_level::info)
+    m_report.summary(std::cout);
 
   // Debug JSON serialization
   json dbg_json = m_debug.to_json();

--- a/src/cpp/ops/ops.cpp
+++ b/src/cpp/ops/ops.cpp
@@ -123,7 +123,7 @@ serialize(std::shared_ptr<assembler_state> state, std::vector<symbol>& symbols,
           // arg 0 to 6 and be patched in CERT.
           // Beyond that its elfloader/host responsibility to patch mandatorily
           if (val > 6 && val != offset_type_marker)
-            LOG_WARN() << "Apply_offset_57 has arg index " << val << " > 6, Should be mandatorily patched in host!!!";
+            log_warn() << "Apply_offset_57 has arg index " << val << " > 6, Should be mandatorily patched in host!!!";
           else if (val != offset_type_marker)
           {
             // val is arg index, to get offset x2

--- a/src/cpp/ops/ops.cpp
+++ b/src/cpp/ops/ops.cpp
@@ -123,7 +123,7 @@ serialize(std::shared_ptr<assembler_state> state, std::vector<symbol>& symbols,
           // arg 0 to 6 and be patched in CERT.
           // Beyond that its elfloader/host responsibility to patch mandatorily
           if (val > 6 && val != offset_type_marker)
-            LOG_WARN("Apply_offset_57 has arg index " << val << " > 6, Should be mandatorily patched in host!!!");
+            LOG_WARN() << "Apply_offset_57 has arg index " << val << " > 6, Should be mandatorily patched in host!!!";
           else if (val != offset_type_marker)
           {
             // val is arg index, to get offset x2

--- a/src/cpp/ops/ops.cpp
+++ b/src/cpp/ops/ops.cpp
@@ -3,6 +3,7 @@
 
 #include "ops.h"
 #include "aiebu/aiebu_error.h"
+#include "logger.h"
 
 #include <string>
 #include <iomanip>
@@ -122,7 +123,7 @@ serialize(std::shared_ptr<assembler_state> state, std::vector<symbol>& symbols,
           // arg 0 to 6 and be patched in CERT.
           // Beyond that its elfloader/host responsibility to patch mandatorily
           if (val > 6 && val != offset_type_marker)
-            std::cout <<"WARNING: Apply_offset_57 has arg index " << val << " > 6, Should be mandatorily patched in host!!!\n";
+            LOG_WARN("Apply_offset_57 has arg index " << val << " > 6, Should be mandatorily patched in host!!!");
           else if (val != offset_type_marker)
           {
             // val is arg index, to get offset x2

--- a/src/cpp/preprocessor/aie2/aie2_blob_preprocessor_input.cpp
+++ b/src/cpp/preprocessor/aie2/aie2_blob_preprocessor_input.cpp
@@ -25,7 +25,7 @@ add_preemption_code(uint32_t col)
     auto error_msg = boost::format("Preemption save/restore code for not available for txn buffer with col:(%d)\n") % col;
     throw error(error::error_code::invalid_asm, error_msg.str());
   }
-  LOG_INFO("Save/Restore preemption code added for col " << col);
+  LOG_INFO() << "Save/Restore preemption code added for col " << col;
   m_data[preempt_save].resize(stx_save_restore_map.at(col).first.size());
   std::memcpy(m_data[preempt_save].data(), stx_save_restore_map.at(col).first.data(), stx_save_restore_map.at(col).first.size());
 
@@ -1026,7 +1026,7 @@ add_preemption_code(uint32_t col)
         const auto& pdis = pt_pdis.get();
         add_pdi(mangled_name, pdis, paths);
       } else {
-        LOG_WARN("PDIs not found");
+        LOG_WARN() << "PDIs not found";
       }
 
       const auto& pt_instance = ctrlcode.get_child_optional("instance");
@@ -1034,7 +1034,7 @@ add_preemption_code(uint32_t col)
         const auto& pinstance = pt_instance.get();
         add_instance(mangled_name, pinstance, paths);
       } else {
-        LOG_WARN("instance not found");
+        LOG_WARN() << "instance not found";
       }
     }
   }

--- a/src/cpp/preprocessor/aie2/aie2_blob_preprocessor_input.cpp
+++ b/src/cpp/preprocessor/aie2/aie2_blob_preprocessor_input.cpp
@@ -25,7 +25,7 @@ add_preemption_code(uint32_t col)
     auto error_msg = boost::format("Preemption save/restore code for not available for txn buffer with col:(%d)\n") % col;
     throw error(error::error_code::invalid_asm, error_msg.str());
   }
-  LOG_INFO() << "Save/Restore preemption code added for col " << col;
+  log_info() << "Save/Restore preemption code added for col " << col;
   m_data[preempt_save].resize(stx_save_restore_map.at(col).first.size());
   std::memcpy(m_data[preempt_save].data(), stx_save_restore_map.at(col).first.data(), stx_save_restore_map.at(col).first.size());
 
@@ -1026,7 +1026,7 @@ add_preemption_code(uint32_t col)
         const auto& pdis = pt_pdis.get();
         add_pdi(mangled_name, pdis, paths);
       } else {
-        LOG_WARN() << "PDIs not found";
+        log_warn() << "PDIs not found";
       }
 
       const auto& pt_instance = ctrlcode.get_child_optional("instance");
@@ -1034,7 +1034,7 @@ add_preemption_code(uint32_t col)
         const auto& pinstance = pt_instance.get();
         add_instance(mangled_name, pinstance, paths);
       } else {
-        LOG_WARN() << "instance not found";
+        log_warn() << "instance not found";
       }
     }
   }

--- a/src/cpp/preprocessor/aie2/aie2_blob_preprocessor_input.cpp
+++ b/src/cpp/preprocessor/aie2/aie2_blob_preprocessor_input.cpp
@@ -4,6 +4,7 @@
 #include <filesystem>
 #include "file_utils.h"
 #include "aie2_blob_preprocessor_input.h"
+#include "logger.h"
 #include "xaiengine.h"
 
 # if defined (AIEBU_NATIVE_BUILD)
@@ -24,7 +25,7 @@ add_preemption_code(uint32_t col)
     auto error_msg = boost::format("Preemption save/restore code for not available for txn buffer with col:(%d)\n") % col;
     throw error(error::error_code::invalid_asm, error_msg.str());
   }
-  std::cout << "Save/Restore preemption code added for col" << col << "\n";
+  LOG_INFO("Save/Restore preemption code added for col " << col);
   m_data[preempt_save].resize(stx_save_restore_map.at(col).first.size());
   std::memcpy(m_data[preempt_save].data(), stx_save_restore_map.at(col).first.data(), stx_save_restore_map.at(col).first.size());
 
@@ -1025,7 +1026,7 @@ add_preemption_code(uint32_t col)
         const auto& pdis = pt_pdis.get();
         add_pdi(mangled_name, pdis, paths);
       } else {
-        std::cout << "PDIs not found\n";
+        LOG_WARN("PDIs not found");
       }
 
       const auto& pt_instance = ctrlcode.get_child_optional("instance");
@@ -1033,7 +1034,7 @@ add_preemption_code(uint32_t col)
         const auto& pinstance = pt_instance.get();
         add_instance(mangled_name, pinstance, paths);
       } else {
-        std::cout << "instance not found\n";
+        LOG_WARN("instance not found");
       }
     }
   }

--- a/src/cpp/preprocessor/aie2/aie2_blob_preprocessor_input.h
+++ b/src/cpp/preprocessor/aie2/aie2_blob_preprocessor_input.h
@@ -9,6 +9,7 @@
 #include "utils.h"
 #include "file_utils.h"
 #include "preprocessor_input.h"
+#include "asm/asm_parser.h"
 #include <boost/format.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
@@ -105,6 +106,8 @@ public:
     {
       if (lib == legacydpuxclbin)
         arg_offset = 1;
+      else if (lib == "verbose")
+        enable_verbose_logging();
       else
         std::cout << "Invalid flag: " << lib << ", ignored !!!" << std::endl;
     }

--- a/src/cpp/preprocessor/aie2/aie2_blob_preprocessor_input.h
+++ b/src/cpp/preprocessor/aie2/aie2_blob_preprocessor_input.h
@@ -120,10 +120,10 @@ public:
         else if (log_level_str == "debug")
           set_log_level(log_level::debug);
         else
-          LOG_WARN() << "Invalid log level flag: " << lib << ", ignored";
+          log_warn() << "Invalid log level flag: " << lib << ", ignored";
       }
       else
-        LOG_WARN() << "Invalid flag: " << lib << ", ignored";
+        log_warn() << "Invalid flag: " << lib << ", ignored";
     }
 
     m_data[".ctrltext"] = mc_code;

--- a/src/cpp/preprocessor/aie2/aie2_blob_preprocessor_input.h
+++ b/src/cpp/preprocessor/aie2/aie2_blob_preprocessor_input.h
@@ -120,10 +120,10 @@ public:
         else if (log_level_str == "debug")
           set_log_level(log_level::debug);
         else
-          LOG_WARN("Invalid log level flag: " << lib << ", ignored");
+          LOG_WARN() << "Invalid log level flag: " << lib << ", ignored";
       }
       else
-        LOG_WARN("Invalid flag: " << lib << ", ignored");
+        LOG_WARN() << "Invalid flag: " << lib << ", ignored";
     }
 
     m_data[".ctrltext"] = mc_code;

--- a/src/cpp/preprocessor/aie2/aie2_blob_preprocessor_input.h
+++ b/src/cpp/preprocessor/aie2/aie2_blob_preprocessor_input.h
@@ -10,6 +10,7 @@
 #include "file_utils.h"
 #include "preprocessor_input.h"
 #include "asm/asm_parser.h"
+#include "logger.h"
 #include <boost/format.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
@@ -102,14 +103,27 @@ public:
                         const std::vector<std::string>& /*libpaths*/,
                         const std::map<uint32_t, std::vector<char> >& ctrlpkt) override
   {
+    const std::string loglevel_prefix = "loglevel_";
     for (const auto& lib: libs)
     {
       if (lib == legacydpuxclbin)
         arg_offset = 1;
-      else if (lib == "verbose")
-        enable_verbose_logging();
+      else if (lib.find(loglevel_prefix) == 0) {
+        // Process log level for library API users
+        std::string log_level_str = lib.substr(loglevel_prefix.size());
+        if (log_level_str == "error")
+          set_log_level(log_level::error);
+        else if (log_level_str == "warn")
+          set_log_level(log_level::warn);
+        else if (log_level_str == "info")
+          set_log_level(log_level::info);
+        else if (log_level_str == "debug")
+          set_log_level(log_level::debug);
+        else
+          LOG_WARN("Invalid log level flag: " << lib << ", ignored");
+      }
       else
-        std::cout << "Invalid flag: " << lib << ", ignored !!!" << std::endl;
+        LOG_WARN("Invalid flag: " << lib << ", ignored");
     }
 
     m_data[".ctrltext"] = mc_code;

--- a/src/cpp/preprocessor/aie2ps/aie2ps_preprocessor.h
+++ b/src/cpp/preprocessor/aie2ps/aie2ps_preprocessor.h
@@ -72,10 +72,10 @@ public:
         else if (log_level_str == "debug")
           set_log_level(log_level::debug);
         else
-          LOG_WARN() << "Invalid log level flag: " << flag << ", ignored";
+          log_warn() << "Invalid log level flag: " << flag << ", ignored";
       }
       else
-        LOG_WARN() << "Invalid flag: " << flag << ", ignored";
+        log_warn() << "Invalid flag: " << flag << ", ignored";
     }
     
     std::shared_ptr<asm_parser> parser(new asm_parser(tinput->get_ctrlcode_data(), tinput->get_include_paths()));

--- a/src/cpp/preprocessor/aie2ps/aie2ps_preprocessor.h
+++ b/src/cpp/preprocessor/aie2ps/aie2ps_preprocessor.h
@@ -12,6 +12,7 @@
 #include "aie2ps_preprocessor_input.h"
 #include "aie2ps_preprocessed_output.h"
 #include "specification/aie2ps/isa.h"
+#include "logger.h"
 
 namespace aiebu {
 
@@ -19,7 +20,6 @@ class aie2ps_preprocessor: public preprocessor
 {
   const std::string disable_dump_map = "disabledump";
   const std::string full_dump_map = "fulldump";
-  const std::string verbose_asm = "verbose";
   std::shared_ptr<std::map<std::string, std::shared_ptr<isa_op>>> m_isa;
 public:
   aie2ps_preprocessor() {}
@@ -47,22 +47,35 @@ public:
     //auto keys = tinput->get_keys();
     const std::string prefix = "opt_level_";
     
-    // Process flags before parsing to set global verbose flag
+    // Process flags before parsing
     auto flags = tinput->get_flags();
     uint32_t optimize = 0;
     asm_dump_flag debug_flag = asm_dump_flag::text;
+    const std::string loglevel_prefix = "loglevel_";
     for (const auto& flag: flags)
     {
       if (flag == disable_dump_map)
         debug_flag = asm_dump_flag::disable;
       else if (flag == full_dump_map)
         debug_flag = asm_dump_flag::full;
-      else if (flag == verbose_asm)
-        enable_verbose_logging();
       else if (flag.find(prefix) == 0)
         optimize = std::stoi(flag.substr(prefix.size()));
+      else if (flag.find(loglevel_prefix) == 0) {
+        // Process log level for library API users
+        std::string log_level_str = flag.substr(loglevel_prefix.size());
+        if (log_level_str == "error")
+          set_log_level(log_level::error);
+        else if (log_level_str == "warn")
+          set_log_level(log_level::warn);
+        else if (log_level_str == "info")
+          set_log_level(log_level::info);
+        else if (log_level_str == "debug")
+          set_log_level(log_level::debug);
+        else
+          LOG_WARN("Invalid log level flag: " << flag << ", ignored");
+      }
       else
-        std::cout << "Invalid flag: " << flag << ", ignored !!!" << std::endl;
+        LOG_WARN("Invalid flag: " << flag << ", ignored");
     }
     
     std::shared_ptr<asm_parser> parser(new asm_parser(tinput->get_ctrlcode_data(), tinput->get_include_paths()));

--- a/src/cpp/preprocessor/aie2ps/aie2ps_preprocessor.h
+++ b/src/cpp/preprocessor/aie2ps/aie2ps_preprocessor.h
@@ -19,6 +19,7 @@ class aie2ps_preprocessor: public preprocessor
 {
   const std::string disable_dump_map = "disabledump";
   const std::string full_dump_map = "fulldump";
+  const std::string verbose_asm = "verbose";
   std::shared_ptr<std::map<std::string, std::shared_ptr<isa_op>>> m_isa;
 public:
   aie2ps_preprocessor() {}
@@ -45,25 +46,32 @@ public:
   {
     //auto keys = tinput->get_keys();
     const std::string prefix = "opt_level_";
-    std::shared_ptr<asm_parser> parser(new asm_parser(tinput->get_ctrlcode_data(), tinput->get_include_paths()));
-    parser->parse_lines();
-    auto collist = parser->get_col_list();
-    isa i;
-    uint32_t optimize = 0;
-    m_isa = i.get_isamap();
-    auto toutput = std::make_shared<aie2ps_preprocessed_output>(parser->get_partition_info());
+    
+    // Process flags before parsing to set global verbose flag
     auto flags = tinput->get_flags();
+    uint32_t optimize = 0;
+    asm_dump_flag debug_flag = asm_dump_flag::text;
     for (const auto& flag: flags)
     {
       if (flag == disable_dump_map)
-        toutput->set_debug(asm_dump_flag::disable);
+        debug_flag = asm_dump_flag::disable;
       else if (flag == full_dump_map)
-        toutput->set_debug(asm_dump_flag::full);
+        debug_flag = asm_dump_flag::full;
+      else if (flag == verbose_asm)
+        enable_verbose_logging();
       else if (flag.find(prefix) == 0)
         optimize = std::stoi(flag.substr(prefix.size()));
       else
         std::cout << "Invalid flag: " << flag << ", ignored !!!" << std::endl;
     }
+    
+    std::shared_ptr<asm_parser> parser(new asm_parser(tinput->get_ctrlcode_data(), tinput->get_include_paths()));
+    parser->parse_lines();
+    auto collist = parser->get_col_list();
+    isa i;
+    m_isa = i.get_isamap();
+    auto toutput = std::make_shared<aie2ps_preprocessed_output>(parser->get_partition_info());
+    toutput->set_debug(debug_flag);
     auto& controlpkts = tinput->get_controlpkt();
     auto& ctrlpkt_id_map = tinput->get_ctrlpkt_id_map();
     toutput->set_optmization(optimize);

--- a/src/cpp/preprocessor/aie2ps/aie2ps_preprocessor.h
+++ b/src/cpp/preprocessor/aie2ps/aie2ps_preprocessor.h
@@ -72,10 +72,10 @@ public:
         else if (log_level_str == "debug")
           set_log_level(log_level::debug);
         else
-          LOG_WARN("Invalid log level flag: " << flag << ", ignored");
+          LOG_WARN() << "Invalid log level flag: " << flag << ", ignored";
       }
       else
-        LOG_WARN("Invalid flag: " << flag << ", ignored");
+        LOG_WARN() << "Invalid flag: " << flag << ", ignored";
     }
     
     std::shared_ptr<asm_parser> parser(new asm_parser(tinput->get_ctrlcode_data(), tinput->get_include_paths()));

--- a/src/cpp/preprocessor/aie2ps/aie2ps_preprocessor_input.h
+++ b/src/cpp/preprocessor/aie2ps/aie2ps_preprocessor_input.h
@@ -9,6 +9,7 @@
 #include "utils.h"
 #include "file_utils.h"
 #include "preprocessor_input.h"
+#include "logger.h"
 #include <boost/format.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
@@ -133,7 +134,7 @@ public:
 
     const auto& pt_xrt_kernel_instance = pt.get_child_optional("xrt-kernels");
     if (!pt_xrt_kernel_instance) {
-      std::cout << "xrt-kernels instance not found returning\n";
+      LOG_WARN("xrt-kernels instance not found, returning");
       return;
     }
     const auto& p_xrt_kernel_instance = pt_xrt_kernel_instance.get();
@@ -160,7 +161,7 @@ public:
         const auto& pinstance = pt_instance.get();
         add_instance(mangled_name, pinstance, flags, paths);
       } else {
-        std::cout << "instance not found\n";
+        LOG_WARN("instance not found");
       }
     }
   }

--- a/src/cpp/preprocessor/aie2ps/aie2ps_preprocessor_input.h
+++ b/src/cpp/preprocessor/aie2ps/aie2ps_preprocessor_input.h
@@ -134,7 +134,7 @@ public:
 
     const auto& pt_xrt_kernel_instance = pt.get_child_optional("xrt-kernels");
     if (!pt_xrt_kernel_instance) {
-      LOG_WARN() << "xrt-kernels instance not found, returning";
+      log_warn() << "xrt-kernels instance not found, returning";
       return;
     }
     const auto& p_xrt_kernel_instance = pt_xrt_kernel_instance.get();
@@ -161,7 +161,7 @@ public:
         const auto& pinstance = pt_instance.get();
         add_instance(mangled_name, pinstance, flags, paths);
       } else {
-        LOG_WARN() << "instance not found";
+        log_warn() << "instance not found";
       }
     }
   }

--- a/src/cpp/preprocessor/aie2ps/aie2ps_preprocessor_input.h
+++ b/src/cpp/preprocessor/aie2ps/aie2ps_preprocessor_input.h
@@ -134,7 +134,7 @@ public:
 
     const auto& pt_xrt_kernel_instance = pt.get_child_optional("xrt-kernels");
     if (!pt_xrt_kernel_instance) {
-      LOG_WARN("xrt-kernels instance not found, returning");
+      LOG_WARN() << "xrt-kernels instance not found, returning";
       return;
     }
     const auto& p_xrt_kernel_instance = pt_xrt_kernel_instance.get();
@@ -161,7 +161,7 @@ public:
         const auto& pinstance = pt_instance.get();
         add_instance(mangled_name, pinstance, flags, paths);
       } else {
-        LOG_WARN("instance not found");
+        LOG_WARN() << "instance not found";
       }
     }
   }

--- a/src/cpp/preprocessor/asm/asm_parser.cpp
+++ b/src/cpp/preprocessor/asm/asm_parser.cpp
@@ -219,7 +219,7 @@ operate(std::shared_ptr<asm_parser> parserptr, const boost::smatch& sm)
   else if (is_annotation_section(args[0]))
     m_parserptr->set_annotation_state();
   else
-    std::cout << "section directive with unknown section found:" << args[0] << std::endl;
+    LOG_WARN("section directive with unknown section found:" << args[0]);
 }
 
 void
@@ -229,17 +229,17 @@ operate(std::shared_ptr<asm_parser> parserptr, const boost::smatch& sm)
   m_parserptr = parserptr;
   static const boost::regex pattern(R"(\.partition\s+(\d+)(column|core:(\d+)mem))");
   boost::smatch match;
-  std::cout << "PARTITION:" << sm[0].str() << "\n";
+  LOG_INFO("PARTITION:" << sm[0].str());
   std::string line = sm[0].str();
   if (boost::regex_match(line, match, pattern)) {
     if (match[2] == "column") {
-      std::cout << "Column count: " << match[1] << std::endl;
+      LOG_INFO("Column count: " << match[1]);
       m_parserptr->set_numcolumn(to_uinteger<uint32_t>(match[1]));
     } else {
       m_parserptr->set_numcore(to_uinteger<uint32_t>(match[1]));
       m_parserptr->set_nummem(to_uinteger<uint32_t>(match[3]));
-      std::cout << "Core count: " << match[1] << std::endl;
-      std::cout << "Memory size: " << match[3] << std::endl;
+      LOG_INFO("Core count: " << match[1]);
+      LOG_INFO("Memory size: " << match[3]);
     }
   } else
     throw error(error::error_code::invalid_asm, "Invalid format!! " + line + "\n");
@@ -253,7 +253,7 @@ read_include_file(std::string filename)
   if (!file.is_open()) {
     return false;
   }
-//  std::cout << "Reading file:" << filename << std::endl;
+  LOG_INFO("Reading file:" << filename);
   std::string line;
   m_parserptr->set_data_state(false);
 
@@ -368,7 +368,7 @@ read_pad_file(std::string& name, std::string& filename)
     return false;
   }
 
-//  std::cout << "Reading file:" << filename << std::endl;
+  LOG_INFO("Reading file:" << filename);
   std::string line;
   m_parserptr->set_data_state(false);
 

--- a/src/cpp/preprocessor/asm/asm_parser.cpp
+++ b/src/cpp/preprocessor/asm/asm_parser.cpp
@@ -219,7 +219,7 @@ operate(std::shared_ptr<asm_parser> parserptr, const smatch& sm)
   else if (is_annotation_section(args[0]))
     m_parserptr->set_annotation_state();
   else
-    LOG_WARN() << "section directive with unknown section found:" << args[0];
+    log_warn() << "section directive with unknown section found:" << args[0];
 }
 
 void
@@ -229,17 +229,17 @@ operate(std::shared_ptr<asm_parser> parserptr, const smatch& sm)
   m_parserptr = parserptr;
   static const regex pattern(R"(\.partition\s+(\d+)(column|core:(\d+)mem))");
   smatch match;
-  LOG_INFO() << "PARTITION:" << sm[0].str();
+  log_info() << "PARTITION:" << sm[0].str();
   std::string line = sm[0].str();
   if (regex_match(line, match, pattern)) {
     if (match[2] == "column") {
-      LOG_INFO() << "Column count: " << match[1];
+      log_info() << "Column count: " << match[1];
       m_parserptr->set_numcolumn(to_uinteger<uint32_t>(match[1]));
     } else {
       m_parserptr->set_numcore(to_uinteger<uint32_t>(match[1]));
       m_parserptr->set_nummem(to_uinteger<uint32_t>(match[3]));
-      LOG_INFO() << "Core count: " << match[1];
-      LOG_INFO() << "Memory size: " << match[3];
+      log_info() << "Core count: " << match[1];
+      log_info() << "Memory size: " << match[3];
     }
   } else
     throw error(error::error_code::invalid_asm, "Invalid format!! " + line + "\n");
@@ -253,7 +253,7 @@ read_include_file(std::string filename)
   if (!file.is_open()) {
     return false;
   }
-  LOG_INFO() << "Reading file:" << filename;
+  log_info() << "Reading file:" << filename;
   std::string line;
   m_parserptr->set_data_state(false);
 
@@ -368,7 +368,7 @@ read_pad_file(std::string& name, std::string& filename)
     return false;
   }
 
-  LOG_INFO() << "Reading file:" << filename;
+  log_info() << "Reading file:" << filename;
   std::string line;
   m_parserptr->set_data_state(false);
 

--- a/src/cpp/preprocessor/asm/asm_parser.cpp
+++ b/src/cpp/preprocessor/asm/asm_parser.cpp
@@ -219,7 +219,7 @@ operate(std::shared_ptr<asm_parser> parserptr, const smatch& sm)
   else if (is_annotation_section(args[0]))
     m_parserptr->set_annotation_state();
   else
-    LOG_WARN("section directive with unknown section found:" << args[0]);
+    LOG_WARN() << "section directive with unknown section found:" << args[0];
 }
 
 void
@@ -229,17 +229,17 @@ operate(std::shared_ptr<asm_parser> parserptr, const smatch& sm)
   m_parserptr = parserptr;
   static const regex pattern(R"(\.partition\s+(\d+)(column|core:(\d+)mem))");
   smatch match;
-  LOG_INFO("PARTITION:" << sm[0].str());
+  LOG_INFO() << "PARTITION:" << sm[0].str();
   std::string line = sm[0].str();
   if (regex_match(line, match, pattern)) {
     if (match[2] == "column") {
-      LOG_INFO("Column count: " << match[1]);
+      LOG_INFO() << "Column count: " << match[1];
       m_parserptr->set_numcolumn(to_uinteger<uint32_t>(match[1]));
     } else {
       m_parserptr->set_numcore(to_uinteger<uint32_t>(match[1]));
       m_parserptr->set_nummem(to_uinteger<uint32_t>(match[3]));
-      LOG_INFO("Core count: " << match[1]);
-      LOG_INFO("Memory size: " << match[3]);
+      LOG_INFO() << "Core count: " << match[1];
+      LOG_INFO() << "Memory size: " << match[3];
     }
   } else
     throw error(error::error_code::invalid_asm, "Invalid format!! " + line + "\n");
@@ -253,7 +253,7 @@ read_include_file(std::string filename)
   if (!file.is_open()) {
     return false;
   }
-  LOG_INFO("Reading file:" << filename);
+  LOG_INFO() << "Reading file:" << filename;
   std::string line;
   m_parserptr->set_data_state(false);
 
@@ -368,7 +368,7 @@ read_pad_file(std::string& name, std::string& filename)
     return false;
   }
 
-  LOG_INFO("Reading file:" << filename);
+  LOG_INFO() << "Reading file:" << filename;
   std::string line;
   m_parserptr->set_data_state(false);
 

--- a/src/cpp/preprocessor/asm/asm_parser.h
+++ b/src/cpp/preprocessor/asm/asm_parser.h
@@ -6,6 +6,7 @@
 #include "code_section.h"
 #include "utils.h"
 #include "file_utils.h"
+#include "logger.h"
 
 #include <map>
 #include <memory>

--- a/src/cpp/preprocessor/asm/asm_parser.h
+++ b/src/cpp/preprocessor/asm/asm_parser.h
@@ -8,6 +8,7 @@
 #include "file_utils.h"
 #include "logger.h"
 #include "common/regex_wrapper.h"
+#include "logger.h"
 
 #include <map>
 #include <memory>

--- a/src/cpp/utils/target/target.cpp
+++ b/src/cpp/utils/target/target.cpp
@@ -12,6 +12,31 @@
 #include "file_utils.h"
 #include "logger.h"
 
+namespace {
+  // Helper function to process log level from flags
+  void process_log_level_flags(const std::vector<std::string>& flags) {
+    const std::string loglevel_prefix = "loglevel_";
+    for (const auto& flag : flags) {
+      if (flag.find(loglevel_prefix) == 0) {
+        std::string log_level_str = flag.substr(loglevel_prefix.size());
+        if (log_level_str == "error")
+          aiebu::set_log_level(aiebu::log_level::error);
+        else if (log_level_str == "warn")
+          aiebu::set_log_level(aiebu::log_level::warn);
+        else if (log_level_str == "info")
+          aiebu::set_log_level(aiebu::log_level::info);
+        else if (log_level_str == "debug")
+          aiebu::set_log_level(aiebu::log_level::debug);
+        else {
+          auto errMsg = boost::format("Invalid log level: %s. Valid options: loglevel_error, loglevel_warn, loglevel_info, loglevel_debug\n") % flag;
+          throw std::runtime_error(errMsg.str());
+        }
+        break; // Only process first log level found
+      }
+    }
+  }
+}
+
 std::map<uint32_t, std::vector<char> >
 aiebu::utilities::
 target_aie2blob::parse_pmctrlpkt(const std::vector<std::string> pm_key_value_pairs)
@@ -60,7 +85,7 @@ target_aie2blob::parseOption(const sub_cmd_options &options)
             ("c,controlcode", "TXN control code binary or ASM file", cxxopts::value<decltype(m_transaction_file)>())
             ("p,controlpkt", "Control packet binary", cxxopts::value<decltype(m_controlpkt_file)>())
             ("j,json", "control packet Patching json file", cxxopts::value<decltype(m_external_buffers_file)>())
-            ("l,lib", "linked libs", cxxopts::value<decltype(m_libs)>())
+            ("l,lib", "linked libs (also supports loglevel_error, loglevel_warn, loglevel_info, loglevel_debug)", cxxopts::value<decltype(m_libs)>())
             ("L,libpath", "libs path", cxxopts::value<decltype(m_libpaths)>())
             ("m,pmctrl", "pm ctrlpkt <id>:<file>", cxxopts::value<decltype(pm_key_value_pairs)>())
             ("r,report", "Generate Report", cxxopts::value<bool>()->default_value("false"))
@@ -108,6 +133,9 @@ target_aie2blob::parseOption(const sub_cmd_options &options)
     auto errMsg = boost::format("Error parsing options: %s\n") % e.what() ;
     throw std::runtime_error(errMsg.str());
   }
+
+  // Process log level from libs
+  process_log_level_flags(m_libs);
 
   if (!m_transaction_file.empty())
     readfile(m_transaction_file, m_transaction_buffer);
@@ -211,7 +239,7 @@ target_aie2ps::assemble(const sub_cmd_options &options)
             ("asm,c", "ASM File", cxxopts::value<decltype(input_file)>())
             ("j,json", "control packet Patching json file", cxxopts::value<decltype(external_buffers_file)>())
             ("L,libpath", "libs path", cxxopts::value<decltype(libpaths)>())
-            ("f,flag", "flags", cxxopts::value<decltype(flags)>())
+            ("f,flag", "flags (e.g., 'disabledump', 'fulldump', 'loglevel_error', 'loglevel_warn', 'loglevel_info', 'loglevel_debug')", cxxopts::value<decltype(flags)>())
             ("help,h", "show help message and exit", cxxopts::value<bool>()->default_value("false"))
     ;
 
@@ -253,6 +281,9 @@ target_aie2ps::assemble(const sub_cmd_options &options)
     throw std::runtime_error(errMsg.str());
   }
 
+  // Process log level from flags
+  process_log_level_flags(flags);
+
   std::vector<char> asmBuffer;
   readfile(input_file, asmBuffer);
 
@@ -277,12 +308,14 @@ target_aie2_config::assemble(const sub_cmd_options &options)
   std::string output_elffile;
   std::string json_file;
   std::vector<std::string> libpaths;
+  std::vector<std::string> flags;
   cxxopts::Options all_options("Target aie2 config Options", m_description);
 
   try {
     all_options.add_options()
             ("o,outputelf", "ELF output file name", cxxopts::value<decltype(output_elffile)>())
             ("j,json", "control packet Patching json file", cxxopts::value<decltype(json_file)>())
+            ("f,flag", "flags (e.g., 'loglevel_error', 'loglevel_warn', 'loglevel_info', 'loglevel_debug')", cxxopts::value<decltype(flags)>())
             ("h,help", "show help message and exit", cxxopts::value<bool>()->default_value("false"))
     ;
 
@@ -303,12 +336,18 @@ target_aie2_config::assemble(const sub_cmd_options &options)
 
     if (result.count("json"))
       json_file = result["json"].as<decltype(json_file)>();
+
+    if (result.count("flag"))
+      flags = result["flag"].as<decltype(flags)>();
   }
   catch (const cxxopts::exceptions::exception& e) {
     std::cout << all_options.help({"", "Target config Options"});
     auto errMsg = boost::format("Error parsing options: %s\n") % e.what() ;
     throw std::runtime_error(errMsg.str());
   }
+
+  // Process log level from flags
+  process_log_level_flags(flags);
 
   std::vector<char> json_buffer;
   if (!json_file.empty())
@@ -339,15 +378,13 @@ target_aie4::assemble(const sub_cmd_options &_options)
 
   cxxopts::Options all_options("Target aie4 Options", m_description);
 
-  std::string log_level_str;
   try {
     all_options.add_options()
             ("outputelf,o", "ELF output file name", cxxopts::value<decltype(output_elffile)>())
             ("asm,c", "ASM File", cxxopts::value<decltype(input_file)>())
             ("j,json", "control packet Patching json file", cxxopts::value<decltype(external_buffers_file)>())
             ("L,libpath", "libs path", cxxopts::value<decltype(libpaths)>())
-            ("f,flag", "flags (e.g., 'verbose' for detailed output, 'disabledump', 'fulldump')", cxxopts::value<decltype(flags)>())
-            ("log-level", "log level: error, warn, info, debug (default: warn)", cxxopts::value<decltype(log_level_str)>())
+            ("f,flag", "flags (e.g., 'disabledump', 'fulldump', 'loglevel_error', 'loglevel_warn', 'loglevel_info', 'loglevel_debug')", cxxopts::value<decltype(flags)>())
             ("help,h", "show help message and exit", cxxopts::value<bool>()->default_value("false"))
     ;
 
@@ -382,28 +419,15 @@ target_aie4::assemble(const sub_cmd_options &_options)
     if (result.count("json"))
       external_buffers_file = result["json"].as<decltype(external_buffers_file)>();
 
-    if (result.count("log-level")) {
-      log_level_str = result["log-level"].as<decltype(log_level_str)>();
-      if (log_level_str == "error")
-        aiebu::set_log_level(aiebu::log_level::error);
-      else if (log_level_str == "warn")
-        aiebu::set_log_level(aiebu::log_level::warn);
-      else if (log_level_str == "info")
-        aiebu::set_log_level(aiebu::log_level::info);
-      else if (log_level_str == "debug")
-        aiebu::set_log_level(aiebu::log_level::debug);
-      else {
-        auto errMsg = boost::format("Invalid log level: %s. Valid options: error, warn, info, debug\n") % log_level_str;
-        throw std::runtime_error(errMsg.str());
-      }
-    }
-
   }
   catch (const cxxopts::exceptions::exception& e) {
     std::cout << all_options.help({"", "Target aie4 Options"});
     auto errMsg = boost::format("Error parsing options: %s\n") % e.what() ;
     throw std::runtime_error(errMsg.str());
   }
+
+  // Process log level from flags
+  process_log_level_flags(flags);
 
   std::vector<char> asmBuffer;
   readfile(input_file, asmBuffer);
@@ -427,7 +451,6 @@ aiebu::utilities::
 asm_config_parser::parser(const sub_cmd_options &options)
 {
   std::string json_file;
-  std::string log_level_str;
   cxxopts::Options all_options("Target config Options", m_description);
   uint32_t optimization_level =0;
 
@@ -435,9 +458,8 @@ asm_config_parser::parser(const sub_cmd_options &options)
     all_options.add_options()
             ("o,outputelf", "ELF output file name", cxxopts::value<decltype(output_elffile)>())
             ("j,json", "control packet Patching json file", cxxopts::value<decltype(json_file)>())
-            ("f,flag", "flags (e.g., 'verbose' for detailed output, 'disabledump', 'fulldump')", cxxopts::value<decltype(flags)>())
+            ("f,flag", "flags (e.g., 'disabledump', 'fulldump', 'loglevel_error', 'loglevel_warn', 'loglevel_info', 'loglevel_debug')", cxxopts::value<decltype(flags)>())
             ("O,optimization", "optimization level (1-4)", cxxopts::value<int>()->default_value("0"))
-            ("log-level", "log level: error, warn, info, debug (default: warn)", cxxopts::value<decltype(log_level_str)>())
             ("h,help", "show help message and exit", cxxopts::value<bool>()->default_value("false"))
     ;
 
@@ -472,28 +494,15 @@ asm_config_parser::parser(const sub_cmd_options &options)
        flags.insert(flags.end(), extra_flags.begin(), extra_flags.end());
     }
 
-    if (result.count("log-level")) {
-      log_level_str = result["log-level"].as<decltype(log_level_str)>();
-      if (log_level_str == "error")
-        aiebu::set_log_level(aiebu::log_level::error);
-      else if (log_level_str == "warn")
-        aiebu::set_log_level(aiebu::log_level::warn);
-      else if (log_level_str == "info")
-        aiebu::set_log_level(aiebu::log_level::info);
-      else if (log_level_str == "debug")
-        aiebu::set_log_level(aiebu::log_level::debug);
-      else {
-        auto errMsg = boost::format("Invalid log level: %s. Valid options: error, warn, info, debug\n") % log_level_str;
-        throw std::runtime_error(errMsg.str());
-      }
-    }
-
   }
   catch (const cxxopts::exceptions::exception& e) {
     std::cout << all_options.help({"", "Target config Options"});
     auto errMsg = boost::format("Error parsing options: %s\n") % e.what() ;
     throw std::runtime_error(errMsg.str());
   }
+
+  // Process log level from flags
+  process_log_level_flags(flags);
 
   if (!json_file.empty()) {
     readfile(json_file, json_buffer);

--- a/src/cpp/utils/target/target.cpp
+++ b/src/cpp/utils/target/target.cpp
@@ -12,31 +12,6 @@
 #include "file_utils.h"
 #include "logger.h"
 
-namespace {
-  // Helper function to process log level from flags
-  void process_log_level_flags(const std::vector<std::string>& flags) {
-    const std::string loglevel_prefix = "loglevel_";
-    for (const auto& flag : flags) {
-      if (flag.find(loglevel_prefix) == 0) {
-        std::string log_level_str = flag.substr(loglevel_prefix.size());
-        if (log_level_str == "error")
-          aiebu::set_log_level(aiebu::log_level::error);
-        else if (log_level_str == "warn")
-          aiebu::set_log_level(aiebu::log_level::warn);
-        else if (log_level_str == "info")
-          aiebu::set_log_level(aiebu::log_level::info);
-        else if (log_level_str == "debug")
-          aiebu::set_log_level(aiebu::log_level::debug);
-        else {
-          auto errMsg = boost::format("Invalid log level: %s. Valid options: loglevel_error, loglevel_warn, loglevel_info, loglevel_debug\n") % flag;
-          throw std::runtime_error(errMsg.str());
-        }
-        break; // Only process first log level found
-      }
-    }
-  }
-}
-
 std::map<uint32_t, std::vector<char> >
 aiebu::utilities::
 target_aie2blob::parse_pmctrlpkt(const std::vector<std::string> pm_key_value_pairs)
@@ -133,9 +108,6 @@ target_aie2blob::parseOption(const sub_cmd_options &options)
     auto errMsg = boost::format("Error parsing options: %s\n") % e.what() ;
     throw std::runtime_error(errMsg.str());
   }
-
-  // Process log level from libs
-  process_log_level_flags(m_libs);
 
   if (!m_transaction_file.empty())
     readfile(m_transaction_file, m_transaction_buffer);
@@ -281,9 +253,6 @@ target_aie2ps::assemble(const sub_cmd_options &options)
     throw std::runtime_error(errMsg.str());
   }
 
-  // Process log level from flags
-  process_log_level_flags(flags);
-
   std::vector<char> asmBuffer;
   readfile(input_file, asmBuffer);
 
@@ -346,9 +315,6 @@ target_aie2_config::assemble(const sub_cmd_options &options)
     throw std::runtime_error(errMsg.str());
   }
 
-  // Process log level from flags
-  process_log_level_flags(flags);
-
   std::vector<char> json_buffer;
   if (!json_file.empty())
   {
@@ -357,7 +323,7 @@ target_aie2_config::assemble(const sub_cmd_options &options)
   }
 
   try {
-    aiebu::aiebu_assembler as(aiebu::aiebu_assembler::buffer_type::aie2_config, {}, {}, libpaths, json_buffer);
+    aiebu::aiebu_assembler as(aiebu::aiebu_assembler::buffer_type::aie2_config, {}, flags, libpaths, json_buffer);
     write_elf(as, output_elffile);
   }
   catch (aiebu::error &ex) {
@@ -425,9 +391,6 @@ target_aie4::assemble(const sub_cmd_options &_options)
     auto errMsg = boost::format("Error parsing options: %s\n") % e.what() ;
     throw std::runtime_error(errMsg.str());
   }
-
-  // Process log level from flags
-  process_log_level_flags(flags);
 
   std::vector<char> asmBuffer;
   readfile(input_file, asmBuffer);
@@ -500,9 +463,6 @@ asm_config_parser::parser(const sub_cmd_options &options)
     auto errMsg = boost::format("Error parsing options: %s\n") % e.what() ;
     throw std::runtime_error(errMsg.str());
   }
-
-  // Process log level from flags
-  process_log_level_flags(flags);
 
   if (!json_file.empty()) {
     readfile(json_file, json_buffer);

--- a/src/cpp/utils/target/target.cpp
+++ b/src/cpp/utils/target/target.cpp
@@ -10,6 +10,7 @@
 #include "target.h"
 #include "utils.h"
 #include "file_utils.h"
+#include "logger.h"
 
 std::map<uint32_t, std::vector<char> >
 aiebu::utilities::
@@ -338,13 +339,15 @@ target_aie4::assemble(const sub_cmd_options &_options)
 
   cxxopts::Options all_options("Target aie4 Options", m_description);
 
+  std::string log_level_str;
   try {
     all_options.add_options()
             ("outputelf,o", "ELF output file name", cxxopts::value<decltype(output_elffile)>())
             ("asm,c", "ASM File", cxxopts::value<decltype(input_file)>())
             ("j,json", "control packet Patching json file", cxxopts::value<decltype(external_buffers_file)>())
             ("L,libpath", "libs path", cxxopts::value<decltype(libpaths)>())
-            ("f,flag", "flags", cxxopts::value<decltype(flags)>())
+            ("f,flag", "flags (e.g., 'verbose' for detailed output, 'disabledump', 'fulldump')", cxxopts::value<decltype(flags)>())
+            ("log-level", "log level: error, warn, info, debug (default: warn)", cxxopts::value<decltype(log_level_str)>())
             ("help,h", "show help message and exit", cxxopts::value<bool>()->default_value("false"))
     ;
 
@@ -379,6 +382,22 @@ target_aie4::assemble(const sub_cmd_options &_options)
     if (result.count("json"))
       external_buffers_file = result["json"].as<decltype(external_buffers_file)>();
 
+    if (result.count("log-level")) {
+      log_level_str = result["log-level"].as<decltype(log_level_str)>();
+      if (log_level_str == "error")
+        aiebu::set_log_level(aiebu::log_level::error);
+      else if (log_level_str == "warn")
+        aiebu::set_log_level(aiebu::log_level::warn);
+      else if (log_level_str == "info")
+        aiebu::set_log_level(aiebu::log_level::info);
+      else if (log_level_str == "debug")
+        aiebu::set_log_level(aiebu::log_level::debug);
+      else {
+        auto errMsg = boost::format("Invalid log level: %s. Valid options: error, warn, info, debug\n") % log_level_str;
+        throw std::runtime_error(errMsg.str());
+      }
+    }
+
   }
   catch (const cxxopts::exceptions::exception& e) {
     std::cout << all_options.help({"", "Target aie4 Options"});
@@ -408,6 +427,7 @@ aiebu::utilities::
 asm_config_parser::parser(const sub_cmd_options &options)
 {
   std::string json_file;
+  std::string log_level_str;
   cxxopts::Options all_options("Target config Options", m_description);
   uint32_t optimization_level =0;
 
@@ -415,8 +435,9 @@ asm_config_parser::parser(const sub_cmd_options &options)
     all_options.add_options()
             ("o,outputelf", "ELF output file name", cxxopts::value<decltype(output_elffile)>())
             ("j,json", "control packet Patching json file", cxxopts::value<decltype(json_file)>())
-            ("f,flag", "flags", cxxopts::value<decltype(flags)>())
+            ("f,flag", "flags (e.g., 'verbose' for detailed output, 'disabledump', 'fulldump')", cxxopts::value<decltype(flags)>())
             ("O,optimization", "optimization level (1-4)", cxxopts::value<int>()->default_value("0"))
+            ("log-level", "log level: error, warn, info, debug (default: warn)", cxxopts::value<decltype(log_level_str)>())
             ("h,help", "show help message and exit", cxxopts::value<bool>()->default_value("false"))
     ;
 
@@ -449,6 +470,22 @@ asm_config_parser::parser(const sub_cmd_options &options)
     if (result.count("flag")) {
        auto extra_flags = result["flag"].as<std::vector<std::string>>();
        flags.insert(flags.end(), extra_flags.begin(), extra_flags.end());
+    }
+
+    if (result.count("log-level")) {
+      log_level_str = result["log-level"].as<decltype(log_level_str)>();
+      if (log_level_str == "error")
+        aiebu::set_log_level(aiebu::log_level::error);
+      else if (log_level_str == "warn")
+        aiebu::set_log_level(aiebu::log_level::warn);
+      else if (log_level_str == "info")
+        aiebu::set_log_level(aiebu::log_level::info);
+      else if (log_level_str == "debug")
+        aiebu::set_log_level(aiebu::log_level::debug);
+      else {
+        auto errMsg = boost::format("Invalid log level: %s. Valid options: error, warn, info, debug\n") % log_level_str;
+        throw std::runtime_error(errMsg.str());
+      }
     }
 
   }

--- a/src/cpp/utils/target/target.h
+++ b/src/cpp/utils/target/target.h
@@ -42,7 +42,7 @@ class target
   inline void write_elf(const aiebu::aiebu_assembler& as, const std::string& outfile)
   {
     auto e = as.get_elf();
-    LOG_INFO("elf size:" << e.size());
+    LOG_INFO() << "elf size:" << e.size();
     std::ofstream output_file(outfile, std::ios_base::binary);
     output_file.write(e.data(), e.size());
   }

--- a/src/cpp/utils/target/target.h
+++ b/src/cpp/utils/target/target.h
@@ -5,6 +5,7 @@
 
 #include "aiebu/aiebu_assembler.h"
 #include "aiebu/aiebu_error.h"
+#include "logger.h"
 
 #include <filesystem>
 #include <fstream>
@@ -41,7 +42,7 @@ class target
   inline void write_elf(const aiebu::aiebu_assembler& as, const std::string& outfile)
   {
     auto e = as.get_elf();
-    std::cout << "elf size:" << e.size() << "\n";
+    LOG_INFO("elf size:" << e.size());
     std::ofstream output_file(outfile, std::ios_base::binary);
     output_file.write(e.data(), e.size());
   }

--- a/src/cpp/utils/target/target.h
+++ b/src/cpp/utils/target/target.h
@@ -42,7 +42,7 @@ class target
   inline void write_elf(const aiebu::aiebu_assembler& as, const std::string& outfile)
   {
     auto e = as.get_elf();
-    LOG_INFO() << "elf size:" << e.size();
+    log_info() << "elf size:" << e.size();
     std::ofstream output_file(outfile, std::ios_base::binary);
     output_file.write(e.data(), e.size());
   }


### PR DESCRIPTION
#### Problem solved by the commit
aiebu-asm was printing information to console output while assembling. This could reduce aiebu-asm performance.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
N/A

#### How problem was solved, alternative solutions (if any) and why they were rejected
1> Added a verbose flag to aiebu-asm utility to enable verbose logs on cout.
2> To further enhance logging, added log levels for logging, enabled by aiebu-asm flags. "warn" is the default level.
Added additional flag options - loglevel_error', 'loglevel_warn', 'loglevel_info', 'loglevel_debug'

**The flag accepts 4 values:**
```
error - Only errors
warn - Errors and warnings (default)
info - Errors, warnings, and info messages
debug - All messages (same as -f verbose)
```

**Below are Log levels and its contents.**

```
Levels	     Contents
---------------------------------------------------------------
error        LOG_ERROR only
warn         (default) LOG_ERROR, LOG_WARN
info	     LOG_ERROR, LOG_WARN, LOG_INFO
debug	     LOG_ERROR, LOG_WARN, LOG_INFO, LOG_DEBUG
```


**Example Usage -**

```
# Default: show errors and warnings
aiebu-asm -c input.asm -o output.elf

# Only show errors
aiebu-asm -c input.asm -o output.elf -f loglevel_error

# Show errors, warnings, and info (verbose output)
aiebu-asm -c input.asm -o output.elf -f loglevel_info

# Show everything (debug mode)
aiebu-asm -c input.asm -o output.elf -f loglevel_debug


```

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
1> Tested on Windows aiebu-asm utility

#### Documentation impact (if any)
N/A