### PR TITLE
Add regex wrapper

### DIFF
--- a/cmake/boost.cmake
+++ b/cmake/boost.cmake
@@ -4,17 +4,32 @@ if(POLICY CMP0144)
   cmake_policy(SET CMP0144 NEW)
 endif()
 
-# We use header only libraries for most components
-# Boost.Regex is header-only from 1.76.0+ (when using C++11 or later)
-# Require minimum Boost 1.76.0 for header-only Boost.Regex support
-if(${CMAKE_VERSION} VERSION_LESS "3.30")
-  find_package(Boost 1.76.0 REQUIRED)
+# First, find Boost to determine the version (minimum 1.65 for property_tree support)
+# Use MODULE mode (default) which is more flexible in finding Boost installations
+find_package(Boost 1.65.0 REQUIRED)
+
+message(STATUS "Boost version: ${Boost_VERSION}")
+message(STATUS "Boost include dir: ${Boost_INCLUDE_DIRS}")
+
+# Determine which regex library to use based on Boost version
+# - Boost < 1.76.0: use std::regex (avoid linking libboost_regex)
+# - Boost >= 1.76.0: use boost::regex (header-only)
+set(USE_BOOST_REGEX OFF)
+
+if(Boost_VERSION_STRING VERSION_GREATER_EQUAL "1.76.0")
+  # Boost >= 1.76.0: use boost::regex (header-only, no linking needed)
+  set(USE_BOOST_REGEX ON)
+  message(STATUS "Boost ${Boost_VERSION_STRING} >= 1.76.0 - Using boost::regex (header-only)")
 else()
-  find_package(Boost 1.76.0 CONFIG REQUIRED)
+  # Boost < 1.76.0: use std::regex (avoids needing libboost_regex)
+  message(STATUS "Boost ${Boost_VERSION_STRING} < 1.76.0 - Using std::regex")
 endif()
 
-message("-- Boost version: ${Boost_VERSION}")
-message("-- Boost include dir: ${Boost_INCLUDE_DIRS}")
+# Configure regex library preprocessor macro
+if(USE_BOOST_REGEX)
+  # Define preprocessor macro to enable boost::regex in wrapper
+  add_compile_definitions(USE_BOOST_REGEX)
+endif()
 
 # Some later versions of boost spews warnings form property_tree
 # but can be disabled with this setting

--- a/src/cpp/common/regex_wrapper.h
+++ b/src/cpp/common/regex_wrapper.h
@@ -1,0 +1,66 @@
+#ifndef AIEBU_COMMON_REGEX_WRAPPER_H_
+#define AIEBU_COMMON_REGEX_WRAPPER_H_
+
+/**
+ * @file regex_wrapper.h
+ * @brief Unified regex API wrapper supporting both std::regex and boost::regex
+ * 
+ * This wrapper allows transparent switching between std::regex and boost::regex
+ * based on platform requirements:
+ * - Ubuntu 22.04 and earlier: uses std::regex (better integration with system)
+ * - Ubuntu 24.04+: uses boost::regex (header-only, no packaging issues)
+ * - Windows: uses boost::regex (consistent with Boost ecosystem)
+ * 
+ * The wrapper is controlled by the USE_BOOST_REGEX CMake option.
+ */
+
+#ifdef USE_BOOST_REGEX
+  #include <boost/regex.hpp>
+#else
+  #include <regex>
+#endif
+
+namespace aiebu {
+
+#ifdef USE_BOOST_REGEX
+  // Use Boost.Regex
+  using regex = boost::regex;
+  using smatch = boost::smatch;
+  using cmatch = boost::cmatch;
+  using sregex_iterator = boost::sregex_iterator;
+  using regex_error = boost::regex_error;
+  
+  // Import functions into aiebu namespace
+  using boost::regex_match;
+  using boost::regex_search;
+  using boost::regex_replace;
+  
+  // Regex constants
+  namespace regex_constants {
+    using namespace boost::regex_constants;
+  }
+  
+#else
+  // Use std::regex
+  using regex = std::regex;
+  using smatch = std::smatch;
+  using cmatch = std::cmatch;
+  using sregex_iterator = std::sregex_iterator;
+  using regex_error = std::regex_error;
+  
+  // Import functions into aiebu namespace
+  using std::regex_match;
+  using std::regex_search;
+  using std::regex_replace;
+  
+  // Regex constants
+  namespace regex_constants {
+    using namespace std::regex_constants;
+  }
+  
+#endif
+
+} // namespace aiebu
+
+#endif // AIEBU_COMMON_REGEX_WRAPPER_H_
+

--- a/src/cpp/common/utils.cpp
+++ b/src/cpp/common/utils.cpp
@@ -3,7 +3,6 @@
 
 #include <map>
 #include <string>
-#include <boost/regex.hpp>
 
 #include "utils.h"
 #include "version.h"
@@ -26,14 +25,14 @@ static const std::map<fragment, std::string> fragment_table = { // NOLINT
     {fragment::row, "[[:space:]]*r\\[([[:digit:]]+)\\][[:space:]]*"},
 };
 
-boost::regex
+aiebu::regex
 get_regex(const std::vector<fragment>& pattern)
 {
   std::string composite;
   for (auto frag : pattern) {
     composite += fragment_table.at(frag);
   }
-  return boost::regex(composite);
+  return aiebu::regex(composite);
 }
 
 std::string

--- a/src/cpp/common/utils.h
+++ b/src/cpp/common/utils.h
@@ -3,11 +3,11 @@
 #ifndef AIEBU_COMMOM_UTILS_H_
 #define AIEBU_COMMOM_UTILS_H_
 #include "aiebu/aiebu_error.h"
+#include "common/regex_wrapper.h"
 
 #include <cassert>
 #include <cstdint>
 #include <limits>
-#include <boost/regex.hpp>
 #include <sstream>
 #include <string>
 #include <string_view>
@@ -192,7 +192,7 @@ enum class fragment {
   dma,
 };
 
-boost::regex get_regex(const std::vector<fragment>& pattern);
+aiebu::regex get_regex(const std::vector<fragment>& pattern);
 
 constexpr unsigned hexbase = 0x10;
 

--- a/src/cpp/dtrace/action/action_control.h
+++ b/src/cpp/dtrace/action/action_control.h
@@ -11,10 +11,10 @@
 #endif
 
 #include <boost/property_tree/ptree.hpp>
+#include "common/regex_wrapper.h"
 
 #include <cstdint>
 #include <map>
-#include <boost/regex.hpp>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -109,23 +109,23 @@ public:
 class action_name
 {
 public:
-    static inline const boost::regex timestamp_regex = boost::regex(R"(timestamp\()");              // NOLINT
-    static inline const boost::regex timestamp32_regex = boost::regex(R"(timestamp32\()");          // NOLINT
-    static inline const boost::regex read_reg_regex = boost::regex(R"(read_reg\()");                // NOLINT
-    static inline const boost::regex write_reg_regex = boost::regex(R"(\bwrite_reg\()");            // NOLINT
-    static inline const boost::regex mask_write_reg_regex = boost::regex(R"(\bmask_write_reg\()");  // NOLINT
-    static inline const boost::regex profile_regex = boost::regex(R"(opcode\(\))");                 // NOLINT
-    static inline const boost::regex print_regex = boost::regex(R"(print\()");                      // NOLINT
-    static inline const boost::regex printa_regex = boost::regex(R"(printa\()");                    // NOLINT
-    static inline const boost::regex read_mem_regex = boost::regex(R"(read_mem\()");                // NOLINT
-    static inline const boost::regex write_mem_regex = boost::regex(R"(write_mem\()");              // NOLINT
-    static inline const boost::regex break_regex = boost::regex(R"(break\()");                      // NOLINT
-    static inline const boost::regex timestamps_regex = boost::regex(R"(timestamps\()");            // NOLINT
-    static inline const boost::regex timestamps32_regex = boost::regex(R"(timestamps32\()");        // NOLINT
-    static inline const boost::regex read_handshake_regex = boost::regex(R"(read_handshake\()");    // NOLINT
-    static inline const boost::regex write_handshake_regex = boost::regex(R"(write_handshake\()");  // NOLINT
-    static inline const boost::regex operation_regex = boost::regex(R"(^(\w+)\s*=\s*(.+)$)");       // NOLINT
-    static inline const boost::regex action_regex = boost::regex(R"((\w+)\((.*)\))");               // NOLINT
+    static inline const aiebu::regex timestamp_regex = aiebu::regex(R"(timestamp\()");              // NOLINT
+    static inline const aiebu::regex timestamp32_regex = aiebu::regex(R"(timestamp32\()");          // NOLINT
+    static inline const aiebu::regex read_reg_regex = aiebu::regex(R"(read_reg\()");                // NOLINT
+    static inline const aiebu::regex write_reg_regex = aiebu::regex(R"(\bwrite_reg\()");            // NOLINT
+    static inline const aiebu::regex mask_write_reg_regex = aiebu::regex(R"(\bmask_write_reg\()");  // NOLINT
+    static inline const aiebu::regex profile_regex = aiebu::regex(R"(opcode\(\))");                 // NOLINT
+    static inline const aiebu::regex print_regex = aiebu::regex(R"(print\()");                      // NOLINT
+    static inline const aiebu::regex printa_regex = aiebu::regex(R"(printa\()");                    // NOLINT
+    static inline const aiebu::regex read_mem_regex = aiebu::regex(R"(read_mem\()");                // NOLINT
+    static inline const aiebu::regex write_mem_regex = aiebu::regex(R"(write_mem\()");              // NOLINT
+    static inline const aiebu::regex break_regex = aiebu::regex(R"(break\()");                      // NOLINT
+    static inline const aiebu::regex timestamps_regex = aiebu::regex(R"(timestamps\()");            // NOLINT
+    static inline const aiebu::regex timestamps32_regex = aiebu::regex(R"(timestamps32\()");        // NOLINT
+    static inline const aiebu::regex read_handshake_regex = aiebu::regex(R"(read_handshake\()");    // NOLINT
+    static inline const aiebu::regex write_handshake_regex = aiebu::regex(R"(write_handshake\()");  // NOLINT
+    static inline const aiebu::regex operation_regex = aiebu::regex(R"(^(\w+)\s*=\s*(.+)$)");       // NOLINT
+    static inline const aiebu::regex action_regex = aiebu::regex(R"((\w+)\((.*)\))");               // NOLINT
 };
 
 //-------------------------Action Control-------------------------//

--- a/src/cpp/dtrace/action/mask_write_register.cpp
+++ b/src/cpp/dtrace/action/mask_write_register.cpp
@@ -30,8 +30,8 @@ mask_write_reg_action(std::string token, uint32_t probe_type, const std::string&
     while (std::getline(token_stream, item, '='))
         fields.push_back(strip(item));
 
-    boost::smatch action;
-    if (!boost::regex_match(fields[0], action, action_name::action_regex))
+    aiebu::smatch action;
+    if (!aiebu::regex_match(fields[0], action, action_name::action_regex))
         DTRACE_ERROR("DTRACE_ACTION_INVALID_TOKEN_FORMAT", 
             "Invalid token: '" << token << "' Expected 'mask_write_reg(addr, mask, val)'");
 
@@ -48,9 +48,9 @@ mask_write_reg_action(std::string token, uint32_t probe_type, const std::string&
             "Invalid arguments: '" << token << "' mask_write_reg requires 3 arguments (addr, mask, val)");
 
     // Check if the value argument is a buffer address reference with HIGH() or LOW()
-    boost::smatch value;
-    boost::regex high_low_regex(R"(^(HIGH|LOW)\(&(\w+)\)$)");
-    if (boost::regex_match(m_arguments[2], value, high_low_regex)) 
+    aiebu::smatch value;
+    aiebu::regex high_low_regex(R"(^(HIGH|LOW)\(&(\w+)\)$)");
+    if (aiebu::regex_match(m_arguments[2], value, high_low_regex)) 
     {
         std::string write_buffer_name = value[2];
         // check if write buffer name exists in the map and get the values

--- a/src/cpp/dtrace/action/profile.cpp
+++ b/src/cpp/dtrace/action/profile.cpp
@@ -35,8 +35,8 @@ profile_action(std::string token, uint32_t probe_type, const std::string& probe_
 
     m_result = fields[0];
 
-    boost::smatch action;
-    if (!boost::regex_match(fields[1], action, action_name::action_regex))
+    aiebu::smatch action;
+    if (!aiebu::regex_match(fields[1], action, action_name::action_regex))
         DTRACE_ERROR("DTRACE_ACTION_INVALID_TOKEN", 
             "Invalid token: '" << m_token << "' Expected 'opcode()'");
 

--- a/src/cpp/dtrace/action/read_handshake.cpp
+++ b/src/cpp/dtrace/action/read_handshake.cpp
@@ -34,8 +34,8 @@ read_handshake_action(std::string token, uint32_t probe_type, const std::string&
 
     m_result = fields[0];
 
-    boost::smatch action;
-    if (!boost::regex_match(fields[1], action, action_name::action_regex))
+    aiebu::smatch action;
+    if (!aiebu::regex_match(fields[1], action, action_name::action_regex))
         DTRACE_ERROR("DTRACE_ACTION_INVALID_TOKEN", 
             "Invalid token: '" << token << "' Expected 'read_handshake(offset)'");
 

--- a/src/cpp/dtrace/action/read_mem.cpp
+++ b/src/cpp/dtrace/action/read_mem.cpp
@@ -38,8 +38,8 @@ read_mem_action(std::string token, uint32_t probe_type, const std::string& probe
 
     m_result = fields[0];
 
-    boost::smatch action;
-    if (!boost::regex_match(fields[1], action, action_name::action_regex))
+    aiebu::smatch action;
+    if (!aiebu::regex_match(fields[1], action, action_name::action_regex))
         DTRACE_ERROR("DTRACE_ACTION_INVALID_TOKEN", 
             "Invalid token: '" << token << "' Expected 'read_mem(addr, length)'");
 

--- a/src/cpp/dtrace/action/read_register.cpp
+++ b/src/cpp/dtrace/action/read_register.cpp
@@ -34,8 +34,8 @@ read_reg_action(std::string token, uint32_t probe_type, const std::string& probe
 
     m_result = fields[0];
 
-    boost::smatch action;
-    if (!boost::regex_match(fields[1], action, action_name::action_regex))
+    aiebu::smatch action;
+    if (!aiebu::regex_match(fields[1], action, action_name::action_regex))
         DTRACE_ERROR("DTRACE_ACTION_INVALID_TOKEN", 
             "Invalid token: '" << token << "' Expected 'read_reg(addr)'");
 

--- a/src/cpp/dtrace/action/timestamp.cpp
+++ b/src/cpp/dtrace/action/timestamp.cpp
@@ -34,8 +34,8 @@ timestamp_action(std::string token, uint32_t probe_type, const std::string& prob
 
     m_result = fields[0];
 
-    boost::smatch action;
-    if (!boost::regex_match(fields[1], action, action_name::action_regex))
+    aiebu::smatch action;
+    if (!aiebu::regex_match(fields[1], action, action_name::action_regex))
         DTRACE_ERROR("DTRACE_ACTION_INVALID_TOKEN", 
             "Invalid token: '" << token << "' Expected 'timestamp()'");
 

--- a/src/cpp/dtrace/action/timestamp32.cpp
+++ b/src/cpp/dtrace/action/timestamp32.cpp
@@ -34,8 +34,8 @@ timestamp32_action(std::string token, uint32_t probe_type, const std::string& pr
     
     m_result = fields[0];
 
-    boost::smatch action;
-    if (!boost::regex_match(fields[1], action, action_name::action_regex))
+    aiebu::smatch action;
+    if (!aiebu::regex_match(fields[1], action, action_name::action_regex))
         DTRACE_ERROR("DTRACE_ACTION_INVALID_TOKEN", 
             "Invalid token: '" << token << "' Expected 'timestamp32()'");
 

--- a/src/cpp/dtrace/action/timestamps.cpp
+++ b/src/cpp/dtrace/action/timestamps.cpp
@@ -33,17 +33,17 @@ timestamps_action(std::string token, uint32_t probe_type, const std::string& pro
             "Invalid token: '" << token << "' Expected 'name[length] = timestamps()'");
 
     // Regex pattern to match '<name>[<length>]' format
-    boost::regex buffer_regex(R"(^(.+)\[(.+)\]$)");
-    boost::smatch buffer;
-    if (!boost::regex_match(fields[0], buffer, buffer_regex))
+    aiebu::regex buffer_regex(R"(^(.+)\[(.+)\]$)");
+    aiebu::smatch buffer;
+    if (!aiebu::regex_match(fields[0], buffer, buffer_regex))
         DTRACE_ERROR("DTRACE_ACTION_INVALID_TOKEN", 
             "Invalid token: '" << token << "' Expected 'name[length]'");
 
     m_result = buffer[1];
     std::string length = buffer[2];
 
-    boost::smatch action;
-    if (!boost::regex_match(fields[1], action, action_name::action_regex))
+    aiebu::smatch action;
+    if (!aiebu::regex_match(fields[1], action, action_name::action_regex))
         DTRACE_ERROR("DTRACE_ACTION_INVALID_TOKEN", 
             "Invalid token: '" << token << "' Expected 'timestamps()'");
 

--- a/src/cpp/dtrace/action/timestamps32.cpp
+++ b/src/cpp/dtrace/action/timestamps32.cpp
@@ -33,17 +33,17 @@ timestamps32_action(std::string token, uint32_t probe_type, const std::string& p
             "Invalid token: '" << token << "' Expected 'name[length] = timestamps32()'");
     
     // Regex pattern to match '<name>[<length>]' format
-    boost::regex buffer_regex(R"(^(.+)\[(.+)\]$)");
-    boost::smatch buffer;
-    if (!boost::regex_match(fields[0], buffer, buffer_regex))
+    aiebu::regex buffer_regex(R"(^(.+)\[(.+)\]$)");
+    aiebu::smatch buffer;
+    if (!aiebu::regex_match(fields[0], buffer, buffer_regex))
         DTRACE_ERROR("DTRACE_ACTION_INVALID_TOKEN", 
             "Invalid token: '" << token << "' Expected 'name[length]'");
 
     m_result = buffer[1];
     std::string length = buffer[2];
 
-    boost::smatch action;
-    if (!boost::regex_match(fields[1], action, action_name::action_regex))
+    aiebu::smatch action;
+    if (!aiebu::regex_match(fields[1], action, action_name::action_regex))
         DTRACE_ERROR("DTRACE_ACTION_INVALID_TOKEN", 
             "Invalid token: '" << token << "' Expected 'timestamps32()'");
 

--- a/src/cpp/dtrace/action/write_handshake.cpp
+++ b/src/cpp/dtrace/action/write_handshake.cpp
@@ -28,8 +28,8 @@ write_handshake_action(std::string token, uint32_t probe_type, const std::string
     while (std::getline(token_stream, item, '='))
         fields.push_back(strip(item));
 
-    boost::smatch action;
-    if (!boost::regex_match(fields[0], action, action_name::action_regex))
+    aiebu::smatch action;
+    if (!aiebu::regex_match(fields[0], action, action_name::action_regex))
         DTRACE_ERROR("DTRACE_ACTION_INVALID_TOKEN", 
             "Invalid token: '" << token << "' Expected 'write_handshake(offset, val)'");
 

--- a/src/cpp/dtrace/action/write_mem.cpp
+++ b/src/cpp/dtrace/action/write_mem.cpp
@@ -29,8 +29,8 @@ write_mem_action(std::string token, uint32_t probe_type, const std::string& prob
     while (std::getline(token_stream, item, '='))
         fields.push_back(strip(item));
 
-    boost::smatch action;
-    if (!boost::regex_match(fields[0], action, action_name::action_regex))
+    aiebu::smatch action;
+    if (!aiebu::regex_match(fields[0], action, action_name::action_regex))
         DTRACE_ERROR("DTRACE_ACTION_INVALID_TOKEN", 
             "Invalid token: '" << token << "' Expected 'write_mem(addr, length, buffer)'");
 

--- a/src/cpp/dtrace/action/write_register.cpp
+++ b/src/cpp/dtrace/action/write_register.cpp
@@ -28,8 +28,8 @@ write_reg_action(std::string token, uint32_t probe_type, const std::string& prob
     while (std::getline(token_stream, item, '='))
         fields.push_back(strip(item));
 
-    boost::smatch action;
-    if (!boost::regex_match(fields[0], action, action_name::action_regex))
+    aiebu::smatch action;
+    if (!aiebu::regex_match(fields[0], action, action_name::action_regex))
         DTRACE_ERROR("DTRACE_ACTION_INVALID_TOKEN", 
             "Invalid token: '" << token << "' Expected 'write_reg(addr, val)'");
 

--- a/src/cpp/dtrace/parser/parser.cpp
+++ b/src/cpp/dtrace/parser/parser.cpp
@@ -345,9 +345,9 @@ parser::
 expand_write_buffer(const std::string& write_buffer)
 {
     // Regex to extract buffer name and values
-    boost::regex buffer_regex(R"(^(\w+)\[(0x[a-fA-F0-9]+|\d+)\]\s*=\s*\[(.*)\]\s*$)");
-    boost::smatch buffer;
-    if (!boost::regex_match(write_buffer, buffer, buffer_regex)) 
+    aiebu::regex buffer_regex(R"(^(\w+)\[(0x[a-fA-F0-9]+|\d+)\]\s*=\s*\[(.*)\]\s*$)");
+    aiebu::smatch buffer;
+    if (!aiebu::regex_match(write_buffer, buffer, buffer_regex)) 
     {
         DTRACE_ERROR("DTRACE_PARSER_INVALID_WRITE_BUFFER",
             "Invalid write buffer format: " << write_buffer);
@@ -417,9 +417,9 @@ parser::
 expand_init_buffer(const std::string& init_buffer)
 {
     // Regex to extract buffer name and length
-    boost::regex buffer_init_regex(R"(^(\w+)\[(0x[a-fA-F0-9]+|\d+)\]\s*=\s*\{0\}\s*$)");
-    boost::smatch buffer;
-    if (!boost::regex_match(init_buffer, buffer, buffer_init_regex)) 
+    aiebu::regex buffer_init_regex(R"(^(\w+)\[(0x[a-fA-F0-9]+|\d+)\]\s*=\s*\{0\}\s*$)");
+    aiebu::smatch buffer;
+    if (!aiebu::regex_match(init_buffer, buffer, buffer_init_regex)) 
     {
         DTRACE_ERROR("DTRACE_PARSER_INVALID_INITIALIZE_BUFFER",
             "Invalid initialize buffer format: " << init_buffer);
@@ -514,98 +514,98 @@ create_action(const std::string& action_string, uint32_t probe_type,
             action_string, probe_type, probe_name
         );
     }
-    else if (boost::regex_search(action_string, dtrace::action::action_name::read_reg_regex))
+    else if (aiebu::regex_search(action_string, dtrace::action::action_name::read_reg_regex))
     {   // Read register action
         action = std::make_shared<dtrace::action::read_reg_action>(
             action_string, probe_type, probe_name
         );
     }
-    else if (boost::regex_search(action_string, dtrace::action::action_name::mask_write_reg_regex))
+    else if (aiebu::regex_search(action_string, dtrace::action::action_name::mask_write_reg_regex))
     {   // Mask write register action
         action = std::make_shared<dtrace::action::mask_write_reg_action>(
             action_string, probe_type, probe_name, m_buffer_map
         );
     }
-    else if (boost::regex_search(action_string, dtrace::action::action_name::write_reg_regex))
+    else if (aiebu::regex_search(action_string, dtrace::action::action_name::write_reg_regex))
     {   // Write register action
         action = std::make_shared<dtrace::action::write_reg_action>(
             action_string, probe_type, probe_name
         );
     }
-    else if (boost::regex_search(action_string, dtrace::action::action_name::timestamp_regex))
+    else if (aiebu::regex_search(action_string, dtrace::action::action_name::timestamp_regex))
     {   // Timestamp action
         action = std::make_shared<dtrace::action::timestamp_action>(
             action_string, probe_type, probe_name
         );
     }
-    else if (boost::regex_search(action_string, dtrace::action::action_name::timestamp32_regex))
+    else if (aiebu::regex_search(action_string, dtrace::action::action_name::timestamp32_regex))
     {   // Timestamp32 action
         action = std::make_shared<dtrace::action::timestamp32_action>(
             action_string, probe_type, probe_name
         );
     }
-    else if (boost::regex_search(action_string, dtrace::action::action_name::profile_regex))
+    else if (aiebu::regex_search(action_string, dtrace::action::action_name::profile_regex))
     {   // Profile action
         action = std::make_shared<dtrace::action::profile_action>(
             action_string, probe_type, probe_name
         );
     }
-    else if (boost::regex_search(action_string, dtrace::action::action_name::print_regex))
+    else if (aiebu::regex_search(action_string, dtrace::action::action_name::print_regex))
     {   // Print action
         action = std::make_shared<dtrace::action::print_action>(
             action_string, probe_type, probe_name, m_maps
         );
     }
-    else if (boost::regex_search(action_string, dtrace::action::action_name::printa_regex))
+    else if (aiebu::regex_search(action_string, dtrace::action::action_name::printa_regex))
     {   // Profile print action
         action = std::make_shared<dtrace::action::printa_action>(
             action_string, probe_type, probe_name, m_maps
         );
     }
-    else if (boost::regex_search(action_string, dtrace::action::action_name::read_mem_regex))
+    else if (aiebu::regex_search(action_string, dtrace::action::action_name::read_mem_regex))
     {   // Read memory action
         action = std::make_shared<dtrace::action::read_mem_action>(
             action_string, probe_type, probe_name, m_mem_host_addr_map[uC_index]
         );
         m_mem_host_addr_map[uC_index] = action->get_mem_host_addr();
     }
-    else if (boost::regex_search(action_string, dtrace::action::action_name::write_mem_regex))
+    else if (aiebu::regex_search(action_string, dtrace::action::action_name::write_mem_regex))
     {   // Write memory action
         action = std::make_shared<dtrace::action::write_mem_action>(
             action_string, probe_type, probe_name, m_buffer_map
         );
     }
-    else if (boost::regex_search(action_string, dtrace::action::action_name::break_regex))
+    else if (aiebu::regex_search(action_string, dtrace::action::action_name::break_regex))
     {   // Break action
         action = std::make_shared<dtrace::action::break_action>(
             action_string, probe_type, probe_name
         );
     }
-    else if (boost::regex_search(action_string, dtrace::action::action_name::timestamps_regex))
+    else if (aiebu::regex_search(action_string, dtrace::action::action_name::timestamps_regex))
     {   // Timestamps action
         action = std::make_shared<dtrace::action::timestamps_action>(
             action_string, probe_type, probe_name
         );
     }
-    else if (boost::regex_search(action_string, dtrace::action::action_name::timestamps32_regex))
+    else if (aiebu::regex_search(action_string, dtrace::action::action_name::timestamps32_regex))
     {   // Timestamps32 action
         action = std::make_shared<dtrace::action::timestamps32_action>(
             action_string, probe_type, probe_name
         );
     }
-    else if (boost::regex_search(action_string, dtrace::action::action_name::read_handshake_regex))
+    else if (aiebu::regex_search(action_string, dtrace::action::action_name::read_handshake_regex))
     {   // Read handshake action
         action = std::make_shared<dtrace::action::read_handshake_action>(
             action_string, probe_type, probe_name
         );
     }
-    else if (boost::regex_search(action_string, dtrace::action::action_name::write_handshake_regex))
+    else if (aiebu::regex_search(action_string, dtrace::action::action_name::write_handshake_regex))
     {   // Write handshake action
         action = std::make_shared<dtrace::action::write_handshake_action>(
             action_string, probe_type, probe_name
         );
     }
-    else if (boost::regex_search(action_string, dtrace::action::action_name::operation_regex))
+    else if (aiebu::regex_search(action_string, dtrace::action::action_name::operation_regex))
     {   // Operation action
         action = std::make_shared<dtrace::action::operation_action>(
             action_string, probe_type, probe_name
@@ -664,13 +664,13 @@ parse_line(const std::string& parse_line)
     }
 
     // Skip comments
-    boost::regex comment_regex(R"(^#(.*)$)");
-    if (boost::regex_match(line, comment_regex))
+    aiebu::regex comment_regex(R"(^#(.*)$)");
+    if (aiebu::regex_match(line, comment_regex))
         return;
 
     // Parse the line for begin probe
-    boost::regex begin_regex(R"(^begin\s*\{?$)");
-    if (boost::regex_match(line, begin_regex))
+    aiebu::regex begin_regex(R"(^begin\s*\{?$)");
+    if (aiebu::regex_match(line, begin_regex))
     {
         if (m_state != state_type::probe || m_begin_exist)
             DTRACE_ERROR("DTRACE_PARSER_INVALID_LINE", "Invalid line " << m_position << ": " << line);
@@ -694,8 +694,8 @@ parse_line(const std::string& parse_line)
     }
 
     // Parse the line for end probe
-    boost::regex end_regex(R"(^end\s*\{?$)");
-    if (boost::regex_match(line, end_regex))
+    aiebu::regex end_regex(R"(^end\s*\{?$)");
+    if (aiebu::regex_match(line, end_regex))
     {
         if (m_state != state_type::probe || m_end_exist)
             DTRACE_ERROR("DTRACE_PARSER_INVALID_LINE", "Invalid line " << m_position << ": " << line);
@@ -741,8 +741,8 @@ parse_line(const std::string& parse_line)
     }
 
     // Parse the line for jprobe
-    boost::regex jprobe_regex(R"(^jprobe:([a-zA-Z0-9_\.\/]*)\:(uc[0-9,-]+)\:((line|annotation)[0-9,-]+)\s*\{?$)");
-    if (boost::regex_match(line, jprobe_regex))
+    aiebu::regex jprobe_regex(R"(^jprobe:([a-zA-Z0-9_\.\/]*)\:(uc[0-9,-]+)\:((line|annotation)[0-9,-]+)\s*\{?$)");
+    if (aiebu::regex_match(line, jprobe_regex))
     {
         if (m_state != state_type::probe)
             DTRACE_ERROR("DTRACE_PARSER_INVALID_LINE", "Invalid line " << m_position << ": " << line);
@@ -760,8 +760,8 @@ parse_line(const std::string& parse_line)
     }
  
     // Parse the line for tracepoint probe
-    boost::regex tracepoint_regex(R"(^tracepoint:(uc[0-9,-]+)\:(id[0-9,-]+)\s*\{?$)");
-    if (boost::regex_match(line, tracepoint_regex))
+    aiebu::regex tracepoint_regex(R"(^tracepoint:(uc[0-9,-]+)\:(id[0-9,-]+)\s*\{?$)");
+    if (aiebu::regex_match(line, tracepoint_regex))
     {
         if (m_state != state_type::probe)
             DTRACE_ERROR("DTRACE_PARSER_INVALID_LINE", "Invalid line " << m_position << ": " << line);
@@ -779,8 +779,8 @@ parse_line(const std::string& parse_line)
     }
 
     // Parse the line for profile probe
-    boost::regex profile_regex(R"(^profile:(uc[0-9,-]+)\:([0-9]+)hz\s*\{?$)");
-    if (boost::regex_match(line, profile_regex))
+    aiebu::regex profile_regex(R"(^profile:(uc[0-9,-]+)\:([0-9]+)hz\s*\{?$)");
+    if (aiebu::regex_match(line, profile_regex))
     {
         if (m_state != state_type::probe)
             DTRACE_ERROR("DTRACE_PARSER_INVALID_LINE", "Invalid line " << m_position << ": " << line);
@@ -798,9 +798,9 @@ parse_line(const std::string& parse_line)
     }
 
     // Parse the line for action and operation
-    boost::regex action_regex(R"(^(.+\(.*\).*\)?)$)");
-    boost::regex operation_regex(R"(^(\w+)\s*=\s*(.+)$)");
-    if ((boost::regex_match(line, action_regex) || boost::regex_match(line, operation_regex))
+    aiebu::regex action_regex(R"(^(.+\(.*\).*\)?)$)");
+    aiebu::regex operation_regex(R"(^(\w+)\s*=\s*(.+)$)");
+    if ((aiebu::regex_match(line, action_regex) || aiebu::regex_match(line, operation_regex))
         && m_state == state_type::action)
     {
         m_state = state_type::action;
@@ -816,23 +816,23 @@ parse_line(const std::string& parse_line)
     }
 
     // Parse the line for buffer initialization
-    boost::regex buffer_init_regex(R"(^(\w+)\[(0x[a-fA-F0-9]+|\d+)\]\s*=\s*\{0\}\s*$)");
-    if (boost::regex_match(line, buffer_init_regex) && m_state == state_type::action)
+    aiebu::regex buffer_init_regex(R"(^(\w+)\[(0x[a-fA-F0-9]+|\d+)\]\s*=\s*\{0\}\s*$)");
+    if (aiebu::regex_match(line, buffer_init_regex) && m_state == state_type::action)
     {
         expand_init_buffer(line);
         return;
     }
 
     // Parse the line for write buffer for memory action
-    boost::regex buffer_open_regex(R"(^(\w+\[(0x[a-fA-F0-9]+|\d+)\])(?:\s*=\s*(\[.*)?)?$)");
-    boost::regex buffer_regex(R"(^(\w+)\[(0x[a-fA-F0-9]+|\d+)\]\s*=\s*\[(.*)\]\s*$)");
-    if (boost::regex_match(line, buffer_open_regex) && m_state == state_type::action)
+    aiebu::regex buffer_open_regex(R"(^(\w+\[(0x[a-fA-F0-9]+|\d+)\])(?:\s*=\s*(\[.*)?)?$)");
+    aiebu::regex buffer_regex(R"(^(\w+)\[(0x[a-fA-F0-9]+|\d+)\]\s*=\s*\[(.*)\]\s*$)");
+    if (aiebu::regex_match(line, buffer_open_regex) && m_state == state_type::action)
     {  
         m_state = state_type::buffer_open;
         m_open_buffer = true;
         m_write_buffer += line;
         // single line buffer
-        if (boost::regex_match(m_write_buffer, buffer_regex))
+        if (aiebu::regex_match(m_write_buffer, buffer_regex))
             expand_write_buffer(m_write_buffer);
             
         return;

--- a/src/cpp/dtrace/parser/parser.h
+++ b/src/cpp/dtrace/parser/parser.h
@@ -16,7 +16,6 @@
 #include <cstdint>
 #include <map>
 #include <memory>
-#include <boost/regex.hpp>
 #include <set>
 #include <string>
 #include <unordered_map>

--- a/src/cpp/preprocessor/aie2/aie2_asm_preprocessor_input.cpp
+++ b/src/cpp/preprocessor/aie2/aie2_asm_preprocessor_input.cpp
@@ -191,10 +191,10 @@ public:
     std::string regoff = args[idx++].substr(1);
     // Determine the total size including extended storage by counting the number of writes
 
-    static const boost::regex index_regex = get_regex({fragment::index_re});
+    static const aiebu::regex index_regex = get_regex({fragment::index_re});
 
-    boost::smatch matches;
-    if (!boost::regex_match(args[idx], matches, index_regex))
+    aiebu::smatch matches;
+    if (!aiebu::regex_match(args[idx], matches, index_regex))
         throw error(error::error_code::invalid_asm, args[idx]);
 
     if (matches.size() != 2)
@@ -250,11 +250,11 @@ public:
 
     auto op = reinterpret_cast<XAie_MaskWrite32Hdr *>(m_op);
     op->RegOff = to_uinteger<uint64_t>(regoff);
-    static const boost::regex mask_regex = get_regex({fragment::begin_anchor_re, fragment::hex_re, fragment::l_brack_re,
+    static const aiebu::regex mask_regex = get_regex({fragment::begin_anchor_re, fragment::hex_re, fragment::l_brack_re,
         fragment::r_brack_re, fragment::end_anchor_re});
 
-    boost::smatch matches;
-    if (!boost::regex_match(args[1], matches, mask_regex))
+    aiebu::smatch matches;
+    if (!aiebu::regex_match(args[1], matches, mask_regex))
         throw error(error::error_code::invalid_asm, args[1]);
 
     if (matches.size() != 2)
@@ -283,11 +283,11 @@ public:
     auto op = reinterpret_cast<XAie_MaskPoll32Hdr *>(m_op);
     op->RegOff = to_uinteger<uint64_t>(regoff);
 
-    static const boost::regex mask_poll_regex = get_regex({fragment::begin_anchor_re, fragment::hex_re, fragment::l_brack_re,
+    static const aiebu::regex mask_poll_regex = get_regex({fragment::begin_anchor_re, fragment::hex_re, fragment::l_brack_re,
         fragment::r_brack_re, fragment::equal_re, fragment::hex_re, fragment::end_anchor_re});
 
-    boost::smatch matches;
-    if (!boost::regex_match(args[idx], matches, mask_poll_regex))
+    aiebu::smatch matches;
+    if (!aiebu::regex_match(args[idx], matches, mask_poll_regex))
         throw error(error::error_code::invalid_asm, args[idx]);
 
     if (matches.size() != 3)
@@ -388,9 +388,9 @@ public:
 
 class XAIE_IO_CUSTOM_OP_TCT_op : public aie2_isa_op {
 private:
-  std::pair<uint8_t, uint8_t> parse_index(const boost::regex &regx, const std::string &token) const {
-    boost::smatch cmatches;
-    if (!boost::regex_match(token, cmatches, regx))
+  std::pair<uint8_t, uint8_t> parse_index(const aiebu::regex &regx, const std::string &token) const {
+    aiebu::smatch cmatches;
+    if (!aiebu::regex_match(token, cmatches, regx))
         throw error(error::error_code::invalid_asm, token);
 
     if (cmatches.size() !=3)
@@ -409,8 +409,8 @@ public:
 
     auto values = get_extended_storage<tct_op_t>();
     unsigned int idx = 0;
-    static const boost::regex row_regex = get_regex({fragment::row, fragment::add_dec_re});
-    static const boost::regex col_regex = get_regex({fragment::column, fragment::add_dec_re});
+    static const aiebu::regex row_regex = get_regex({fragment::row, fragment::add_dec_re});
+    static const aiebu::regex col_regex = get_regex({fragment::column, fragment::add_dec_re});
 
     std::pair<uint8_t, uint8_t> row_val = parse_index(row_regex, args[idx++]);
     std::pair<uint8_t, uint8_t> col_val = parse_index(col_regex, args[idx++]);
@@ -449,9 +449,9 @@ public:
 
     auto values = get_extended_storage<tct_op_t>();
 
-    static const boost::regex regx = get_regex({fragment::column, fragment::equal_re, fragment::dec_re});
-    boost::smatch cmatches;
-    if (!boost::regex_match(args[0], cmatches, regx))
+    static const aiebu::regex regx = get_regex({fragment::column, fragment::equal_re, fragment::dec_re});
+    aiebu::smatch cmatches;
+    if (!aiebu::regex_match(args[0], cmatches, regx))
         throw error(error::error_code::invalid_asm, args[0]);
 
     if (cmatches.size() !=3)

--- a/src/cpp/preprocessor/asm/asm_parser.cpp
+++ b/src/cpp/preprocessor/asm/asm_parser.cpp
@@ -114,10 +114,10 @@ asm_parser::
 parse_lines(const std::vector<char>& data, std::string& file)
 {
   //parse asm code
-  const static boost::regex COMMENT_REGEX("^;(.*)$");
-  const static boost::regex LABEL_REGEX("^([a-zA-Z0-9_]+):$");
-  const static boost::regex OP_REGEX("^([.a-zA-Z0-9_]+)(?:[ \\t]+(.+))?$");
-  const static boost::regex DIRCETIVE_REGEX(".^([a-zA-Z0-9_]+)(?:[ \\t]+(.+))?$");
+  const static regex COMMENT_REGEX("^;(.*)$");
+  const static regex LABEL_REGEX("^([a-zA-Z0-9_]+):$");
+  const static regex OP_REGEX("^([.a-zA-Z0-9_]+)(?:[ \\t]+(.+))?$");
+  const static regex DIRCETIVE_REGEX(".^([a-zA-Z0-9_]+)(?:[ \\t]+(.+))?$");
 
   std::string str(data.begin(), data.end());
   std::istringstream isstr(str);
@@ -130,10 +130,10 @@ parse_lines(const std::vector<char>& data, std::string& file)
     if(line.empty())
       continue;
 
-    if (line[0] == ';') //boost::regex_match(line, COMMENT_REGEX))
+    if (line[0] == ';') //regex_match(line, COMMENT_REGEX))
       continue;
 
-    boost::smatch sm;
+    smatch sm;
 
     // Check for Directive (starts with .) - only check regex if prefix matches
     if (line[0] == '.' && operate_directive(line))
@@ -163,7 +163,7 @@ parse_lines(const std::vector<char>& data, std::string& file)
     }
 
     // check for label - fast check for ':' at end before regex
-    if (line.back() == ':' && boost::regex_match(line, sm, LABEL_REGEX))
+    if (line.back() == ':' && regex_match(line, sm, LABEL_REGEX))
     {
       if (!get_data_state())
         m_current_label = m_current_label + ":" + sm[1].str();
@@ -174,7 +174,7 @@ parse_lines(const std::vector<char>& data, std::string& file)
       continue;
     }
     // check for operation
-    else if (boost::regex_match(line, sm, OP_REGEX))
+    else if (regex_match(line, sm, OP_REGEX))
     {
       std::string arg_str = (sm.size() > 2 && sm[2].matched) ? sm[2].str() : "";
       insert_col_asmdata(std::make_shared<asm_data>(std::make_shared<operation>(sm[1].str(), arg_str),
@@ -191,7 +191,7 @@ parse_lines(const std::vector<char>& data, std::string& file)
 
 void
 attach_to_group_directive::
-operate(std::shared_ptr<asm_parser> parserptr, const boost::smatch& sm)
+operate(std::shared_ptr<asm_parser> parserptr, const smatch& sm)
 {
   m_parserptr = parserptr;
   verify_match(sm, error::error_code::invalid_asm, "Invalid attach_to_group directive argument\n");
@@ -206,7 +206,7 @@ operate(std::shared_ptr<asm_parser> parserptr, const boost::smatch& sm)
 
 void
 section_directive::
-operate(std::shared_ptr<asm_parser> parserptr, const boost::smatch& sm)
+operate(std::shared_ptr<asm_parser> parserptr, const smatch& sm)
 {
   m_parserptr = parserptr;
   verify_match(sm, error::error_code::invalid_asm, ".section directive requires arguments\n");
@@ -224,14 +224,15 @@ operate(std::shared_ptr<asm_parser> parserptr, const boost::smatch& sm)
 
 void
 partition_directive::
-operate(std::shared_ptr<asm_parser> parserptr, const boost::smatch& sm)
+operate(std::shared_ptr<asm_parser> parserptr, const smatch& sm)
 {
   m_parserptr = parserptr;
-  static const boost::regex pattern(R"(\.partition\s+(\d+)(column|core:(\d+)mem))");
-  boost::smatch match;
-  std::cout << "PARTITION:" << sm[0].str() << "\n";
+  static const regex pattern(R"(\.partition\s+(\d+)(column|core:(\d+)mem))");
+  smatch match;
+//  LOG_INFO("PARTITION:" << sm[0].str());
+  std::cout << "PARTITION:" << sm[0].str() << std::endl;
   std::string line = sm[0].str();
-  if (boost::regex_match(line, match, pattern)) {
+  if (regex_match(line, match, pattern)) {
     if (match[2] == "column") {
       std::cout << "Column count: " << match[1] << std::endl;
       m_parserptr->set_numcolumn(to_uinteger<uint32_t>(match[1]));
@@ -266,7 +267,7 @@ read_include_file(std::string filename)
 
 void
 include_directive::
-operate(std::shared_ptr<asm_parser> parserptr, const boost::smatch& sm)
+operate(std::shared_ptr<asm_parser> parserptr, const smatch& sm)
 {
   m_parserptr = parserptr;
   //std::vector<std::string> args = splitoption(sm[2].str().c_str(), ',');
@@ -293,7 +294,7 @@ operate(std::shared_ptr<asm_parser> parserptr, const boost::smatch& sm)
 
 void
 end_of_label_directive::
-operate(std::shared_ptr<asm_parser> parserptr, const boost::smatch& sm)
+operate(std::shared_ptr<asm_parser> parserptr, const smatch& sm)
 {
   m_parserptr = parserptr;
 
@@ -309,7 +310,7 @@ operate(std::shared_ptr<asm_parser> parserptr, const boost::smatch& sm)
 
 void
 pad_directive::
-operate(std::shared_ptr<asm_parser> parserptr, const boost::smatch& sm)
+operate(std::shared_ptr<asm_parser> parserptr, const smatch& sm)
 {
   m_parserptr = parserptr;
   verify_match(sm, error::error_code::invalid_asm, ".setpad directive requires arguments\n");
@@ -330,8 +331,8 @@ add_scratchpad(std::string& name, std::string& str) {
     return;
   }
   // Check if the string is a hexadecimal number
-  static const boost::regex hex_regex("0[xX][0-9a-fA-F]+");
-  if (boost::regex_match(str, hex_regex)) {
+  static const regex hex_regex("0[xX][0-9a-fA-F]+");
+  if (regex_match(str, hex_regex)) {
     std::vector<char> empty_vector;
     m_parserptr->insert_scratchpad(name, convert2int(str) * WORD_SIZE, empty_vector);
     return;

--- a/src/cpp/preprocessor/asm/asm_parser.h
+++ b/src/cpp/preprocessor/asm/asm_parser.h
@@ -6,10 +6,10 @@
 #include "code_section.h"
 #include "utils.h"
 #include "file_utils.h"
+#include "common/regex_wrapper.h"
 
 #include <map>
 #include <memory>
-#include <boost/regex.hpp>
 #include <stack>
 #include <sstream>
 #include <string>
@@ -27,7 +27,7 @@ inline std::string trim(const std::string& line)
     return (start == end && start == std::string::npos) ? std::string() : line.substr(start, end - start + 1);
 }
 
-inline void verify_match(const boost::smatch& sm, error::error_code ecode, const char* msg)
+inline void verify_match(const smatch& sm, error::error_code ecode, const char* msg)
 {
   if (sm.size() < 3 || !sm[2].matched || sm[2].length() == 0)
     throw error(ecode, msg);
@@ -77,7 +77,7 @@ public:
   std::shared_ptr<asm_parser> m_parserptr;
 public:
   directive() {}
-  virtual void operate(std::shared_ptr<asm_parser> parserptr, const boost::smatch& sm) = 0;
+  virtual void operate(std::shared_ptr<asm_parser> parserptr, const smatch& sm) = 0;
   virtual ~directive() = default;
 };
 
@@ -85,7 +85,7 @@ class attach_to_group_directive: public directive
 {
 public:
   attach_to_group_directive() = default;
-  void operate(std::shared_ptr<asm_parser> parserptr, const boost::smatch& sm) override;
+  void operate(std::shared_ptr<asm_parser> parserptr, const smatch& sm) override;
   ~attach_to_group_directive() override = default;
 };
 
@@ -95,7 +95,7 @@ class include_directive: public directive
   bool read_include_file(std::string filename);
 public:
   include_directive() = default;
-  void operate(std::shared_ptr<asm_parser> parserptr, const boost::smatch& sm) override;
+  void operate(std::shared_ptr<asm_parser> parserptr, const smatch& sm) override;
   ~include_directive() override = default;
 };
 
@@ -103,7 +103,7 @@ class end_of_label_directive: public directive
 {
 public:
   end_of_label_directive() = default;
-  void operate(std::shared_ptr<asm_parser> parserptr, const boost::smatch& sm) override;
+  void operate(std::shared_ptr<asm_parser> parserptr, const smatch& sm) override;
   ~end_of_label_directive() override = default;
 };
 
@@ -129,7 +129,7 @@ public:
   }
   void add_scratchpad(std::string& name, std::string& str);
   pad_directive() = default;
-  void operate(std::shared_ptr<asm_parser> parserptr, const boost::smatch& sm) override;
+  void operate(std::shared_ptr<asm_parser> parserptr, const smatch& sm) override;
   ~pad_directive() override = default;
 };
 
@@ -140,7 +140,7 @@ class section_directive: public directive
   bool is_annotation_section(const std::string& str) {return !str.substr(0,10).compare("annotation"); }
 public:
   section_directive() = default;
-  void operate(std::shared_ptr<asm_parser> parserptr, const boost::smatch& sm) override;
+  void operate(std::shared_ptr<asm_parser> parserptr, const smatch& sm) override;
   ~section_directive() override = default;
 };
 
@@ -148,7 +148,7 @@ class partition_directive: public directive
 {
 public:
   partition_directive() = default;
-  void operate(std::shared_ptr<asm_parser> parserptr, const boost::smatch& sm) override;
+  void operate(std::shared_ptr<asm_parser> parserptr, const smatch& sm) override;
   ~partition_directive() override = default;
   partition_directive(const partition_directive&) = default;
   partition_directive& operator=(const partition_directive&) = default;
@@ -383,9 +383,9 @@ public:
 
   bool operate_directive(const std::string& line)
   {
-    boost::smatch sm;
-    const static boost::regex DIRCETIVE_REGEX("^([.a-zA-Z0-9_]+)(?:[ \\t]+(.+))?$");
-    boost::regex_match(line, sm, DIRCETIVE_REGEX);
+    smatch sm;
+    const static regex DIRCETIVE_REGEX("^([.a-zA-Z0-9_]+)(?:[ \\t]+(.+))?$");
+    regex_match(line, sm, DIRCETIVE_REGEX);
     if (sm.size() == 0)
       return false;
 


### PR DESCRIPTION
#### Problem solved by the commit
Some customers are still using Ubuntu 22.04 which has older boost versions (<1.76 ) and don't support Boost::regex header only.
Hence, for customers having boost < 1.76 will be using std::regex and boost>=1.76 will use boost::regex

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
N/A

#### How problem was solved, alternative solutions (if any) and why they were rejected
1> Added regex wrapper in aiebu wrapped around std::regex and boost::regex. boost::regex v/s std::regex  is selected considering boost::regex version.
```
If boost version < 1.76 
    std::regex
Else
   boost::regex
```

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
1> Successfully built and ran build ctests on Windows and Ubuntu 22.04
2> Ubuntu CI pipelines build ran successfully too which is Ubuntu 24.04

#### Documentation impact (if any)
