### PR TITLE
Fix include search path of ELFIO to honor parent repository settings

### DIFF
--- a/src/cpp/utils/transform/CMakeLists.txt
+++ b/src/cpp/utils/transform/CMakeLists.txt
@@ -13,10 +13,10 @@ set_target_properties(aiebu_transform_objects PROPERTIES
 
 target_include_directories(aiebu_transform_objects
   PRIVATE
+  ${AIEBU_ELFIO_SRC_DIR}
   ${AIEBU_SOURCE_DIR}/src/cpp/include
   ${AIEBU_SOURCE_DIR}/src/cpp/cxxopts/include
   ${AIEBU_SOURCE_DIR}/src/cpp
-  ${AIEBU_SOURCE_DIR}/src/cpp/ELFIO
   ${Boost_INCLUDE_DIRS}
   )
 


### PR DESCRIPTION
#### Problem solved by the commit
When AIEBU is built from parent project it must use parents ELFIO if specified.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The build was failing when building XRT for Debian upstreaming. Some recent change to AIEBU did not add the proper include search for ELFIO.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Fix include search path

