### PR TITLE
Fix typo in windows.cmake

### DIFF
--- a/cmake/windows.cmake
+++ b/cmake/windows.cmake
@@ -25,7 +25,7 @@ add_compile_options(
   )
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-  add_compile_options(/Qspectre>)  # compile with the Spectre mitigations switch
+  add_compile_options(/Qspectre)  # compile with the Spectre mitigations switch
 endif()
 
 add_link_options(


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Corrected the /Qspectre> compiler flag to /Qspectre by removing an extraneous > character

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
