### PR TITLE
Fix build failures on Fedora 43

### DIFF
--- a/src/cpp/analyzer/basicpass.h
+++ b/src/cpp/analyzer/basicpass.h
@@ -4,6 +4,7 @@
 #ifndef AIEBU_BASICPASS_H_
 #define AIEBU_BASICPASS_H_
 
+#include <cstdint>
 #include <elfio/elfio.hpp>
 #include <elfio/elfio_section.hpp>
 

--- a/src/cpp/common/assembler_state.cpp
+++ b/src/cpp/common/assembler_state.cpp
@@ -78,14 +78,15 @@ process(bool makeunique)
         {
           m_jobmap[EOF_ID]->set_end(m_pos);
           m_jobmap[EOF_ID]->set_end_index(index);
-          cjob_id = -1;
+          cjob_id = std::to_string(-1);
         }
       } else if (!name.compare(".eop")) {
         m_jobmap[gen_eop_name(eopnum)] = std::make_shared<job>(gen_eop_name(eopnum), m_pos, index, eopnum, false);
         m_jobids.push_back(gen_eop_name(eopnum));
         ++eopnum;
-      } else
+      } else {
         throw error(error::error_code::internal_error, "Invalid operation:" + name);
+      }
 
       if (!name.compare("local_barrier"))
       {
@@ -207,8 +208,9 @@ uint32_t assembler_state::parse_num_arg(const std::string& str) {
   } else if (is_number(str))
   { //parse numeric string
     return std::stoul(str);
-  } else
+  } else {
     throw symbol_exception();
+  }
 }
 
 void

--- a/src/cpp/encoder/aie2ps/aie2ps_encoder.h
+++ b/src/cpp/encoder/aie2ps/aie2ps_encoder.h
@@ -21,9 +21,9 @@ class aie2ps_encoder : public encoder
   std::vector<std::shared_ptr<writer>> twriter;
   asm_report m_report;
   Debug m_debug;
-  asm_dump_flag m_dump_flag;
+  asm_dump_flag m_dump_flag = asm_dump_flag::disable;
 public:
-  aie2ps_encoder() {     
+  aie2ps_encoder() {
     isa i;
     m_isa = i.get_isamap();
   }
@@ -40,7 +40,7 @@ public:
   void fill_scratchpad(std::shared_ptr<section_writer> padwriter,const std::map<std::string, std::shared_ptr<scratchpad_info>>& scratchpads);
   void fill_controlpkt(std::shared_ptr<section_writer> padwriter, const std::vector<char>& ctrlpkt);
   void fill_control_packet_symbols(std::shared_ptr<section_writer> ctrlpktwriter, const std::vector<symbol>& syms);
- 
+
   std::string findKey(const std::map<std::string, std::vector<std::string>>& myMap, const std::string& value);
 
   virtual std::shared_ptr<assembler_state>

--- a/test/aie2ps-ctrlcode/run-readelf.sh
+++ b/test/aie2ps-ctrlcode/run-readelf.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 
 # SPDX-License-Identifier: MIT
-# Copyright (C) 2023-2024 Advanced Micro Devices, Inc.
+# Copyright (C) 2023-2025 Advanced Micro Devices, Inc.
 
-eu-readelf -a $1 > $2
+# Strip out the following from readelf output if present. Newer readelf
+# include this message which skews the gold file comparison
+# Key to Flags:
+#   W (write), A (alloc), X (execute), M (merge), S (strings), I (info),
+#   L (link order), N (extra OS processing required), G (group), T (TLS),
+#   C (compressed), O (ordered), R (GNU retain), E (exclude)
+
+
+eu-readelf -a $1 | sed "/Key to Flags/,+3d" > $2


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Fix the build on Fedora 43

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA

#### How problem was solved, alternative solutions (if any) and why they were rejected
1. Update errors identified by clang-tidy on F43
2. Filter out "Key to Flags" message from readelf on F43 as it skews the gold comparison

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Compile and build tested

#### Documentation impact (if any)
None