### PR TITLE
eof mamagment across labels in same file

### DIFF
--- a/src/cpp/preprocessor/asm/asm_parser.cpp
+++ b/src/cpp/preprocessor/asm/asm_parser.cpp
@@ -165,9 +165,10 @@ parse_lines(const std::vector<char>& data, std::string& file)
     // check for label - fast check for ':' at end before regex
     if (line.back() == ':' && regex_match(line, sm, LABEL_REGEX))
     {
-      if (!get_data_state())
+      if (!get_data_state()) {
         m_current_label = m_current_label + ":" + sm[1].str();
-      else
+        set_data_state(false);
+      } else
         insert_col_asmdata(std::make_shared<asm_data>(std::make_shared<operation>(sm[1].str(), ""),
                                                       operation_type::label, code_section::unknown, 0,
                                                       (uint32_t)-1, linenumber, line, file));
@@ -306,6 +307,7 @@ operate(std::shared_ptr<asm_parser> parserptr, const smatch& sm)
   std::vector<std::string> args = splitoption(sm[2].str().c_str(), ',');
   if (label.compare(args[0]))
     throw error(error::error_code::internal_error, "endl label missmatch (" + label + " != " + args[0] + ")\n");
+  m_parserptr->pop_data_state();
 }
 
 void

--- a/src/cpp/preprocessor/asm/asm_parser.cpp
+++ b/src/cpp/preprocessor/asm/asm_parser.cpp
@@ -306,7 +306,7 @@ operate(std::shared_ptr<asm_parser> parserptr, const smatch& sm)
 
   std::vector<std::string> args = splitoption(sm[2].str().c_str(), ',');
   if (label.compare(args[0]))
-    throw error(error::error_code::internal_error, "endl label missmatch (" + label + " != " + args[0] + ")\n");
+    throw error(error::error_code::internal_error, "endl label mismatch (" + label + " != " + args[0] + ")\n");
   m_parserptr->pop_data_state();
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
eof mamagment across labels in same file
when we find eof in file we consider everything below as data section but we should consider label boundaries also
```
START_JOB 0
LOAD_PDI 0, @pdi
END_JOB
.eop
 
START_JOB 1
LOAD_CORES 0, @core
END_JOB
.eop
 
START_JOB 2
NOP
END_JOB
 
pdi:
START_JOB 0
NOP
END_JOB
EOF
.endl pdi
 
core:
START_JOB 0
NOP
END_JOB
EOF
.endl core
 
EOF
```
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
when we find eof in file we consider everything below as data section but we should consider label boundaries.

#### How problem was solved, alternative solutions (if any) and why they were rejected
we use stack for checking text or data section

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
```
START_JOB 0
LOAD_PDI 0, @pdi
END_JOB
.eop
 
START_JOB 1
LOAD_CORES 0, @core
END_JOB
.eop
 
START_JOB 2
NOP
UC_DMA_WRITE_DES_SYNC	 @UCBD_label_0
END_JOB
 
pdi:
START_JOB 0
NOP
UC_DMA_WRITE_DES_SYNC	 @UCBD_label_1
END_JOB
EOF
.align    16
UCBD_label_1:
	 UC_DMA_BD	 0, 0x30b5c0, @DMAWRITE_data_1, 0x1, 0, 0
.align    4
DMAWRITE_data_1:
	.long 0x66660001
.endl pdi
 
core:
START_JOB 0
NOP
UC_DMA_WRITE_DES_SYNC	 @UCBD_label_2
END_JOB
EOF
.align    16
UCBD_label_2:
	 UC_DMA_BD	 0, 0x30b5c0, @DMAWRITE_data_2, 0x1, 0, 0
.align    4
DMAWRITE_data_2:
	.long 0x66660002

.endl core
 
EOF
.align    16
UCBD_label_0:
	 UC_DMA_BD	 0, 0x30b5c0, @DMAWRITE_data_0, 0x1, 0, 0
.align    4	 
DMAWRITE_data_0:
	.long 0x66660000

```

#### Documentation impact (if any)
