### PR TITLE
Add binary i/p support to disassembler + fix bugs

### DIFF
--- a/src/cpp/analyzer/reporter.cpp
+++ b/src/cpp/analyzer/reporter.cpp
@@ -182,6 +182,16 @@ namespace aiebu {
         else if (m_buffer_type == aiebu::aiebu_assembler::buffer_type::blob_instr_transaction) {
             disassemble_blob(stream);
         }
+        else if (m_buffer_type == aiebu::aiebu_assembler::buffer_type::unspecified) {
+            // Treat unspecified buffer type as raw binary data
+            try {
+                aiebu::asm_disassembler disasm(m_buffer, stream, true);
+                disasm.run();
+            } catch (const std::exception& ex) {
+                throw error(error::error_code::internal_error,
+                    "Binary disassembler error: " + std::string(ex.what()));
+            }
+        }
         else {
             throw error(error::error_code::invalid_buffer_type,
                   "Invalid buffer type for disassembly");

--- a/src/cpp/analyzer/reporter.cpp
+++ b/src/cpp/analyzer/reporter.cpp
@@ -14,8 +14,8 @@
 #include <elfio/elfio_dump.hpp>
 namespace aiebu {
 
-    reporter::reporter(aiebu::aiebu_assembler::buffer_type type, const std::vector<char>& buffer, const std::string& target_arch) :
-        m_buffer_type(type), m_buffer(buffer), m_target_arch(target_arch)
+    reporter::reporter(aiebu::aiebu_assembler::buffer_type type, const std::vector<char>& buffer) :
+        m_buffer_type(type), m_buffer(buffer)
     {
         if (buffer.empty()) {
             throw error(error::error_code::invalid_input, "Input buffer is empty");
@@ -132,7 +132,7 @@ namespace aiebu {
         }
         else if (m_buffer_type == aiebu::aiebu_assembler::buffer_type::elf_aie2ps ) {
             try {
-                aiebu::asm_disassembler disasm(root.string(), std::cout);
+                aiebu::elf_asm_disassembler disasm(root.string(), std::cout);
                 disasm.run();
             } catch (const std::exception& ex) {
                 throw error(error::error_code::internal_error,
@@ -179,10 +179,8 @@ namespace aiebu {
                 stream << tprint.get_all_ops() << std::endl;
             }
         }
-        else if (m_buffer_type == aiebu::aiebu_assembler::buffer_type::blob_instr_transaction) {
-            disassemble_blob(stream);
-        }
-        else if (m_buffer_type == aiebu::aiebu_assembler::buffer_type::blob_aie2ps ||
+        else if (m_buffer_type == aiebu::aiebu_assembler::buffer_type::blob_instr_transaction ||
+                 m_buffer_type == aiebu::aiebu_assembler::buffer_type::blob_aie2ps ||
                  m_buffer_type == aiebu::aiebu_assembler::buffer_type::blob_aie4) {
             // Disassemble binary files - delegate to disassemble_blob for evaluation
             disassemble_blob(stream);
@@ -201,35 +199,25 @@ namespace aiebu {
 
     void reporter::disassemble_blob(std::ostream &stream) const
     {
-        // Evaluate buffer type and disassemble accordingly
-        if (m_buffer_type == aiebu::aiebu_assembler::buffer_type::blob_aie2ps) {
-            // Disassemble aie2ps binary file
-            try {
-                aiebu::asm_disassembler disasm(m_buffer, stream, "aie2ps");
+        try {
+            // Evaluate buffer type and disassemble accordingly
+            if (m_buffer_type == aiebu::aiebu_assembler::buffer_type::blob_aie2ps ||
+                m_buffer_type == aiebu::aiebu_assembler::buffer_type::blob_aie4) {
+                aiebu::bin_asm_disassembler disasm(m_buffer, stream, m_buffer_type);
                 disasm.run();
-            } catch (const std::exception& ex) {
-                throw error(error::error_code::internal_error,
-                    "AIE2PS binary disassembler error: " + std::string(ex.what()));
             }
-        }
-        else if (m_buffer_type == aiebu::aiebu_assembler::buffer_type::blob_aie4) {
-            // Disassemble aie4 binary file
-            try {
-                aiebu::asm_disassembler disasm(m_buffer, stream, "aie4");
-                disasm.run();
-            } catch (const std::exception& ex) {
-                throw error(error::error_code::internal_error,
-                    "AIE4 binary disassembler error: " + std::string(ex.what()));
+            else if (m_buffer_type == aiebu::aiebu_assembler::buffer_type::blob_instr_transaction) {
+                // Legacy transaction format disassembly
+                transaction tprint(m_buffer.data(), m_buffer.size());
+                stream << tprint.get_all_ops() << std::endl;
             }
-        }
-        else if (m_buffer_type == aiebu::aiebu_assembler::buffer_type::blob_instr_transaction) {
-            // Legacy transaction format disassembly
-            transaction tprint(m_buffer.data(), m_buffer.size());
-            stream << tprint.get_all_ops() << std::endl;
-        }
-        else {
-            throw error(error::error_code::invalid_buffer_type,
-                "disassemble_blob called with unsupported buffer type");
+            else {
+                throw error(error::error_code::invalid_buffer_type,
+                    "disassemble_blob called with unsupported buffer type");
+            }
+        } catch (const std::exception& ex) {
+            throw error(error::error_code::internal_error,
+                "Binary disassembler error: " + std::string(ex.what()));
         }
     }
 

--- a/src/cpp/analyzer/reporter.cpp
+++ b/src/cpp/analyzer/reporter.cpp
@@ -14,8 +14,8 @@
 #include <elfio/elfio_dump.hpp>
 namespace aiebu {
 
-    reporter::reporter(aiebu::aiebu_assembler::buffer_type type, const std::vector<char>& buffer) :
-        m_buffer_type(type), m_buffer(buffer)
+    reporter::reporter(aiebu::aiebu_assembler::buffer_type type, const std::vector<char>& buffer, const std::string& target_arch) :
+        m_buffer_type(type), m_buffer(buffer), m_target_arch(target_arch)
     {
         if (buffer.empty()) {
             throw error(error::error_code::invalid_input, "Input buffer is empty");
@@ -182,15 +182,10 @@ namespace aiebu {
         else if (m_buffer_type == aiebu::aiebu_assembler::buffer_type::blob_instr_transaction) {
             disassemble_blob(stream);
         }
-        else if (m_buffer_type == aiebu::aiebu_assembler::buffer_type::unspecified) {
-            // Treat unspecified buffer type as raw binary data
-            try {
-                aiebu::asm_disassembler disasm(m_buffer, stream, true);
-                disasm.run();
-            } catch (const std::exception& ex) {
-                throw error(error::error_code::internal_error,
-                    "Binary disassembler error: " + std::string(ex.what()));
-            }
+        else if (m_buffer_type == aiebu::aiebu_assembler::buffer_type::blob_aie2ps ||
+                 m_buffer_type == aiebu::aiebu_assembler::buffer_type::blob_aie4) {
+            // Disassemble binary files - delegate to disassemble_blob for evaluation
+            disassemble_blob(stream);
         }
         else {
             throw error(error::error_code::invalid_buffer_type,
@@ -206,8 +201,36 @@ namespace aiebu {
 
     void reporter::disassemble_blob(std::ostream &stream) const
     {
-        transaction tprint(m_buffer.data(), m_buffer.size());
-        stream << tprint.get_all_ops() << std::endl;
+        // Evaluate buffer type and disassemble accordingly
+        if (m_buffer_type == aiebu::aiebu_assembler::buffer_type::blob_aie2ps) {
+            // Disassemble aie2ps binary file
+            try {
+                aiebu::asm_disassembler disasm(m_buffer, stream, "aie2ps");
+                disasm.run();
+            } catch (const std::exception& ex) {
+                throw error(error::error_code::internal_error,
+                    "AIE2PS binary disassembler error: " + std::string(ex.what()));
+            }
+        }
+        else if (m_buffer_type == aiebu::aiebu_assembler::buffer_type::blob_aie4) {
+            // Disassemble aie4 binary file
+            try {
+                aiebu::asm_disassembler disasm(m_buffer, stream, "aie4");
+                disasm.run();
+            } catch (const std::exception& ex) {
+                throw error(error::error_code::internal_error,
+                    "AIE4 binary disassembler error: " + std::string(ex.what()));
+            }
+        }
+        else if (m_buffer_type == aiebu::aiebu_assembler::buffer_type::blob_instr_transaction) {
+            // Legacy transaction format disassembly
+            transaction tprint(m_buffer.data(), m_buffer.size());
+            stream << tprint.get_all_ops() << std::endl;
+        }
+        else {
+            throw error(error::error_code::invalid_buffer_type,
+                "disassemble_blob called with unsupported buffer type");
+        }
     }
 
     void reporter::disassemble_blob(const std::filesystem::path &root) const

--- a/src/cpp/analyzer/reporter.h
+++ b/src/cpp/analyzer/reporter.h
@@ -14,7 +14,6 @@ namespace aiebu {
         ELFIO::elfio my_elf_reader;
         const aiebu::aiebu_assembler::buffer_type m_buffer_type;
         const std::vector<char> m_buffer;
-        std::string m_target_arch;
         void ctrlcode_blob_summary(std::ostream &stream) const;
         void disassemble_blob(std::ostream &stream) const;
         void disassemble_blob(const std::filesystem::path &root) const;
@@ -32,7 +31,7 @@ namespace aiebu {
         }
     public:
         // Constructor
-        reporter(aiebu::aiebu_assembler::buffer_type type, const std::vector<char>& buffer, const std::string& target_arch = "aie2ps");
+        reporter(aiebu::aiebu_assembler::buffer_type type, const std::vector<char>& buffer);
 
         // Delete copy and move constructors and assignment operators
         reporter(const reporter&) = delete;               // Copy constructor

--- a/src/cpp/analyzer/reporter.h
+++ b/src/cpp/analyzer/reporter.h
@@ -14,6 +14,7 @@ namespace aiebu {
         ELFIO::elfio my_elf_reader;
         const aiebu::aiebu_assembler::buffer_type m_buffer_type;
         const std::vector<char> m_buffer;
+        std::string m_target_arch;
         void ctrlcode_blob_summary(std::ostream &stream) const;
         void disassemble_blob(std::ostream &stream) const;
         void disassemble_blob(const std::filesystem::path &root) const;
@@ -31,7 +32,7 @@ namespace aiebu {
         }
     public:
         // Constructor
-        reporter(aiebu::aiebu_assembler::buffer_type type, const std::vector<char>& buffer);
+        reporter(aiebu::aiebu_assembler::buffer_type type, const std::vector<char>& buffer, const std::string& target_arch = "aie2ps");
 
         // Delete copy and move constructors and assignment operators
         reporter(const reporter&) = delete;               // Copy constructor

--- a/src/cpp/common/file_utils.cpp
+++ b/src/cpp/common/file_utils.cpp
@@ -51,8 +51,6 @@ identify_buffer_type(const std::vector<char>& buffer)
   if ((data[0] == pdi_magic0) && (data[1] == pdi_magic1))
     return aiebu_assembler::buffer_type::pdi_aie2;
 
-  // TODO: Put the reference to Packet Header and Control Packet here
-  // ctrlpkt identification is WIP
   return identify_control_packet(buffer.data(), buffer.size());
 }
 

--- a/src/cpp/disassembler/disassembler.cpp
+++ b/src/cpp/disassembler/disassembler.cpp
@@ -37,6 +37,9 @@ static constexpr size_t align_16 = 16;                      // 16-byte alignment
 static constexpr size_t ctrltext_string_length = 9;        // Length of ".ctrltext"
 static constexpr size_t ctrldata_string_length = 9;        // Length of ".ctrldata"
 
+// Bit Shift Constants
+static constexpr size_t byte_shift = 8;                    // Bit shift for byte-to-word conversion
+
 // Base class constructor
 asm_disassembler::asm_disassembler(std::ostream& output_stream)
     : m_asm_writer(output_stream), m_target_arch("") {
@@ -152,9 +155,7 @@ void elf_asm_disassembler::run() {
 bin_asm_disassembler::bin_asm_disassembler(const std::vector<char>& binary_data, 
                                           std::ostream& output_stream, 
                                           aiebu_assembler::buffer_type buffer_type)
-    : asm_disassembler(output_stream) {
-    m_binary_data = binary_data;
-    
+    : asm_disassembler(output_stream), m_binary_data(binary_data) {
     // Set target architecture from buffer type
     switch (buffer_type) {
         case aiebu_assembler::buffer_type::blob_aie2ps:
@@ -274,7 +275,7 @@ void bin_asm_disassembler::process_binary() {
         
         // Read cur_page_len from header
         uint16_t cur_page_len = static_cast<uint8_t>(m_binary_data[offset + page_header_cur_len_low]) | 
-                               (static_cast<uint8_t>(m_binary_data[offset + page_header_cur_len_high]) << 8);
+                               (static_cast<uint8_t>(m_binary_data[offset + page_header_cur_len_high]) << byte_shift);
         
         // cur_page_len includes the header itself, so content is (cur_page_len - page_header_size)
         size_t content_size = (cur_page_len > page_header_size) ? 

--- a/src/cpp/disassembler/disassembler.cpp
+++ b/src/cpp/disassembler/disassembler.cpp
@@ -4,6 +4,8 @@
 #include <fstream>
 #include <stdexcept>
 #include <iostream>
+#include <iomanip>
+#include <sstream>
 
 namespace aiebu {
 
@@ -13,15 +15,27 @@ static constexpr size_t CTRLTEXT_STRING_LENGTH = 9;  // Length of ".ctrltext"
 static constexpr size_t CTRLDATA_STRING_LENGTH = 9;  // Length of ".ctrldata"
 
 asm_disassembler::asm_disassembler(const std::string& input_elf_path, std::ostream& output_stream)
-    : m_asm_writer(output_stream) {
+    : m_asm_writer(output_stream), m_is_binary_mode(false) {
     if (!m_elf_reader.load(input_elf_path)) {
         throw error(error::error_code::invalid_elf, "Failed to load ELF:" + input_elf_path + "\n");
     }
     isa_op_map = isa_disasm.get_isa_map();
 }
 
+asm_disassembler::asm_disassembler(const std::vector<char>& binary_data, std::ostream& output_stream, bool is_binary)
+    : m_asm_writer(output_stream), m_binary_data(binary_data), m_is_binary_mode(is_binary) {
+    if (!is_binary) {
+        throw error(error::error_code::invalid_input, "Binary mode constructor requires is_binary to be true\n");
+    }
+    isa_op_map = isa_disasm.get_isa_map();
+}
+
 void asm_disassembler::run() {
-    process_sections();
+    if (m_is_binary_mode) {
+        process_binary();
+    } else {
+        process_sections();
+    }
 }
 
 void asm_disassembler::process_sections() {
@@ -51,7 +65,7 @@ void asm_disassembler::print_section_info(const ELFIO::section* section) {
         flags += "x";
     m_asm_writer.write_directive("");
     if (is_data_section(section->get_name()))
-        m_asm_writer.write_directive(".align " + std::to_string(section->get_addr_align()));
+        m_asm_writer.write_directive("  .ALIGN             " + std::to_string(section->get_addr_align()));
 }
 
 void asm_disassembler::process_text_section(const ELFIO::section* section, std::shared_ptr<disassembler_state> state) {
@@ -77,6 +91,7 @@ void asm_disassembler::process_data_section(const ELFIO::section* section, std::
     const char* section_data = section->get_data();
     size_t section_size = section->get_size();
     isa_op_disasm dummy_isa_op("dummy", 0, std::vector<opArg>{});
+    bool align_4_written = false;
     for (size_t offset = 0; offset < section_size;) {
         uint8_t opcode = *reinterpret_cast<const uint8_t*>(section_data + offset);
         auto label_map = state->get_labels();
@@ -86,7 +101,11 @@ void asm_disassembler::process_data_section(const ELFIO::section* section, std::
             size_t consumed = deserializer.deserialize(m_asm_writer, state, section_data + offset);
             offset += consumed;
         } else if (local_ptr_map.find(state->get_address()) != local_ptr_map.end()) {
-            m_asm_writer.write_directive(".align 4");
+            if (!align_4_written) {
+                m_asm_writer.write_directive("");
+                m_asm_writer.write_directive("  .ALIGN             4");
+                align_4_written = true;
+            }
             long_op_deserializer deserializer(&dummy_isa_op);
             size_t consumed = deserializer.deserialize(m_asm_writer, state, section_data + offset);
             offset += consumed;
@@ -111,5 +130,205 @@ bool asm_disassembler::is_text_section(const std::string& section_name) const {
 bool asm_disassembler::is_data_section(const std::string& section_name) const {
     bool result = section_name.substr(0, CTRLDATA_STRING_LENGTH) == ".ctrldata";
     return result;
+}
+
+void asm_disassembler::process_binary() {
+    if (m_binary_data.empty()) {
+        throw error(error::error_code::invalid_input, "Binary data is empty\n");
+    }
+    
+    // Binary files contain multiple pages, each exactly PAGE_SIZE (8192) bytes
+    // Each page has: 16-byte header + content (up to cur_page_len) + padding to 8192
+    static constexpr size_t PAGE_SIZE = 8192;
+    static constexpr size_t PAGE_HEADER_SIZE = 16;
+    
+    size_t offset = 0;
+    int page_num = 0;
+    
+    while (offset < m_binary_data.size()) {
+        // Check if there's enough data for a page
+        size_t remaining = m_binary_data.size() - offset;
+        if (remaining < PAGE_HEADER_SIZE) {
+            break; // Not enough data for another page
+        }
+        
+        // Check for page header (0xFF 0xFF magic bytes)
+        if (static_cast<uint8_t>(m_binary_data[offset]) != 0xFF ||
+            static_cast<uint8_t>(m_binary_data[offset + 1]) != 0xFF) {
+            // No more pages
+            break;
+        }
+        
+        // Read cur_page_len from header (bytes 8-9)
+        uint16_t cur_page_len = static_cast<uint8_t>(m_binary_data[offset + 8]) | 
+                               (static_cast<uint8_t>(m_binary_data[offset + 9]) << 8);
+        
+        // cur_page_len includes the header itself, so content is (cur_page_len - PAGE_HEADER_SIZE)
+        size_t content_size = (cur_page_len > PAGE_HEADER_SIZE) ? 
+                             (cur_page_len - PAGE_HEADER_SIZE) : 0;
+        
+        // Process this page
+        auto state = std::make_shared<disassembler_state>();
+        
+        if (content_size > 0) {
+            process_binary_data(m_binary_data.data() + offset + PAGE_HEADER_SIZE, 
+                               content_size, state);
+        }
+        
+        // Move to next page (always at PAGE_SIZE boundary)
+        offset += PAGE_SIZE;
+        page_num++;
+    }
+    
+    if (page_num == 0) {
+        throw error(error::error_code::invalid_input, 
+                   "No valid pages found in binary file\n");
+    }
+}
+
+size_t asm_disassembler::detect_binary_header_offset() const {
+    // Check for various binary formats and determine header size
+    if (m_binary_data.size() < 16) {
+        return 0; // Too small for any header
+    }
+    
+    // Check for AIE2PS/AIE4 page header (16 bytes)
+    // Page header format: { 0xFF, 0xFF, page_index[2], ooo_len1[2], ooo_len2[2], 
+    //                       cur_len[2], in_order_len[2], reserved[4] }
+    if (static_cast<uint8_t>(m_binary_data[0]) == 0xFF && 
+        static_cast<uint8_t>(m_binary_data[1]) == 0xFF) {
+        return 16;  // Skip 16-byte page header
+    }
+    
+    // Check if this looks like ELF section padding (all zeros or alignment padding)
+    if (m_binary_data.size() >= 16) {
+        bool looks_like_padding = true;
+        for (size_t i = 0; i < 16; i++) {
+            if (m_binary_data[i] != 0 && m_binary_data[i] != static_cast<char>(0xA5)) {
+                looks_like_padding = false;
+                break;
+            }
+        }
+        if (looks_like_padding) {
+            return 16;  // Skip padding
+        }
+    }
+    
+    // No header detected, start from beginning
+    return 0;
+}
+
+void asm_disassembler::process_binary_data(const char* data, size_t size, std::shared_ptr<disassembler_state> state) {
+    // Process PAGE structure: TEXT section → EOF → DATA section → padding
+    // This mirrors how ELF sections are processed
+    
+    size_t text_end_offset = 0;
+    bool found_eof = false;
+    
+    // Find EOF to determine TEXT section boundary
+    for (size_t i = 0; i < size; i++) {
+        if (static_cast<uint8_t>(data[i]) == 0xFF) {
+            // Check if this is actually an EOF opcode (not just 0xFF in data)
+            auto op_it = isa_op_map->find(0xFF);
+            if (op_it != isa_op_map->end()) {
+                text_end_offset = i + 4; // EOF is 4 bytes (opcode + pad + pad)
+                found_eof = true;
+                break;
+            }
+        }
+    }
+    
+    // If no EOF found, entire file is TEXT section
+    if (!found_eof) {
+        text_end_offset = size;
+    }
+    
+    // Process TEXT section (mirroring process_text_section for ELF)
+    m_asm_writer.write_directive("");
+    m_asm_writer.write_directive(";");
+    m_asm_writer.write_directive("; Code");
+    m_asm_writer.write_directive(";");
+    m_asm_writer.write_directive("");
+    
+    size_t offset = 0;
+    while (offset < text_end_offset) {
+        uint8_t opcode = *reinterpret_cast<const uint8_t*>(data + offset);
+        
+        // Handle alignment padding
+        if (opcode == ALIGN_OPCODE) {
+            state->increment_address(1);
+            ++offset;
+            continue;
+        }
+        
+        auto op_it = isa_op_map->find(opcode);
+        if (op_it == isa_op_map->end()) {
+            std::ostringstream err;
+            err << "Unknown Opcode: 0x" << std::hex << static_cast<int>(opcode) 
+                << " at offset " << std::dec << offset << "\n";
+            throw error(error::error_code::invalid_asm, err.str());
+        }
+        
+        auto deserializer = op_it->second.create_deserializer();
+        size_t consumed = deserializer->deserialize(m_asm_writer, state, data + offset);
+        offset += consumed;
+    }
+    
+    // Process DATA section if present (mirroring process_data_section for ELF)
+    if (found_eof && text_end_offset < size) {
+        m_asm_writer.write_directive("");
+        m_asm_writer.write_directive(";");
+        m_asm_writer.write_directive("; Data");
+        m_asm_writer.write_directive(";");
+        m_asm_writer.write_directive("");
+        m_asm_writer.write_directive("  .ALIGN             16");
+        
+        process_data_section_binary(data + text_end_offset, size - text_end_offset, state);
+        
+        // Reset state after DATA section (like ELF disassembler does)
+        state->reset();
+    }
+}
+
+void asm_disassembler::process_data_section_binary(const char* data, size_t size, std::shared_ptr<disassembler_state> state) {
+    // Process DATA section - mirrors ELF process_data_section logic
+    isa_op_disasm dummy_isa_op("dummy", 0, std::vector<opArg>{});
+    size_t offset = 0;
+    bool align_4_written = false;
+    
+    while (offset < size) {
+        uint8_t opcode = *reinterpret_cast<const uint8_t*>(data + offset);
+        auto label_map = state->get_labels();
+        auto local_ptr_map = state->get_local_ptrs();
+        
+        // Check for UC_DMA_BD at label positions
+        if (label_map.find(state->get_address()) != label_map.end()) {
+            ucDmaBd_op_deserializer deserializer(&dummy_isa_op);
+            size_t consumed = deserializer.deserialize(m_asm_writer, state, data + offset);
+            offset += consumed;
+        } 
+        // Check for .long at local pointer positions
+        else if (local_ptr_map.find(state->get_address()) != local_ptr_map.end()) {
+            if (!align_4_written) {
+                m_asm_writer.write_directive("");
+                m_asm_writer.write_directive("  .ALIGN             4");
+                align_4_written = true;
+            }
+            long_op_deserializer deserializer(&dummy_isa_op);
+            size_t consumed = deserializer.deserialize(m_asm_writer, state, data + offset);
+            offset += consumed;
+        } 
+        // Handle alignment and padding bytes (most common case in DATA section)
+        else if (opcode == ALIGN_OPCODE || opcode == 0) {
+            state->increment_address(1);
+            ++offset;
+        } 
+        // Unknown byte - this shouldn't happen in a valid binary
+        // Just skip it silently (it's likely padding we don't recognize)
+        else {
+            state->increment_address(1);
+            ++offset;
+        }
+    }
 }
 } // namespace aiebu

--- a/src/cpp/disassembler/disassembler.cpp
+++ b/src/cpp/disassembler/disassembler.cpp
@@ -9,25 +9,60 @@
 
 namespace aiebu {
 
+// Part of this code are generated using Cursor.
+// ELF and Binary Format Constants
 static constexpr size_t ELF_SECTION_HEADER_PADDING = 16;  // ELF-specific header padding
-static constexpr uint8_t ALIGN_OPCODE = 0xA5;  // .align pseudo-instruction opcode
-static constexpr size_t CTRLTEXT_STRING_LENGTH = 9;  // Length of ".ctrltext"
-static constexpr size_t CTRLDATA_STRING_LENGTH = 9;  // Length of ".ctrldata"
+static constexpr size_t PAGE_SIZE = 8192;                   // Binary page size (8KB)
+static constexpr size_t PAGE_HEADER_SIZE = 16;              // Page header size in bytes
+static constexpr size_t MIN_HEADER_SIZE = 16;               // Minimum header size for detection
+
+// Page Header Field Offsets
+static constexpr size_t PAGE_HEADER_MAGIC_BYTE_0 = 0;       // First magic byte offset
+static constexpr size_t PAGE_HEADER_MAGIC_BYTE_1 = 1;       // Second magic byte offset
+static constexpr size_t PAGE_HEADER_CUR_LEN_LOW = 8;        // Current page length low byte offset
+static constexpr size_t PAGE_HEADER_CUR_LEN_HIGH = 9;       // Current page length high byte offset
+
+// Magic Values
+static constexpr uint8_t PAGE_HEADER_MAGIC = 0xFF;          // Page header magic byte value
+static constexpr uint8_t ALIGN_OPCODE = 0xA5;               // .align pseudo-instruction opcode
+static constexpr uint8_t EOF_OPCODE = 0xFF;                 // End-of-file opcode
+static constexpr uint8_t ZERO_PADDING = 0x00;               // Zero padding byte
+
+// Opcode Sizes
+static constexpr size_t EOF_SIZE = 4;                       // EOF instruction size in bytes
+static constexpr size_t ALIGN_4 = 4;                        // 4-byte alignment
+static constexpr size_t ALIGN_16 = 16;                      // 16-byte alignment
+
+// Section Name Lengths
+static constexpr size_t CTRLTEXT_STRING_LENGTH = 9;        // Length of ".ctrltext"
+static constexpr size_t CTRLDATA_STRING_LENGTH = 9;        // Length of ".ctrldata"
 
 asm_disassembler::asm_disassembler(const std::string& input_elf_path, std::ostream& output_stream)
-    : m_asm_writer(output_stream), m_is_binary_mode(false) {
+    : m_asm_writer(output_stream), m_is_binary_mode(false), m_target_arch("aie2ps") {
     if (!m_elf_reader.load(input_elf_path)) {
         throw error(error::error_code::invalid_elf, "Failed to load ELF:" + input_elf_path + "\n");
     }
     isa_op_map = isa_disasm.get_isa_map();
 }
 
-asm_disassembler::asm_disassembler(const std::vector<char>& binary_data, std::ostream& output_stream, bool is_binary)
-    : m_asm_writer(output_stream), m_binary_data(binary_data), m_is_binary_mode(is_binary) {
-    if (!is_binary) {
-        throw error(error::error_code::invalid_input, "Binary mode constructor requires is_binary to be true\n");
-    }
+asm_disassembler::asm_disassembler(const std::vector<char>& binary_data, std::ostream& output_stream, const std::string& target_arch)
+    : m_asm_writer(output_stream), m_binary_data(binary_data), m_is_binary_mode(true), m_target_arch(target_arch) {
+    
+    // TODO: Load architecture-specific ISA when differences emerge between aie2ps and aie4
+    // Currently both use the same ISA specification from specification/aie2ps/isa.h
+    // Future implementation:
+    //   if (target_arch == "aie4") {
+    //     // Load aie4-specific ISA from specification/aie4/isa.h
+    //     isa_disasm_aie4 aie4_disasm;
+    //     isa_op_map = aie4_disasm.get_isa_map();
+    //   } else {
+    //     // Load aie2ps ISA (default)
+    //     isa_op_map = isa_disasm.get_isa_map();
+    //   }
     isa_op_map = isa_disasm.get_isa_map();
+    
+    // Output target architecture information for binary files
+    m_asm_writer.write_directive("; Target Architecture: " + m_target_arch);
 }
 
 void asm_disassembler::run() {
@@ -100,16 +135,16 @@ void asm_disassembler::process_data_section(const ELFIO::section* section, std::
             ucDmaBd_op_deserializer deserializer(&dummy_isa_op);
             size_t consumed = deserializer.deserialize(m_asm_writer, state, section_data + offset);
             offset += consumed;
-        } else if (local_ptr_map.find(state->get_address()) != local_ptr_map.end()) {
+        }         else if (local_ptr_map.find(state->get_address()) != local_ptr_map.end()) {
             if (!align_4_written) {
                 m_asm_writer.write_directive("");
-                m_asm_writer.write_directive("  .ALIGN             4");
+                m_asm_writer.write_directive("  .ALIGN             " + std::to_string(ALIGN_4));
                 align_4_written = true;
             }
             long_op_deserializer deserializer(&dummy_isa_op);
             size_t consumed = deserializer.deserialize(m_asm_writer, state, section_data + offset);
             offset += consumed;
-        } else if (opcode == align || opcode == 0) {
+        } else if (opcode == align || opcode == ZERO_PADDING) {
             state->increment_address(1);
             ++offset;
         } else {
@@ -137,11 +172,6 @@ void asm_disassembler::process_binary() {
         throw error(error::error_code::invalid_input, "Binary data is empty\n");
     }
     
-    // Binary files contain multiple pages, each exactly PAGE_SIZE (8192) bytes
-    // Each page has: 16-byte header + content (up to cur_page_len) + padding to 8192
-    static constexpr size_t PAGE_SIZE = 8192;
-    static constexpr size_t PAGE_HEADER_SIZE = 16;
-    
     size_t offset = 0;
     int page_num = 0;
     
@@ -152,16 +182,16 @@ void asm_disassembler::process_binary() {
             break; // Not enough data for another page
         }
         
-        // Check for page header (0xFF 0xFF magic bytes)
-        if (static_cast<uint8_t>(m_binary_data[offset]) != 0xFF ||
-            static_cast<uint8_t>(m_binary_data[offset + 1]) != 0xFF) {
+        // Check for page header magic bytes
+        if (static_cast<uint8_t>(m_binary_data[offset + PAGE_HEADER_MAGIC_BYTE_0]) != PAGE_HEADER_MAGIC ||
+            static_cast<uint8_t>(m_binary_data[offset + PAGE_HEADER_MAGIC_BYTE_1]) != PAGE_HEADER_MAGIC) {
             // No more pages
             break;
         }
         
-        // Read cur_page_len from header (bytes 8-9)
-        uint16_t cur_page_len = static_cast<uint8_t>(m_binary_data[offset + 8]) | 
-                               (static_cast<uint8_t>(m_binary_data[offset + 9]) << 8);
+        // Read cur_page_len from header
+        uint16_t cur_page_len = static_cast<uint8_t>(m_binary_data[offset + PAGE_HEADER_CUR_LEN_LOW]) | 
+                               (static_cast<uint8_t>(m_binary_data[offset + PAGE_HEADER_CUR_LEN_HIGH]) << 8);
         
         // cur_page_len includes the header itself, so content is (cur_page_len - PAGE_HEADER_SIZE)
         size_t content_size = (cur_page_len > PAGE_HEADER_SIZE) ? 
@@ -188,29 +218,29 @@ void asm_disassembler::process_binary() {
 
 size_t asm_disassembler::detect_binary_header_offset() const {
     // Check for various binary formats and determine header size
-    if (m_binary_data.size() < 16) {
+    if (m_binary_data.size() < MIN_HEADER_SIZE) {
         return 0; // Too small for any header
     }
     
-    // Check for AIE2PS/AIE4 page header (16 bytes)
+    // Check for AIE2PS/AIE4 page header
     // Page header format: { 0xFF, 0xFF, page_index[2], ooo_len1[2], ooo_len2[2], 
     //                       cur_len[2], in_order_len[2], reserved[4] }
-    if (static_cast<uint8_t>(m_binary_data[0]) == 0xFF && 
-        static_cast<uint8_t>(m_binary_data[1]) == 0xFF) {
-        return 16;  // Skip 16-byte page header
+    if (static_cast<uint8_t>(m_binary_data[PAGE_HEADER_MAGIC_BYTE_0]) == PAGE_HEADER_MAGIC && 
+        static_cast<uint8_t>(m_binary_data[PAGE_HEADER_MAGIC_BYTE_1]) == PAGE_HEADER_MAGIC) {
+        return PAGE_HEADER_SIZE;
     }
     
     // Check if this looks like ELF section padding (all zeros or alignment padding)
-    if (m_binary_data.size() >= 16) {
+    if (m_binary_data.size() >= MIN_HEADER_SIZE) {
         bool looks_like_padding = true;
-        for (size_t i = 0; i < 16; i++) {
-            if (m_binary_data[i] != 0 && m_binary_data[i] != static_cast<char>(0xA5)) {
+        for (size_t i = 0; i < MIN_HEADER_SIZE; i++) {
+            if (m_binary_data[i] != ZERO_PADDING && m_binary_data[i] != static_cast<char>(ALIGN_OPCODE)) {
                 looks_like_padding = false;
                 break;
             }
         }
         if (looks_like_padding) {
-            return 16;  // Skip padding
+            return PAGE_HEADER_SIZE;
         }
     }
     
@@ -227,11 +257,11 @@ void asm_disassembler::process_binary_data(const char* data, size_t size, std::s
     
     // Find EOF to determine TEXT section boundary
     for (size_t i = 0; i < size; i++) {
-        if (static_cast<uint8_t>(data[i]) == 0xFF) {
+        if (static_cast<uint8_t>(data[i]) == EOF_OPCODE) {
             // Check if this is actually an EOF opcode (not just 0xFF in data)
-            auto op_it = isa_op_map->find(0xFF);
+            auto op_it = isa_op_map->find(EOF_OPCODE);
             if (op_it != isa_op_map->end()) {
-                text_end_offset = i + 4; // EOF is 4 bytes (opcode + pad + pad)
+                text_end_offset = i + EOF_SIZE;
                 found_eof = true;
                 break;
             }
@@ -281,7 +311,7 @@ void asm_disassembler::process_binary_data(const char* data, size_t size, std::s
         m_asm_writer.write_directive("; Data");
         m_asm_writer.write_directive(";");
         m_asm_writer.write_directive("");
-        m_asm_writer.write_directive("  .ALIGN             16");
+        m_asm_writer.write_directive("  .ALIGN             " + std::to_string(ALIGN_16));
         
         process_data_section_binary(data + text_end_offset, size - text_end_offset, state);
         
@@ -311,7 +341,7 @@ void asm_disassembler::process_data_section_binary(const char* data, size_t size
         else if (local_ptr_map.find(state->get_address()) != local_ptr_map.end()) {
             if (!align_4_written) {
                 m_asm_writer.write_directive("");
-                m_asm_writer.write_directive("  .ALIGN             4");
+                m_asm_writer.write_directive("  .ALIGN             " + std::to_string(ALIGN_4));
                 align_4_written = true;
             }
             long_op_deserializer deserializer(&dummy_isa_op);
@@ -319,7 +349,7 @@ void asm_disassembler::process_data_section_binary(const char* data, size_t size
             offset += consumed;
         } 
         // Handle alignment and padding bytes (most common case in DATA section)
-        else if (opcode == ALIGN_OPCODE || opcode == 0) {
+        else if (opcode == ALIGN_OPCODE || opcode == ZERO_PADDING) {
             state->increment_address(1);
             ++offset;
         } 

--- a/src/cpp/disassembler/disassembler.cpp
+++ b/src/cpp/disassembler/disassembler.cpp
@@ -11,286 +11,70 @@ namespace aiebu {
 
 // Part of this code are generated using Cursor.
 // ELF and Binary Format Constants
-static constexpr size_t ELF_SECTION_HEADER_PADDING = 16;  // ELF-specific header padding
-static constexpr size_t PAGE_SIZE = 8192;                   // Binary page size (8KB)
-static constexpr size_t PAGE_HEADER_SIZE = 16;              // Page header size in bytes
-static constexpr size_t MIN_HEADER_SIZE = 16;               // Minimum header size for detection
+static constexpr size_t elf_section_header_padding = 16;  // ELF-specific header padding
+static constexpr size_t page_size = 8192;                   // Binary page size (8KB)
+static constexpr size_t page_header_size = 16;              // Page header size in bytes
+static constexpr size_t min_header_size = 16;               // Minimum header size for detection
 
 // Page Header Field Offsets
-static constexpr size_t PAGE_HEADER_MAGIC_BYTE_0 = 0;       // First magic byte offset
-static constexpr size_t PAGE_HEADER_MAGIC_BYTE_1 = 1;       // Second magic byte offset
-static constexpr size_t PAGE_HEADER_CUR_LEN_LOW = 8;        // Current page length low byte offset
-static constexpr size_t PAGE_HEADER_CUR_LEN_HIGH = 9;       // Current page length high byte offset
+static constexpr size_t page_header_magic_byte_0 = 0;       // First magic byte offset
+static constexpr size_t page_header_magic_byte_1 = 1;       // Second magic byte offset
+static constexpr size_t page_header_cur_len_low = 8;        // Current page length low byte offset
+static constexpr size_t page_header_cur_len_high = 9;       // Current page length high byte offset
 
 // Magic Values
-static constexpr uint8_t PAGE_HEADER_MAGIC = 0xFF;          // Page header magic byte value
-static constexpr uint8_t ALIGN_OPCODE = 0xA5;               // .align pseudo-instruction opcode
-static constexpr uint8_t EOF_OPCODE = 0xFF;                 // End-of-file opcode
-static constexpr uint8_t ZERO_PADDING = 0x00;               // Zero padding byte
+static constexpr uint8_t page_header_magic = 0xFF;          // Page header magic byte value
+static constexpr uint8_t align_opcode = 0xA5;               // .align pseudo-instruction opcode
+static constexpr uint8_t eof_opcode = 0xFF;                 // End-of-file opcode
+static constexpr uint8_t zero_padding = 0x00;               // Zero padding byte
 
 // Opcode Sizes
-static constexpr size_t EOF_SIZE = 4;                       // EOF instruction size in bytes
-static constexpr size_t ALIGN_4 = 4;                        // 4-byte alignment
-static constexpr size_t ALIGN_16 = 16;                      // 16-byte alignment
+static constexpr size_t eof_size = 4;                       // EOF instruction size in bytes
+static constexpr size_t align_4 = 4;                        // 4-byte alignment
+static constexpr size_t align_16 = 16;                      // 16-byte alignment
 
 // Section Name Lengths
-static constexpr size_t CTRLTEXT_STRING_LENGTH = 9;        // Length of ".ctrltext"
-static constexpr size_t CTRLDATA_STRING_LENGTH = 9;        // Length of ".ctrldata"
+static constexpr size_t ctrltext_string_length = 9;        // Length of ".ctrltext"
+static constexpr size_t ctrldata_string_length = 9;        // Length of ".ctrldata"
 
-asm_disassembler::asm_disassembler(const std::string& input_elf_path, std::ostream& output_stream)
-    : m_asm_writer(output_stream), m_is_binary_mode(false), m_target_arch("aie2ps") {
-    if (!m_elf_reader.load(input_elf_path)) {
-        throw error(error::error_code::invalid_elf, "Failed to load ELF:" + input_elf_path + "\n");
-    }
+// Base class constructor
+asm_disassembler::asm_disassembler(std::ostream& output_stream)
+    : m_asm_writer(output_stream), m_target_arch("") {
     isa_op_map = isa_disasm.get_isa_map();
 }
 
-asm_disassembler::asm_disassembler(const std::vector<char>& binary_data, std::ostream& output_stream, const std::string& target_arch)
-    : m_asm_writer(output_stream), m_binary_data(binary_data), m_is_binary_mode(true), m_target_arch(target_arch) {
-    
-    // TODO: Load architecture-specific ISA when differences emerge between aie2ps and aie4
-    // Currently both use the same ISA specification from specification/aie2ps/isa.h
-    // Future implementation:
-    //   if (target_arch == "aie4") {
-    //     // Load aie4-specific ISA from specification/aie4/isa.h
-    //     isa_disasm_aie4 aie4_disasm;
-    //     isa_op_map = aie4_disasm.get_isa_map();
-    //   } else {
-    //     // Load aie2ps ISA (default)
-    //     isa_op_map = isa_disasm.get_isa_map();
-    //   }
-    isa_op_map = isa_disasm.get_isa_map();
-    
-    // Output target architecture information for binary files
-    m_asm_writer.write_directive("; Target Architecture: " + m_target_arch);
-}
-
-void asm_disassembler::run() {
-    if (m_is_binary_mode) {
-        process_binary();
-    } else {
-        process_sections();
-    }
-}
-
-void asm_disassembler::process_sections() {
-    auto state = std::make_shared<disassembler_state>();
-    for (const auto& section_ptr : m_elf_reader.sections) {
-        const ELFIO::section* section = section_ptr.get();
-        const std::string section_name = section->get_name();
-        if (section->get_type() != ELFIO::SHT_PROGBITS)
-            continue;
-        print_section_info(section);
-        if (is_text_section(section_name))
-            process_text_section(section, state);
-        if (is_data_section(section_name)) {
-            process_data_section(section, state);
-            state->reset();
-        }
-    }
-}
-
-void asm_disassembler::print_section_info(const ELFIO::section* section) {
-    std::string flags;
-    if (section->get_flags() & ELFIO::SHF_ALLOC)
-        flags += "a";
-    if (section->get_flags() & ELFIO::SHF_WRITE)
-        flags += "w";
-    if (section->get_flags() & ELFIO::SHF_EXECINSTR)
-        flags += "x";
-    m_asm_writer.write_directive("");
-    if (is_data_section(section->get_name()))
-        m_asm_writer.write_directive("  .ALIGN             " + std::to_string(section->get_addr_align()));
-}
-
-void asm_disassembler::process_text_section(const ELFIO::section* section, std::shared_ptr<disassembler_state> state) {
-    const char* section_data = section->get_data();
-    size_t section_size = section->get_size();
-    for (size_t offset = ELF_SECTION_HEADER_PADDING; offset < section_size;) {
-        uint8_t opcode = *reinterpret_cast<const uint8_t*>(section_data + offset);
-        auto op_it = isa_op_map->find(opcode);
-        if (op_it == isa_op_map->end())
-            throw error(error::error_code::invalid_asm, "Unknown Opcode:" + std::to_string(opcode) + " at position " + std::to_string(offset) + "\n");
-        if (opcode == ALIGN_OPCODE) {
-            state->increment_address(1);
-            ++offset;
-            continue;
-        }
-        auto deserializer = op_it->second.create_deserializer();
-        size_t consumed = deserializer->deserialize(m_asm_writer, state, section_data + offset);
-        offset += consumed;
-    }
-}
-
-void asm_disassembler::process_data_section(const ELFIO::section* section, std::shared_ptr<disassembler_state> state) {
-    const char* section_data = section->get_data();
-    size_t section_size = section->get_size();
-    isa_op_disasm dummy_isa_op("dummy", 0, std::vector<opArg>{});
-    bool align_4_written = false;
-    for (size_t offset = 0; offset < section_size;) {
-        uint8_t opcode = *reinterpret_cast<const uint8_t*>(section_data + offset);
-        auto label_map = state->get_labels();
-        auto local_ptr_map = state->get_local_ptrs();
-        if (label_map.find(state->get_address()) != label_map.end()) {
-            ucDmaBd_op_deserializer deserializer(&dummy_isa_op);
-            size_t consumed = deserializer.deserialize(m_asm_writer, state, section_data + offset);
-            offset += consumed;
-        }         else if (local_ptr_map.find(state->get_address()) != local_ptr_map.end()) {
-            if (!align_4_written) {
-                m_asm_writer.write_directive("");
-                m_asm_writer.write_directive("  .ALIGN             " + std::to_string(ALIGN_4));
-                align_4_written = true;
-            }
-            long_op_deserializer deserializer(&dummy_isa_op);
-            size_t consumed = deserializer.deserialize(m_asm_writer, state, section_data + offset);
-            offset += consumed;
-        } else if (opcode == align || opcode == ZERO_PADDING) {
-            state->increment_address(1);
-            ++offset;
-        } else {
-            throw error(error::error_code::invalid_asm, "Illegal state at position " + std::to_string(opcode) + "\n");
-        }
-    }
-}
-
-void asm_disassembler::process_pad_section(const ELFIO::section* /*section*/, std::shared_ptr<disassembler_state> /*state*/) {
-    std::cout << "Dumping .pad not supported\n";
-}
-
-bool asm_disassembler::is_text_section(const std::string& section_name) const {
-    bool result = section_name.substr(0, CTRLTEXT_STRING_LENGTH) == ".ctrltext";
-    return result;
-}
-
-bool asm_disassembler::is_data_section(const std::string& section_name) const {
-    bool result = section_name.substr(0, CTRLDATA_STRING_LENGTH) == ".ctrldata";
-    return result;
-}
-
-void asm_disassembler::process_binary() {
-    if (m_binary_data.empty()) {
-        throw error(error::error_code::invalid_input, "Binary data is empty\n");
-    }
-    
-    size_t offset = 0;
-    int page_num = 0;
-    
-    while (offset < m_binary_data.size()) {
-        // Check if there's enough data for a page
-        size_t remaining = m_binary_data.size() - offset;
-        if (remaining < PAGE_HEADER_SIZE) {
-            break; // Not enough data for another page
-        }
-        
-        // Check for page header magic bytes
-        if (static_cast<uint8_t>(m_binary_data[offset + PAGE_HEADER_MAGIC_BYTE_0]) != PAGE_HEADER_MAGIC ||
-            static_cast<uint8_t>(m_binary_data[offset + PAGE_HEADER_MAGIC_BYTE_1]) != PAGE_HEADER_MAGIC) {
-            // No more pages
-            break;
-        }
-        
-        // Read cur_page_len from header
-        uint16_t cur_page_len = static_cast<uint8_t>(m_binary_data[offset + PAGE_HEADER_CUR_LEN_LOW]) | 
-                               (static_cast<uint8_t>(m_binary_data[offset + PAGE_HEADER_CUR_LEN_HIGH]) << 8);
-        
-        // cur_page_len includes the header itself, so content is (cur_page_len - PAGE_HEADER_SIZE)
-        size_t content_size = (cur_page_len > PAGE_HEADER_SIZE) ? 
-                             (cur_page_len - PAGE_HEADER_SIZE) : 0;
-        
-        // Process this page
-        auto state = std::make_shared<disassembler_state>();
-        
-        if (content_size > 0) {
-            process_binary_data(m_binary_data.data() + offset + PAGE_HEADER_SIZE, 
-                               content_size, state);
-        }
-        
-        // Move to next page (always at PAGE_SIZE boundary)
-        offset += PAGE_SIZE;
-        page_num++;
-    }
-    
-    if (page_num == 0) {
-        throw error(error::error_code::invalid_input, 
-                   "No valid pages found in binary file\n");
-    }
-}
-
-size_t asm_disassembler::detect_binary_header_offset() const {
-    // Check for various binary formats and determine header size
-    if (m_binary_data.size() < MIN_HEADER_SIZE) {
-        return 0; // Too small for any header
-    }
-    
-    // Check for AIE2PS/AIE4 page header
-    // Page header format: { 0xFF, 0xFF, page_index[2], ooo_len1[2], ooo_len2[2], 
-    //                       cur_len[2], in_order_len[2], reserved[4] }
-    if (static_cast<uint8_t>(m_binary_data[PAGE_HEADER_MAGIC_BYTE_0]) == PAGE_HEADER_MAGIC && 
-        static_cast<uint8_t>(m_binary_data[PAGE_HEADER_MAGIC_BYTE_1]) == PAGE_HEADER_MAGIC) {
-        return PAGE_HEADER_SIZE;
-    }
-    
-    // Check if this looks like ELF section padding (all zeros or alignment padding)
-    if (m_binary_data.size() >= MIN_HEADER_SIZE) {
-        bool looks_like_padding = true;
-        for (size_t i = 0; i < MIN_HEADER_SIZE; i++) {
-            if (m_binary_data[i] != ZERO_PADDING && m_binary_data[i] != static_cast<char>(ALIGN_OPCODE)) {
-                looks_like_padding = false;
-                break;
-            }
-        }
-        if (looks_like_padding) {
-            return PAGE_HEADER_SIZE;
-        }
-    }
-    
-    // No header detected, start from beginning
-    return 0;
-}
-
-void asm_disassembler::process_binary_data(const char* data, size_t size, std::shared_ptr<disassembler_state> state) {
-    // Process PAGE structure: TEXT section → EOF → DATA section → padding
-    // This mirrors how ELF sections are processed
-    
-    size_t text_end_offset = 0;
-    bool found_eof = false;
-    
-    // Find EOF to determine TEXT section boundary
-    for (size_t i = 0; i < size; i++) {
-        if (static_cast<uint8_t>(data[i]) == EOF_OPCODE) {
-            // Check if this is actually an EOF opcode (not just 0xFF in data)
-            auto op_it = isa_op_map->find(EOF_OPCODE);
-            if (op_it != isa_op_map->end()) {
-                text_end_offset = i + EOF_SIZE;
-                found_eof = true;
-                break;
-            }
-        }
-    }
-    
-    // If no EOF found, entire file is TEXT section
-    if (!found_eof) {
-        text_end_offset = size;
-    }
-    
-    // Process TEXT section (mirroring process_text_section for ELF)
+// Common helper to write text section header
+void asm_disassembler::add_text_sec_comment() {
     m_asm_writer.write_directive("");
     m_asm_writer.write_directive(";");
-    m_asm_writer.write_directive("; Code");
+    m_asm_writer.write_directive(";text");
     m_asm_writer.write_directive(";");
     m_asm_writer.write_directive("");
-    
-    size_t offset = 0;
-    while (offset < text_end_offset) {
+}
+
+// Common helper to write data section header
+void asm_disassembler::add_data_sec_comment() {
+    m_asm_writer.write_directive("");
+    m_asm_writer.write_directive(";");
+    m_asm_writer.write_directive(";data");
+    m_asm_writer.write_directive(";");
+    m_asm_writer.write_directive("");
+}
+
+// Common text block processing (used by both ELF and binary disassemblers)
+void asm_disassembler::process_text_block(const char* data, size_t start_offset, size_t end_offset, 
+                                         std::shared_ptr<disassembler_state> state) {
+    for (size_t offset = start_offset; offset < end_offset;) {
         uint8_t opcode = *reinterpret_cast<const uint8_t*>(data + offset);
         
         // Handle alignment padding
-        if (opcode == ALIGN_OPCODE) {
+        if (opcode == align_opcode) {
             state->increment_address(1);
             ++offset;
             continue;
         }
         
+        // Look up opcode in ISA map
         auto op_it = isa_op_map->find(opcode);
         if (op_it == isa_op_map->end()) {
             std::ostringstream err;
@@ -299,34 +83,20 @@ void asm_disassembler::process_binary_data(const char* data, size_t size, std::s
             throw error(error::error_code::invalid_asm, err.str());
         }
         
+        // Deserialize and consume bytes
         auto deserializer = op_it->second.create_deserializer();
         size_t consumed = deserializer->deserialize(m_asm_writer, state, data + offset);
         offset += consumed;
     }
-    
-    // Process DATA section if present (mirroring process_data_section for ELF)
-    if (found_eof && text_end_offset < size) {
-        m_asm_writer.write_directive("");
-        m_asm_writer.write_directive(";");
-        m_asm_writer.write_directive("; Data");
-        m_asm_writer.write_directive(";");
-        m_asm_writer.write_directive("");
-        m_asm_writer.write_directive("  .ALIGN             " + std::to_string(ALIGN_16));
-        
-        process_data_section_binary(data + text_end_offset, size - text_end_offset, state);
-        
-        // Reset state after DATA section (like ELF disassembler does)
-        state->reset();
-    }
 }
 
-void asm_disassembler::process_data_section_binary(const char* data, size_t size, std::shared_ptr<disassembler_state> state) {
-    // Process DATA section - mirrors ELF process_data_section logic
+// Common data block processing (used by both ELF and binary disassemblers)
+void asm_disassembler::process_data_block(const char* data, size_t size, 
+                                         std::shared_ptr<disassembler_state> state) {
     isa_op_disasm dummy_isa_op("dummy", 0, std::vector<opArg>{});
-    size_t offset = 0;
     bool align_4_written = false;
     
-    while (offset < size) {
+    for (size_t offset = 0; offset < size;) {
         uint8_t opcode = *reinterpret_cast<const uint8_t*>(data + offset);
         auto label_map = state->get_labels();
         auto local_ptr_map = state->get_local_ptrs();
@@ -341,24 +111,271 @@ void asm_disassembler::process_data_section_binary(const char* data, size_t size
         else if (local_ptr_map.find(state->get_address()) != local_ptr_map.end()) {
             if (!align_4_written) {
                 m_asm_writer.write_directive("");
-                m_asm_writer.write_directive("  .ALIGN             " + std::to_string(ALIGN_4));
+                m_asm_writer.write_directive("  .align             " + std::to_string(align_4));
                 align_4_written = true;
             }
             long_op_deserializer deserializer(&dummy_isa_op);
             size_t consumed = deserializer.deserialize(m_asm_writer, state, data + offset);
             offset += consumed;
         } 
-        // Handle alignment and padding bytes (most common case in DATA section)
-        else if (opcode == ALIGN_OPCODE || opcode == ZERO_PADDING) {
+        // Handle padding bytes
+        else if (opcode == align || opcode == zero_padding) {
             state->increment_address(1);
             ++offset;
         } 
-        // Unknown byte - this shouldn't happen in a valid binary
-        // Just skip it silently (it's likely padding we don't recognize)
         else {
-            state->increment_address(1);
-            ++offset;
+            std::ostringstream err;
+            err << "Illegal state at offset " << offset 
+                << " (opcode: 0x" << std::hex << static_cast<int>(opcode) << ")\n";
+            throw error(error::error_code::invalid_asm, err.str());
         }
     }
+}
+
+// ELF disassembler constructor
+elf_asm_disassembler::elf_asm_disassembler(const std::string& input_elf_path, std::ostream& output_stream)
+    : asm_disassembler(output_stream) {
+    if (!m_elf_reader.load(input_elf_path)) {
+        throw error(error::error_code::invalid_elf, "Failed to load ELF:" + input_elf_path + "\n");
+    }
+    // Set target architecture from ELF header (EI_OSABI)
+    // For now, default to aie2ps; future: extract from ELF header byte 7
+    m_target_arch = "aie2ps";
+}
+
+// ELF disassembler run method
+void elf_asm_disassembler::run() {
+    process_sections();
+}
+
+// Binary disassembler constructor
+bin_asm_disassembler::bin_asm_disassembler(const std::vector<char>& binary_data, 
+                                          std::ostream& output_stream, 
+                                          aiebu_assembler::buffer_type buffer_type)
+    : asm_disassembler(output_stream) {
+    m_binary_data = binary_data;
+    
+    // Set target architecture from buffer type
+    switch (buffer_type) {
+        case aiebu_assembler::buffer_type::blob_aie2ps:
+            m_target_arch = "aie2ps";
+            break;
+        case aiebu_assembler::buffer_type::blob_aie4:
+            m_target_arch = "aie4";
+            break;
+        default:
+            m_target_arch = "unknown";
+            break;
+    }
+    
+    // TODO: Load architecture-specific ISA when differences emerge between aie2ps and aie4
+    // Currently both use the same ISA specification from specification/aie2ps/isa.h
+    // Future implementation:
+    //   if (m_target_arch == "aie4") {
+    //     // Load aie4-specific ISA from specification/aie4/isa.h
+    //     isa_disasm_aie4 aie4_disasm;
+    //     isa_op_map = aie4_disasm.get_isa_map();
+    //   } else {
+    //     // Load aie2ps ISA (default)
+    //     isa_op_map = isa_disasm.get_isa_map();
+    //   }
+    
+    // Output target architecture information for binary files
+    m_asm_writer.write_directive("; Target Architecture: " + m_target_arch);
+}
+
+// Binary disassembler run method
+void bin_asm_disassembler::run() {
+    process_binary();
+}
+
+void elf_asm_disassembler::process_sections() {
+    auto state = std::make_shared<disassembler_state>();
+    for (const auto& section_ptr : m_elf_reader.sections) {
+        const ELFIO::section* section = section_ptr.get();
+        const std::string section_name = section->get_name();
+        if (section->get_type() != ELFIO::SHT_PROGBITS)
+            continue;
+        print_section_info(section);
+        if (is_text_section(section_name)) {
+            add_text_sec_comment();
+            process_text_section(section, state);
+        }
+        if (is_data_section(section_name)) {
+            add_data_sec_comment();
+            process_data_section(section, state);
+            state->reset();
+        }
+    }
+}
+
+void elf_asm_disassembler::print_section_info(const ELFIO::section* section) {
+    std::string flags;
+    if (section->get_flags() & ELFIO::SHF_ALLOC)
+        flags += "a";
+    if (section->get_flags() & ELFIO::SHF_WRITE)
+        flags += "w";
+    if (section->get_flags() & ELFIO::SHF_EXECINSTR)
+        flags += "x";
+    m_asm_writer.write_directive("");
+    if (is_data_section(section->get_name()))
+        m_asm_writer.write_directive("  .align             " + std::to_string(section->get_addr_align()));
+}
+
+void elf_asm_disassembler::process_text_section(const ELFIO::section* section, std::shared_ptr<disassembler_state> state) {
+    const char* section_data = section->get_data();
+    size_t section_size = section->get_size();
+    // Use common base class method for text processing
+    process_text_block(section_data, elf_section_header_padding, section_size, state);
+}
+
+void elf_asm_disassembler::process_data_section(const ELFIO::section* section, std::shared_ptr<disassembler_state> state) {
+    const char* section_data = section->get_data();
+    size_t section_size = section->get_size();
+    // Use common base class method for data processing
+    process_data_block(section_data, section_size, state);
+}
+
+void elf_asm_disassembler::process_pad_section(const ELFIO::section* /*section*/, std::shared_ptr<disassembler_state> /*state*/) {
+    std::cout << "Dumping .pad not supported\n";
+}
+
+bool elf_asm_disassembler::is_text_section(const std::string& section_name) const {
+    bool result = section_name.substr(0, ctrltext_string_length) == ".ctrltext";
+    return result;
+}
+
+bool elf_asm_disassembler::is_data_section(const std::string& section_name) const {
+    bool result = section_name.substr(0, ctrldata_string_length) == ".ctrldata";
+    return result;
+}
+
+void bin_asm_disassembler::process_binary() {
+    if (m_binary_data.empty()) {
+        throw error(error::error_code::invalid_input, "Binary data is empty\n");
+    }
+    
+    size_t offset = 0;
+    int page_num = 0;
+    
+    while (offset < m_binary_data.size()) {
+        // Check if there's enough data for a page
+        size_t remaining = m_binary_data.size() - offset;
+        if (remaining < page_header_size) {
+            break; // Not enough data for another page
+        }
+        
+        // Check for page header magic bytes
+        if (static_cast<uint8_t>(m_binary_data[offset + page_header_magic_byte_0]) != page_header_magic ||
+            static_cast<uint8_t>(m_binary_data[offset + page_header_magic_byte_1]) != page_header_magic) {
+            // No more pages
+            break;
+        }
+        
+        // Read cur_page_len from header
+        uint16_t cur_page_len = static_cast<uint8_t>(m_binary_data[offset + page_header_cur_len_low]) | 
+                               (static_cast<uint8_t>(m_binary_data[offset + page_header_cur_len_high]) << 8);
+        
+        // cur_page_len includes the header itself, so content is (cur_page_len - page_header_size)
+        size_t content_size = (cur_page_len > page_header_size) ? 
+                             (cur_page_len - page_header_size) : 0;
+        
+        // Process this page
+        auto state = std::make_shared<disassembler_state>();
+        
+        if (content_size > 0) {
+            process_binary_data(m_binary_data.data() + offset + page_header_size, 
+                               content_size, state);
+        }
+        
+        // Move to next page (always at page_size boundary)
+        offset += page_size;
+        page_num++;
+    }
+    
+    if (page_num == 0) {
+        throw error(error::error_code::invalid_input, 
+                   "No valid pages found in binary file\n");
+    }
+}
+
+size_t bin_asm_disassembler::detect_binary_header_offset() const {
+    // Check for various binary formats and determine header size
+    if (m_binary_data.size() < min_header_size) {
+        return 0; // Too small for any header
+    }
+    
+    // Check for AIE2PS/AIE4 page header
+    // Page header format: { 0xFF, 0xFF, page_index[2], ooo_len1[2], ooo_len2[2], 
+    //                       cur_len[2], in_order_len[2], reserved[4] }
+    if (static_cast<uint8_t>(m_binary_data[page_header_magic_byte_0]) == page_header_magic && 
+        static_cast<uint8_t>(m_binary_data[page_header_magic_byte_1]) == page_header_magic) {
+        return page_header_size;
+    }
+    
+    // Check if this looks like ELF section padding (all zeros or alignment padding)
+    if (m_binary_data.size() >= min_header_size) {
+        bool looks_like_padding = true;
+        for (size_t i = 0; i < min_header_size; i++) {
+            if (m_binary_data[i] != zero_padding && m_binary_data[i] != static_cast<char>(align_opcode)) {
+                looks_like_padding = false;
+                break;
+            }
+        }
+        if (looks_like_padding) {
+            return page_header_size;
+        }
+    }
+    
+    // No header detected, start from beginning
+    return 0;
+}
+
+void bin_asm_disassembler::process_binary_data(const char* data, size_t size, std::shared_ptr<disassembler_state> state) {
+    // Process PAGE structure: TEXT section → EOF → DATA section → padding
+    // This mirrors how ELF sections are processed
+    
+    size_t text_end_offset = 0;
+    bool found_eof = false;
+    
+    // Find EOF to determine TEXT section boundary
+    for (size_t i = 0; i < size; i++) {
+        if (static_cast<uint8_t>(data[i]) == eof_opcode) {
+            // Check if this is actually an EOF opcode (not just 0xFF in data)
+            auto op_it = isa_op_map->find(eof_opcode);
+            if (op_it != isa_op_map->end()) {
+                text_end_offset = i + eof_size;
+                found_eof = true;
+                break;
+            }
+        }
+    }
+    
+    // If no EOF found, entire file is TEXT section
+    if (!found_eof) {
+        text_end_offset = size;
+    }
+    
+    // Process TEXT section (mirroring process_text_section for ELF)
+    add_text_sec_comment();
+    
+    // Use common base class method for text processing
+    process_text_block(data, 0, text_end_offset, state);
+    
+    // Process DATA section if present (mirroring process_data_section for ELF)
+    if (found_eof && text_end_offset < size) {
+        add_data_sec_comment();
+        m_asm_writer.write_directive("  .align             " + std::to_string(align_16));
+        
+        process_data_section_binary(data + text_end_offset, size - text_end_offset, state);
+        
+        // Reset state after DATA section (like ELF disassembler does)
+        state->reset();
+    }
+}
+
+void bin_asm_disassembler::process_data_section_binary(const char* data, size_t size, std::shared_ptr<disassembler_state> state) {
+    // Use common base class method for data processing
+    process_data_block(data, size, state);
 }
 } // namespace aiebu

--- a/src/cpp/disassembler/disassembler.h
+++ b/src/cpp/disassembler/disassembler.h
@@ -16,7 +16,12 @@ namespace aiebu {
 
 class asm_disassembler {
 public:
+    // Constructor for ELF input files
     asm_disassembler(const std::string& input_elf_path, std::ostream& output_stream);
+    
+    // Constructor for binary input files
+    asm_disassembler(const std::vector<char>& binary_data, std::ostream& output_stream, bool is_binary);
+    
     ~asm_disassembler() = default;
 
     // Delete copy constructor and copy assignment operator
@@ -34,12 +39,18 @@ private:
     asm_writer m_asm_writer;
     const std::map<uint8_t, isa_op_disasm>* isa_op_map;
     isa_disassembler isa_disasm;
+    std::vector<char> m_binary_data;
+    bool m_is_binary_mode;
 
     void process_sections();
+    void process_binary();
     void print_section_info(const ELFIO::section* section) ;
     void process_text_section(const ELFIO::section* section, std::shared_ptr<disassembler_state> state);
     void process_data_section(const ELFIO::section* section, std::shared_ptr<disassembler_state> state);
     void process_pad_section(const ELFIO::section* /*section*/, std::shared_ptr<disassembler_state> /*state*/);
+    void process_binary_data(const char* data, size_t size, std::shared_ptr<disassembler_state> state);
+    void process_data_section_binary(const char* data, size_t size, std::shared_ptr<disassembler_state> state);
+    size_t detect_binary_header_offset() const;
     bool is_text_section(const std::string& section_name) const;
     bool is_data_section(const std::string& section_name) const;
 };

--- a/src/cpp/disassembler/disassembler.h
+++ b/src/cpp/disassembler/disassembler.h
@@ -20,7 +20,7 @@ public:
     asm_disassembler(const std::string& input_elf_path, std::ostream& output_stream);
     
     // Constructor for binary input files
-    asm_disassembler(const std::vector<char>& binary_data, std::ostream& output_stream, bool is_binary);
+    asm_disassembler(const std::vector<char>& binary_data, std::ostream& output_stream, const std::string& target_arch = "aie2ps");
     
     ~asm_disassembler() = default;
 
@@ -41,6 +41,7 @@ private:
     isa_disassembler isa_disasm;
     std::vector<char> m_binary_data;
     bool m_is_binary_mode;
+    std::string m_target_arch;
 
     void process_sections();
     void process_binary();

--- a/src/cpp/disassembler/disassembler.h
+++ b/src/cpp/disassembler/disassembler.h
@@ -14,15 +14,10 @@
 
 namespace aiebu {
 
+// Abstract base class for disassemblers
 class asm_disassembler {
 public:
-    // Constructor for ELF input files
-    asm_disassembler(const std::string& input_elf_path, std::ostream& output_stream);
-    
-    // Constructor for binary input files
-    asm_disassembler(const std::vector<char>& binary_data, std::ostream& output_stream, const std::string& target_arch = "aie2ps");
-    
-    ~asm_disassembler() = default;
+    virtual ~asm_disassembler() = default;
 
     // Delete copy constructor and copy assignment operator
     asm_disassembler(const asm_disassembler&) = delete;
@@ -32,28 +27,69 @@ public:
     asm_disassembler(asm_disassembler&&) = delete;
     asm_disassembler& operator=(asm_disassembler&&) = delete;
 
-    void run();
+    // Main entry point - to be implemented by derived classes
+    virtual void run() = 0;
 
-private:
-    ELFIO::elfio m_elf_reader;
+protected:
+    // Protected constructor for derived classes
+    asm_disassembler(std::ostream& output_stream);
+
+    // Common members accessible to derived classes
     asm_writer m_asm_writer;
     const std::map<uint8_t, isa_op_disasm>* isa_op_map;
     isa_disassembler isa_disasm;
-    std::vector<char> m_binary_data;
-    bool m_is_binary_mode;
-    std::string m_target_arch;
+    std::string m_target_arch;  // Set by derived classes based on their input format
 
+    // Comments marking start of sections
+    void add_text_sec_comment();
+    void add_data_sec_comment();
+
+    // Common section processing methods
+    void process_text_block(const char* data, size_t start_offset, size_t end_offset, 
+                           std::shared_ptr<disassembler_state> state);
+    void process_data_block(const char* data, size_t size, 
+                           std::shared_ptr<disassembler_state> state);
+};
+
+// ELF disassembler - handles ELF file format
+class elf_asm_disassembler : public asm_disassembler {
+public:
+    // Constructor for ELF input files
+    elf_asm_disassembler(const std::string& input_elf_path, std::ostream& output_stream);
+    
+    void run() override;
+
+private:
+    ELFIO::elfio m_elf_reader;
+
+    // ELF-specific processing methods
     void process_sections();
-    void process_binary();
-    void print_section_info(const ELFIO::section* section) ;
+    void print_section_info(const ELFIO::section* section);
     void process_text_section(const ELFIO::section* section, std::shared_ptr<disassembler_state> state);
     void process_data_section(const ELFIO::section* section, std::shared_ptr<disassembler_state> state);
     void process_pad_section(const ELFIO::section* /*section*/, std::shared_ptr<disassembler_state> /*state*/);
+    bool is_text_section(const std::string& section_name) const;
+    bool is_data_section(const std::string& section_name) const;
+};
+
+// Binary disassembler - handles raw binary files with architecture specification
+class bin_asm_disassembler : public asm_disassembler {
+public:
+    // Constructor for binary input files
+    bin_asm_disassembler(const std::vector<char>& binary_data, 
+                        std::ostream& output_stream, 
+                        aiebu_assembler::buffer_type buffer_type);
+    
+    void run() override;
+
+private:
+    std::vector<char> m_binary_data;
+
+    // Binary-specific processing methods
+    void process_binary();
     void process_binary_data(const char* data, size_t size, std::shared_ptr<disassembler_state> state);
     void process_data_section_binary(const char* data, size_t size, std::shared_ptr<disassembler_state> state);
     size_t detect_binary_header_offset() const;
-    bool is_text_section(const std::string& section_name) const;
-    bool is_data_section(const std::string& section_name) const;
 };
 
 } // namespace aiebu

--- a/src/cpp/disassembler/disassembler.h
+++ b/src/cpp/disassembler/disassembler.h
@@ -32,7 +32,7 @@ public:
 
 protected:
     // Protected constructor for derived classes
-    asm_disassembler(std::ostream& output_stream);
+    explicit asm_disassembler(std::ostream& output_stream);
 
     // Common members accessible to derived classes
     asm_writer m_asm_writer;

--- a/src/cpp/include/aiebu/aiebu_assembler.h
+++ b/src/cpp/include/aiebu/aiebu_assembler.h
@@ -54,6 +54,8 @@ class aiebu_assembler
       elf_aie4,
       elf_aie4_config,
       unspecified,
+      blob_aie2ps,    // Raw binary file for aie2ps architecture
+      blob_aie4,      // Raw binary file for aie4 architecture
     };
 
   private:

--- a/src/cpp/ops/ops.cpp
+++ b/src/cpp/ops/ops.cpp
@@ -300,9 +300,34 @@ handle_generic_const_arg(const opArg& arg, uint32_t val)
     val = val / 2;
   }
 
-  // Format as hexadecimal string
   std::ostringstream oss;
-  oss << "0x" << std::uppercase << std::hex << val;
+  
+  // Formatting rules based on ISA spec and original assembly patterns:
+  // 1. Addresses: always hex
+  // 2. Large data/value/mask fields (> 0xFFFF): hex (bit patterns, test data)
+  // 3. Small values, counts, IDs: decimal
+  
+  bool format_as_hex = false;
+  std::string arg_name = arg.get_name();
+  
+  if (val == offset_type_marker) {
+    // Special marker 0xFFFF for control code base address patching
+    format_as_hex = true;
+  } else if (arg_name == "address" || arg_name.find("addr") != std::string::npos) {
+    // Memory addresses should always be hex
+    format_as_hex = true;
+  } else if ((arg_name == "data" || arg_name == "value" || arg_name == "mask") && val > 0xFFFF) {
+    // Large data/value/mask fields are typically hex (bit patterns like 0xabcdabcd, 0x80000001)
+    format_as_hex = true;
+  }
+  
+  if (format_as_hex) {
+    oss << "0x" << std::uppercase << std::hex << val;
+  } else {
+    // Format as decimal for small values, counts, IDs, sizes, and flags
+    oss << val;
+  }
+  
   return oss.str();
 }
 
@@ -405,6 +430,11 @@ deserialize(asm_writer& writer, std::shared_ptr<disassembler_state> state, const
             default:
                 throw std::runtime_error("Invalid argument type!");
         }
+    }
+
+    // Write .eop directive before eof instruction
+    if (m_opcode->get_code_name() == "eof") {
+        writer.write_eop();
     }
 
     state->increment_address(size);

--- a/src/cpp/ops/ops.h
+++ b/src/cpp/ops/ops.h
@@ -137,11 +137,15 @@ public:
   }
 
   uint16_t read_uint16(const char* data) {
-    return static_cast<uint16_t>(data[0] | (data[1] << byte_shift_8));
+    return static_cast<uint16_t>(static_cast<uint8_t>(data[0])) | 
+           (static_cast<uint16_t>(static_cast<uint8_t>(data[1])) << byte_shift_8);
   }
 
   uint32_t read_uint32(const char* data) {
-    return static_cast<uint32_t>(data[0] | (data[1] << byte_shift_8) | (data[2] << byte_shift_16) | (data[3] << byte_shift_24));
+    return static_cast<uint32_t>(static_cast<uint8_t>(data[0])) | 
+           (static_cast<uint32_t>(static_cast<uint8_t>(data[1])) << byte_shift_8) | 
+           (static_cast<uint32_t>(static_cast<uint8_t>(data[2])) << byte_shift_16) | 
+           (static_cast<uint32_t>(static_cast<uint8_t>(data[3])) << byte_shift_24);
   }
 
   uint32_t get_arg_val(const char* data, uint32_t len) {

--- a/src/cpp/utils/dump/dump.cpp
+++ b/src/cpp/utils/dump/dump.cpp
@@ -129,7 +129,7 @@ int main(int argc, char* argv[])
       std::cout << "Warning: Binary file detected without specified architecture.\n";
       std::cout << "Please use -m option to specify target (aie2ps or aie4) for correct disassembly.\n";
       std::cout << "Example: aiebu-dump -d -m aie2ps input.bin\n";
-      std::cout << "Defaulting to aie2ps ISA...\n\n";
+      std::cout << "Defaulting to aie2ps...\n\n";
       target_arch = "aie2ps";
     }
 
@@ -150,7 +150,7 @@ int main(int argc, char* argv[])
     }
   }
   else {
-    aiebu::reporter rep(type, buffer, target_arch);
+    aiebu::reporter rep(type, buffer);
     if (result["all-headers"].as<bool>()) {
       if (type == aiebu::aiebu_assembler::buffer_type::elf_aie2) {
         rep.elf_summary(std::cout);

--- a/src/cpp/utils/dump/dump.cpp
+++ b/src/cpp/utils/dump/dump.cpp
@@ -135,7 +135,8 @@ int main(int argc, char* argv[])
     }
     else if (result["disassemble"].as<bool>()) {
       if (type == aiebu::aiebu_assembler::buffer_type::elf_aie2 ||
-          type == aiebu::aiebu_assembler::buffer_type::blob_instr_transaction) {
+          type == aiebu::aiebu_assembler::buffer_type::blob_instr_transaction ||
+          type == aiebu::aiebu_assembler::buffer_type::unspecified) {
         rep.disassemble(std::cout);
       }
     }
@@ -145,6 +146,9 @@ int main(int argc, char* argv[])
       }
       else if (type == aiebu::aiebu_assembler::buffer_type::elf_aie2ps) {
         rep.disassemble(result["filename"].as<std::string>(), true);
+      }
+      else if (type == aiebu::aiebu_assembler::buffer_type::unspecified) {
+        rep.disassemble(std::cout, true);
       }
     }
     else if (result["private-headers"].as<bool>()) {

--- a/src/cpp/utils/dump/dump.cpp
+++ b/src/cpp/utils/dump/dump.cpp
@@ -18,6 +18,7 @@ namespace aiebu {
 static const std::set<std::string>
 targets = { //NOLINT
     "aie2ps",
+    "aie4",
     "aie2asm",
     "aie2txn",
     "aie2dpu",
@@ -38,6 +39,8 @@ buffer_type_table = { // NOLINT
   {aiebu::aiebu_assembler::buffer_type::pdi_aie2, "aie2-pdi"},
   {aiebu::aiebu_assembler::buffer_type::pdi_aie2ps, "aie2ps-pdi"},
   {aiebu::aiebu_assembler::buffer_type::unspecified, "unknown"},
+  {aiebu::aiebu_assembler::buffer_type::blob_aie2ps, "aie2ps-binary"},
+  {aiebu::aiebu_assembler::buffer_type::blob_aie4, "aie4-binary"},
 };
 
 
@@ -58,7 +61,7 @@ cxxopts::ParseResult main_helper(int argc, const char* const *argv,
       ("d,disassemble", "Display assembler contents of ctrltext sections if elf file is provided or display control packet \
         in assembled format if control packet binary file is provided", cxxopts::value<bool>()->default_value("false"))
       ("H,help", "show help message and exit", cxxopts::value<bool>()->default_value("false"))
-      ("m,architecture", "Specify the target architecture as MACHINE (aie2ps/aie2asm/aie2txn/aie2dpu)", cxxopts::value<std::string>()->default_value("unspecified"))
+      ("m,architecture", "Specify the target architecture as MACHINE (aie2ps/aie4/aie2asm/aie2txn/aie2dpu). Required for binary files to select correct ISA.", cxxopts::value<std::string>()->default_value("unspecified"))
       ("D,disassemble-all", "Display assembler contents of all sections", cxxopts::value<bool>()->default_value("false"))
       ("t,syms", "Display contents of the symbols table(s)", cxxopts::value<bool>()->default_value("false"))
       ("r,reloc", "Display relocation entries in the file", cxxopts::value<bool>()->default_value("false"))
@@ -118,6 +121,26 @@ int main(int argc, char* argv[])
 
   const std::vector<char> buffer = aiebu::readfile(result["filename"].as<std::string>());
   aiebu::aiebu_assembler::buffer_type type = aiebu::identify_buffer_type(buffer);
+  std::string target_arch = result["architecture"].as<std::string>();
+
+  // For binary files (unspecified), convert to architecture-specific buffer type
+  if (type == aiebu::aiebu_assembler::buffer_type::unspecified) {
+    if (target_arch == "unspecified") {
+      std::cout << "Warning: Binary file detected without specified architecture.\n";
+      std::cout << "Please use -m option to specify target (aie2ps or aie4) for correct disassembly.\n";
+      std::cout << "Example: aiebu-dump -d -m aie2ps input.bin\n";
+      std::cout << "Defaulting to aie2ps ISA...\n\n";
+      target_arch = "aie2ps";
+    }
+
+    // Set buffer type based on target architecture
+    if (target_arch == "aie4") {
+      type = aiebu::aiebu_assembler::buffer_type::blob_aie4;
+    } else {
+      // Default to aie2ps for any other case
+      type = aiebu::aiebu_assembler::buffer_type::blob_aie2ps;
+    }
+  }
 
   if (type == aiebu::aiebu_assembler::buffer_type::blob_control_packet ||
       type == aiebu::aiebu_assembler::buffer_type::blob_control_packet_aie2) {
@@ -127,30 +150,32 @@ int main(int argc, char* argv[])
     }
   }
   else {
-    aiebu::reporter rep(type, buffer);
+    aiebu::reporter rep(type, buffer, target_arch);
     if (result["all-headers"].as<bool>()) {
       if (type == aiebu::aiebu_assembler::buffer_type::elf_aie2) {
         rep.elf_summary(std::cout);
       }
     }
-    else if (result["disassemble"].as<bool>()) {
-      if (type == aiebu::aiebu_assembler::buffer_type::elf_aie2 ||
-          type == aiebu::aiebu_assembler::buffer_type::blob_instr_transaction ||
-          type == aiebu::aiebu_assembler::buffer_type::unspecified) {
-        rep.disassemble(std::cout);
+      else if (result["disassemble"].as<bool>()) {
+        if (type == aiebu::aiebu_assembler::buffer_type::elf_aie2 ||
+            type == aiebu::aiebu_assembler::buffer_type::blob_instr_transaction ||
+            type == aiebu::aiebu_assembler::buffer_type::blob_aie2ps ||
+            type == aiebu::aiebu_assembler::buffer_type::blob_aie4) {
+          rep.disassemble(std::cout);
+        }
       }
-    }
-    else if (result["disassemble-all"].as<bool>()) {
-      if (type == aiebu::aiebu_assembler::buffer_type::elf_aie2) {
-        rep.disassemble(std::cout, true);
+      else if (result["disassemble-all"].as<bool>()) {
+        if (type == aiebu::aiebu_assembler::buffer_type::elf_aie2) {
+          rep.disassemble(std::cout, true);
+        }
+        else if (type == aiebu::aiebu_assembler::buffer_type::elf_aie2ps) {
+          rep.disassemble(result["filename"].as<std::string>(), true);
+        }
+        else if (type == aiebu::aiebu_assembler::buffer_type::blob_aie2ps ||
+                 type == aiebu::aiebu_assembler::buffer_type::blob_aie4) {
+          rep.disassemble(std::cout, true);
+        }
       }
-      else if (type == aiebu::aiebu_assembler::buffer_type::elf_aie2ps) {
-        rep.disassemble(result["filename"].as<std::string>(), true);
-      }
-      else if (type == aiebu::aiebu_assembler::buffer_type::unspecified) {
-        rep.disassemble(std::cout, true);
-      }
-    }
     else if (result["private-headers"].as<bool>()) {
       rep.ctrlcode_summary(std::cout);
     }

--- a/test/aie2ps-ctrlcode/dump/disassemble_golden.asm
+++ b/test/aie2ps-ctrlcode/dump/disassemble_golden.asm
@@ -1,26 +1,28 @@
 
-start_job	0x0
-    uc_dma_write_des	$r0, @label0
-    wait_uc_dma	$r0
-    local_barrier	$lb0, 0x2
-end_job	
-start_job	0x1
-    local_barrier	$lb0, 0x2
-    write_32	0x1A0634, 0x80000000
-    wait_tcts	TILE_0_1, MEM_MM2S_0, 0x1
-end_job	
-eof	
+start_job       0
+    uc_dma_write_des    $r0, @label0
+    wait_uc_dma $r0
+    local_barrier       $lb0, 2
+end_job
+start_job       1
+    local_barrier       $lb0, 2
+    write_32    0x1A0634, 0x80000000
+    wait_tcts   TILE_0_1, MEM_MM2S_0, 1
+end_job
+.eop
+eof
 
-.align 16
+  .ALIGN             16
 label0:
-UC_DMA_BD	 0x00000000,  0x001A0000,  @label1,  8,  0,  0
-.align 4
+UC_DMA_BD        0x00000000,  0x001A0000,  @label1,  8,  0,  0
+
+  .ALIGN             4
 label1:
-.long	 0x00000001
-.long	 0x00020000
-.long	 0x00000000
-.long	 0x00000000
-.long	 0x00000000
-.long	 0x00000000
-.long	 0x00000000
-.long	 0x80000000
+.long    0x00000001
+.long    0x00020000
+.long    0x00000000
+.long    0x00000000
+.long    0x00000000
+.long    0x00000000
+.long    0x00000000
+.long    0x80000000

--- a/test/aie2ps-ctrlcode/dump/disassemble_golden.asm
+++ b/test/aie2ps-ctrlcode/dump/disassemble_golden.asm
@@ -1,28 +1,38 @@
 
-start_job       0
-    uc_dma_write_des    $r0, @label0
-    wait_uc_dma $r0
-    local_barrier       $lb0, 2
-end_job
-start_job       1
-    local_barrier       $lb0, 2
-    write_32    0x1A0634, 0x80000000
-    wait_tcts   TILE_0_1, MEM_MM2S_0, 1
-end_job
+
+;
+;text
+;
+
+start_job	0
+    uc_dma_write_des	$r0, @label0
+    wait_uc_dma	$r0
+    local_barrier	$lb0, 2
+end_job	
+start_job	1
+    local_barrier	$lb0, 2
+    write_32	0x1A0634, 0x80000000
+    wait_tcts	TILE_0_1, MEM_MM2S_0, 1
+end_job	
 .eop
-eof
+eof	
 
-  .ALIGN             16
+  .align             16
+
+;
+;data
+;
+
 label0:
-UC_DMA_BD        0x00000000,  0x001A0000,  @label1,  8,  0,  0
+UC_DMA_BD	 0x00000000,  0x001A0000,  @label1,  8,  0,  0
 
-  .ALIGN             4
+  .align             4
 label1:
-.long    0x00000001
-.long    0x00020000
-.long    0x00000000
-.long    0x00000000
-.long    0x00000000
-.long    0x00000000
-.long    0x00000000
-.long    0x80000000
+.long	 0x00000001
+.long	 0x00020000
+.long	 0x00000000
+.long	 0x00000000
+.long	 0x00000000
+.long	 0x00000000
+.long	 0x00000000
+.long	 0x80000000


### PR DESCRIPTION
#### Problem solved by the commit
1> Add support to disassemble a binary input to ASM
2> Fix sign-extension bug leading to value overflow
3> .align frequency
4> Some small values were displayed in hex (0x..)which should decimal.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
1> Added binary parser
2> type casted to unsigned integer as current type was char hence was signed leading to overflow.
Old value - 0xFFFFFFCD
Expected/corrected value - 0xabcdabcd
3> .align was repeated after every label. Fixed it to be only once before the start of sections.
4> Added logic to display small values in decimal if bigger values are present then display in hex. This is as per current ASM
format seen.


#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
1> Dumped single_col_vadd binaries in ASM format.
2> Dumped single_col_vadd and sinle_col_move_memtiles ELF in ASM format

#### Documentation impact (if any)
