### PR TITLE
Add a hook for on demand aie2p save/restore generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,10 @@ add_subdirectory(src/cpp)
 
 add_subdirectory(specification)
 
-#add_subdirectory(lib)
+if (AIEBU_CTRLCODE_CODEGEN)
+  add_subdirectory(lib)
+endif()
+
 if (AIEBU_NATIVE_BUILD)
   add_subdirectory(test)
 endif()

--- a/build/build.sh
+++ b/build/build.sh
@@ -20,9 +20,14 @@ run_test="yes"
 function compile {
     local config=$1
     local build_python=$2
+    local ctrlcode_codegen=$3
     local cmakeflags="-DCMAKE_BUILD_TYPE=$config"
     if [[ $build_python == "yes" ]]; then
       cmakeflags="$cmakeflags -DAIEBU_PYTHON=ON"
+    fi
+
+    if [[ $ctrlcode_codegen == "yes" ]]; then
+      cmakeflags="$cmakeflags -DAIEBU_CTRLCODE_CODEGEN=ON"
     fi
 
     if [[ $config == "Debug" ]]; then
@@ -47,18 +52,22 @@ function compile {
 }
 
 build_python="yes"
-usage() { echo "Usage: $0 [-pth]" 1>&2; exit 1; }
+ctrlcode_codegen="no"
+usage() { echo "Usage: $0 [-pthc]" 1>&2; exit 1; }
 
-while getopts ":rtph" o; do
+while getopts ":rtphc" o; do
     case "${o}" in
         p)
             build_python="yes"
             ;;
-	m)
-	    run_memtest="yes"
-	    ;;
+        m)
+            run_memtest="yes"
+            ;;
         t)
             run_test="no"
+            ;;
+        c)
+            ctrlcode_codegen="yes"
             ;;
         h)
             usage
@@ -70,8 +79,8 @@ shift $((OPTIND-1))
 here=$PWD
 cd $BUILDDIR
 
-compile Debug $build_python
+compile Debug $build_python $ctrlcode_codegen
 
-compile Release $build_python
+compile Release $build_python $ctrlcode_codegen
 
 cd $here

--- a/cmake/settings.cmake
+++ b/cmake/settings.cmake
@@ -89,32 +89,12 @@ set(AIEBU_GEN_DIR                   ${AIEBU_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}/
 
 # If this repository is used as a submodule, the parent repository may
 # set the following variables in CMake to make aiebu point to the
-# parents copy of ELFIO and/or AIE-RT.
-#
-# For example, XRT parent repository can set the following in its
-# CMake for aiebu to inherit the XRT build of aie-rt:
-#   set(AIEBU_AIE-RT_BIN_DIR ${XRT_BINARY_DIR}/src/runtime_src/aie-rt/driver/src)
-#   set(AIEBU_AIE-RT_HEADER_DIR ${AIEBU_AIE-RT_BIN_DIR}/include)
-# or it can set the source dir from which AIEBU should build aie-rt:
-#   set(AIEBU_AIE-RT_SRC_DIR ${XRT_SOURCE_DIR}/src/runtime_src/aie-rt)
-# If no AIEBU_AIE-RT_* variables are set, aiebu will build aie-rt
-# from its own submodule aie-rt in lib/aie-rt.
+# parents copy of ELFIO.
 #
 # For using XRT's copy of ELFIO, XRT can set the following in its
 # CMake for aiebu to inherit:
 #   set(AIEBU_ELFIO_SRC_DIR ${XRT_SOURCE_DIR}/src/runtime_src/core/common/elf)
-if (DEFINED AIEBU_AIE-RT_BIN_DIR AND DEFINED AIEBU_AIE-RT_HEADER_DIR)
-  message("-- AIEBU uses aie-rt binaries from ${AIEBU_AIE-RT_BIN_DIR}")
-  message("-- AIEBU uses aie-rt headers from ${AIEBU_AIE-RT_HEADER_DIR}")
-elseif (NOT DEFINED AIEBU_AIE-RT_SRC_DIR)
-  set(AIEBU_AIE-RT_SRC_DIR ${AIEBU_SOURCE_DIR}/lib/aie-rt)
-endif()
-
-if (DEFINED AIEBU_AIE-RT_SRC_DIR)
-  set(AIEBU_AIE-RT_HEADER_DIR ${AIEBU_BINARY_DIR}/lib/aie-rt/driver/driver-src/include)
-  message("-- AIEBU builds aie-rt binaries from ${AIEBU_AIE-RT_SRC_DIR}")
-  message("-- AIEBU uses aie-rt headers from ${AIEBU_AIE-RT_HEADER_DIR}")
-endif()
+#
 
 if (NOT DEFINED AIEBU_ELFIO_SRC_DIR)
   set(AIEBU_ELFIO_SRC_DIR "${AIEBU_SOURCE_DIR}/src/cpp/ELFIO")

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,11 +1,74 @@
 # SPDX-License-Identifier: MIT
-# Copyright (C) 2024-2025 Advanced Micro Devices, Inc.
-if (DEFINED AIEBU_AIE-RT_SRC_DIR)
+# Copyright (C) 2024-2026 Advanced Micro Devices, Inc.
+
+# Clone aie-rt from GitHub in the build directory if AIEBU_AIE-RT_SRC_DIR is not defined or doesn't exist
+if (NOT DEFINED AIEBU_AIE-RT_SRC_DIR)
+  set(AIEBU_AIE-RT_SRC_DIR ${CMAKE_BINARY_DIR}/lib/aie-rt)
+endif()
+
+set(AIE_RT_COMMIT_HASH "c60f889558ed9a82dd650125f813fb40017b1333")
+
+if (NOT EXISTS ${AIEBU_AIE-RT_SRC_DIR})
+  message(STATUS "Cloning aie-rt from https://github.com/Xilinx/aie-rt.git to ${AIEBU_AIE-RT_SRC_DIR}")
+  find_package(Git REQUIRED)
+  # Ensure the parent directory exists
+  get_filename_component(AIE_RT_PARENT_DIR ${AIEBU_AIE-RT_SRC_DIR} DIRECTORY)
+  file(MAKE_DIRECTORY ${AIE_RT_PARENT_DIR})
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} clone https://github.com/Xilinx/aie-rt.git ${AIEBU_AIE-RT_SRC_DIR}
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    RESULT_VARIABLE GIT_CLONE_RESULT
+    ERROR_VARIABLE GIT_CLONE_ERROR
+  )
+  if (NOT GIT_CLONE_RESULT EQUAL "0")
+    message(FATAL_ERROR "Failed to clone aie-rt repository: ${GIT_CLONE_ERROR}")
+  endif()
+  message(STATUS "Checking out commit ${AIE_RT_COMMIT_HASH}")
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} checkout ${AIE_RT_COMMIT_HASH}
+    WORKING_DIRECTORY ${AIEBU_AIE-RT_SRC_DIR}
+    RESULT_VARIABLE GIT_CHECKOUT_RESULT
+    ERROR_VARIABLE GIT_CHECKOUT_ERROR
+  )
+  if (NOT GIT_CHECKOUT_RESULT EQUAL "0")
+    message(FATAL_ERROR "Failed to checkout commit ${AIE_RT_COMMIT_HASH}: ${GIT_CHECKOUT_ERROR}")
+  endif()
+  message(STATUS "Successfully cloned aie-rt repository at commit ${AIE_RT_COMMIT_HASH}")
+else()
+  # Verify that the existing repository is at the correct commit
+  find_package(Git REQUIRED)
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} rev-parse HEAD
+    WORKING_DIRECTORY ${AIEBU_AIE-RT_SRC_DIR}
+    OUTPUT_VARIABLE CURRENT_COMMIT
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+  )
+  if (NOT CURRENT_COMMIT STREQUAL "${AIE_RT_COMMIT_HASH}")
+    message(STATUS "aie-rt repository exists but is at different commit. Checking out ${AIE_RT_COMMIT_HASH}")
+    execute_process(
+      COMMAND ${GIT_EXECUTABLE} checkout ${AIE_RT_COMMIT_HASH}
+      WORKING_DIRECTORY ${AIEBU_AIE-RT_SRC_DIR}
+      RESULT_VARIABLE GIT_CHECKOUT_RESULT
+      ERROR_VARIABLE GIT_CHECKOUT_ERROR
+    )
+    if (NOT GIT_CHECKOUT_RESULT EQUAL "0")
+      message(FATAL_ERROR "Failed to checkout commit ${AIE_RT_COMMIT_HASH}: ${GIT_CHECKOUT_ERROR}")
+    endif()
+    message(STATUS "Successfully checked out commit ${AIE_RT_COMMIT_HASH}")
+  endif()
+endif()
+
+if (DEFINED AIEBU_AIE-RT_SRC_DIR AND EXISTS ${AIEBU_AIE-RT_SRC_DIR})
+  message(STATUS "Building aie-rt from ${AIEBU_AIE-RT_SRC_DIR}")
   set(XAIENGINE_BUILD_SHARED OFF CACHE BOOL "Force static build of xaiengine library" FORCE)
   if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     add_compile_options("-Wno-error=unused-parameter")
   endif()
+  # Build aie-rt driver as part of the main build
   aiebu_add_subdirectory_disable_install_target(${AIEBU_AIE-RT_SRC_DIR}/driver ${AIEBU_BINARY_DIR}/lib/aie-rt/driver)
+  message(STATUS "aie-rt driver will be built from ${AIEBU_AIE-RT_SRC_DIR}/driver")
+  set(AIEBU_AIE-RT_HEADER_DIR ${AIEBU_AIE-RT_SRC_DIR}/driver/include)
 endif()
 
 if (AIEBU_NATIVE_BUILD)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
If aie2p ave/restore code generation is requested via build.sh, then CMake will download aie-rt, build it and then link the code generator with aie-rt.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA

#### How problem was solved, alternative solutions (if any) and why they were rejected
CMake updates

#### Risks (if any) associated the changes in the commit
None since the codegeneration is disabled for regular builds

#### What has been tested and how, request additional testing if necessary
Build and ctest with and without -c switch to build.sh

#### Documentation impact (if any)
None