### PR TITLE
Resolve a build failure of RHEL

### DIFF
--- a/test/dtrace_test/CMakeLists.txt
+++ b/test/dtrace_test/CMakeLists.txt
@@ -10,6 +10,8 @@ add_executable(${DTRACE_TESTNAME} dtrace_test.cpp)
 
 add_dependencies(${DTRACE_TESTNAME} cert_dtrace)
 
+target_link_libraries(${DTRACE_TESTNAME} PRIVATE ${CMAKE_DL_LIBS})
+
 if (MSVC)
   set(DTRACE_LIBRARY_PATH "${DTRACE_SOURCE_DIR}/$<CONFIG>/cert_dtrace.dll")
 else()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
dtrace_test fails on RHEL 8 with undefined dl* symbols. Explicitly link dtrace_test with libdl.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
CMake update

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
ctest validated on Ubuntu

#### Documentation impact (if any)
None