### PR TITLE
dynamic tracing compiler handle support for runlist commands 

### DIFF
--- a/src/cpp/dtrace/dtrace.cpp
+++ b/src/cpp/dtrace/dtrace.cpp
@@ -14,15 +14,11 @@
 
 extern "C" {
 
-// Intial parse to create control buffer and memory buffer
-// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-static std::unique_ptr<dtrace::control> g_control = nullptr;
-
 /**
  * @struct dtrace_buffer_info
  *
  * @brief 
- * Typed dtrace_buffer_info used to hold dtarce buffer information.
+ * Typed dtrace_buffer_info used to hold dtrace buffer information.
  *
  * @details
  * Contains members that specify virtual and physical address of dtrace buffer,
@@ -34,76 +30,98 @@ struct dtrace_buffer_info {
     std::vector<uint32_t> control_buffer; 
     std::vector<uint32_t> mem_buffer;
 };
-// multiple uC dtrace
-// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-static std::unordered_map<uint32_t, dtrace_buffer_info> g_dtrace_buffer_info_map;
 
-//---------------------------multiple uC dtrace---------------------------
-uint32_t 
+/**
+ * @struct dtrace_command_handle
+ *
+ * @brief 
+ * dtrace command handle to maintain dtrace information for multiple commands.
+ *
+ * @details
+ * Each command handle maintains its own dtrace control and buffer information maps.
+ * This allows multiple dtrace commands to operate independently without interference.
+ */
+struct dtrace_command_handle {
+    // Intial parse to create control buffer and memory buffer
+    std::unique_ptr<dtrace::control> g_control = nullptr;
+    // multiple uC dtrace
+    std::unordered_map<uint32_t, dtrace_buffer_info> g_dtrace_buffer_info_map;
+};
+
+dtrace_handle_t 
 get_dtrace_col_numbers(const char* script_file, const char* map_data, 
     uint32_t* buffers_length)
 {
     try
     {
+        // Create new dtrace handle
+        auto handle = std::make_unique<dtrace_command_handle>();
+
         // Initialize the memory host address map and dtrace compiler control object
         // set the log level to default error level
         uint32_t log_level = 1;
-        g_control = 
+        handle->g_control = 
             std::make_unique<dtrace::control>(script_file, map_data, log_level);
 
         // Get the number of uC in the script file
-        uint32_t number_uC = g_control->m_control_uC_indices.size();
+        uint32_t number_uC = handle->g_control->m_control_uC_indices.size();
         *buffers_length = number_uC;
 
-        return 0; // Success
+        return static_cast<dtrace_handle_t>(handle.release());
     }
     catch (const std::exception& e)
     {
         std::cerr << e.what();
-        return 1; // Failure
+        return nullptr; // Failure
     }
 }
 
-uint32_t 
+dtrace_handle_t 
 get_dtrace_col_numbers_with_log(const char* script_file, const char* map_data, 
     uint32_t* buffers_length, uint32_t log_level)
 {
     try
     {
+        // Create new dtrace handle
+        auto handle = std::make_unique<dtrace_command_handle>();
+
         // Initialize the memory host address map and dtrace compiler control object
         // and set the log level
-        g_control = 
+        handle->g_control = 
             std::make_unique<dtrace::control>(script_file, map_data, log_level);
 
         // Get the number of uC in the script file
-        uint32_t number_uC = g_control->m_control_uC_indices.size();
+        uint32_t number_uC = handle->g_control->m_control_uC_indices.size();
         *buffers_length = number_uC;
 
-        return 0; // Success
+        return static_cast<dtrace_handle_t>(handle.release());
     }
     catch (const std::exception& e)
     {
         std::cerr << e.what();
-        return 1; // Failure
+        return nullptr; // Failure
     }
 }
 
 void 
-get_dtrace_buffer_size(uint64_t* buffers)
+get_dtrace_buffer_size(dtrace_handle_t dtrace_handle, uint64_t* buffers)
 {
     try
     {
+        // dtrace handle
+        auto* handle = static_cast<dtrace_command_handle*>(dtrace_handle);
+
         uint32_t buffer_index = 0;
         // Control buffer size and memory buffer size for each uC
-        for (const auto& uC_index : g_control->m_control_uC_indices)
+        for (const auto& uC_index : handle->g_control->m_control_uC_indices)
         {
             // Get control buffer and memory buffer size and populate the map
             // with the dtrace_buffer_info for uC_index
             dtrace_buffer_info l_dtrace_buffer_info;
             l_dtrace_buffer_info.buffer_addr = nullptr;
             l_dtrace_buffer_info.buffer_dma_addr = 0; 
-            l_dtrace_buffer_info.control_buffer = g_control->create_control_buffer(uC_index);
-            l_dtrace_buffer_info.mem_buffer = g_control->create_mem_buffer(uC_index);
+            l_dtrace_buffer_info.control_buffer = handle->g_control->create_control_buffer(uC_index);
+            l_dtrace_buffer_info.mem_buffer = handle->g_control->create_mem_buffer(uC_index);
 
             uint32_t length = 
                 l_dtrace_buffer_info.control_buffer.size() + l_dtrace_buffer_info.mem_buffer.size();
@@ -111,7 +129,7 @@ get_dtrace_buffer_size(uint64_t* buffers)
             buffers[buffer_index] = (static_cast<uint64_t>(length) << 32) | uC_index; // NOLINT(cppcoreguidelines-avoid-magic-numbers)
             buffer_index++;
 
-            g_dtrace_buffer_info_map[uC_index] = std::move(l_dtrace_buffer_info);
+            handle->g_dtrace_buffer_info_map[uC_index] = std::move(l_dtrace_buffer_info);
         }
     }
     catch (const std::exception& e)
@@ -121,20 +139,24 @@ get_dtrace_buffer_size(uint64_t* buffers)
 }
 
 void 
-populate_dtrace_buffer(uint32_t* dtrace_buffer, uint64_t dtrace_buffer_dma)
+populate_dtrace_buffer(dtrace_handle_t dtrace_handle, uint32_t* dtrace_buffer, 
+    uint64_t dtrace_buffer_dma)
 {
     try
     {
+        // dtrace handle
+        auto* handle = static_cast<dtrace_command_handle*>(dtrace_handle);
+
         // Initialize the memory host address map
         std::unordered_map<uint32_t, uint64_t> mem_host_addr_map;
 
         uint64_t uC_buffer_dma_addr = dtrace_buffer_dma;
         // Update control buffer with mem host addr if mem buffer is present
-        if (g_control->m_mem_action_present) {
-            for (const auto& uC_index : g_control->m_control_uC_indices)
+        if (handle->g_control->m_mem_action_present) {
+            for (const auto& uC_index : handle->g_control->m_control_uC_indices)
             {
                 // Get the dtrace_buffer_info for the given uC_index
-                dtrace_buffer_info& l_dtrace_buffer_info = g_dtrace_buffer_info_map[uC_index];
+                dtrace_buffer_info& l_dtrace_buffer_info = handle->g_dtrace_buffer_info_map[uC_index];
 
                 uC_buffer_dma_addr += l_dtrace_buffer_info.control_buffer.size() * sizeof(uint32_t);
                 if (!l_dtrace_buffer_info.mem_buffer.empty()) {
@@ -146,22 +168,22 @@ populate_dtrace_buffer(uint32_t* dtrace_buffer, uint64_t dtrace_buffer_dma)
 
             }
             // Patch the control buffer with memory host address
-            g_control->patch_control_buffer(mem_host_addr_map);  
+            handle->g_control->patch_control_buffer(mem_host_addr_map);  
 
             // Update control buffer and memory buffer in the global structure after patching
-            for (auto& [uC_index, l_dtrace_buffer_info] : g_dtrace_buffer_info_map)
+            for (auto& [uC_index, l_dtrace_buffer_info] : handle->g_dtrace_buffer_info_map)
             {
-                l_dtrace_buffer_info.control_buffer = g_control->create_control_buffer(uC_index);
-                l_dtrace_buffer_info.mem_buffer = g_control->create_mem_buffer(uC_index);
+                l_dtrace_buffer_info.control_buffer = handle->g_control->create_control_buffer(uC_index);
+                l_dtrace_buffer_info.mem_buffer = handle->g_control->create_mem_buffer(uC_index);
             }
         }
 
         uint32_t* uC_buffer_addr = dtrace_buffer;
         // Control buffer and memory buffer for each uC
-        for (const auto& uC_index : g_control->m_control_uC_indices)
+        for (const auto& uC_index : handle->g_control->m_control_uC_indices)
         {    
             // Get the dtrace_buffer_info for the given uC_index
-            dtrace_buffer_info& l_dtrace_buffer_info = g_dtrace_buffer_info_map[uC_index];
+            dtrace_buffer_info& l_dtrace_buffer_info = handle->g_dtrace_buffer_info_map[uC_index];
 
             // Buffer address for the current uC index
             l_dtrace_buffer_info.buffer_addr = uC_buffer_addr;
@@ -195,16 +217,21 @@ populate_dtrace_buffer(uint32_t* dtrace_buffer, uint64_t dtrace_buffer_dma)
 }
 
 void 
-get_dtrace_result_file(const char* result_file)
+get_dtrace_result_file(dtrace_handle_t dtrace_handle, const char* result_file)
 {
     try
     {
+        // dtrace handle unique pointer
+        auto handle = std::unique_ptr<dtrace_command_handle>(
+            static_cast<dtrace_command_handle*>(dtrace_handle)
+        );
+
         // Initialize the result buffers and memory buffers vector
         std::unordered_map<uint32_t, std::vector<uint32_t>> result_buffers;
         std::unordered_map<uint32_t, std::vector<uint32_t>> mem_buffers;
 
         // Iterate over all result buffer and memory buffer for each uC in global map
-        for (const auto& [uC_index, l_dtrace_buffer_info] : g_dtrace_buffer_info_map)
+        for (const auto& [uC_index, l_dtrace_buffer_info] : handle->g_dtrace_buffer_info_map)
         {
             std::vector<uint32_t> buffer(
                 l_dtrace_buffer_info.control_buffer.size() + l_dtrace_buffer_info.mem_buffer.size()
@@ -232,7 +259,7 @@ get_dtrace_result_file(const char* result_file)
             mem_buffers[uC_index] = std::move(mem_buffer);
         }
         // Create the result file
-        g_control->create_result_file(result_buffers, mem_buffers, result_file);
+        handle->g_control->create_result_file(result_buffers, mem_buffers, result_file);
     }
     catch (const std::exception& e)
     {

--- a/src/cpp/dtrace/dtrace.h
+++ b/src/cpp/dtrace/dtrace.h
@@ -37,7 +37,7 @@ typedef void* dtrace_handle_t;
  * Return:          Handle to the dtrace context, or NULL on failure.
  *
  * This function calculates and returns the length of uC for dynamic tracing based
- * on the provided script file and map data. It returns 0 on success and 1 on failure.
+ * on the provided script file and map data. It returns a handle to the dtrace context.
  * Does not include the log level parameter, log_level is set to error by default.
  */
 DTRACE_EXPORT
@@ -55,7 +55,7 @@ get_dtrace_col_numbers(const char* script_file, const char* map_data,
  * Return:          Handle to the dtrace context, or NULL on failure.
  *
  * This function calculates and returns the length of uC for dynamic tracing based
- * on the provided script file and map data. It returns 0 on success and 1 on failure.
+ * on the provided script file and map data. It returns a handle to the dtrace context.
  */
 DTRACE_EXPORT
 dtrace_handle_t 
@@ -68,11 +68,9 @@ get_dtrace_col_numbers_with_log(const char* script_file, const char* map_data,
  * @dtrace_handle:  Handle to the dtrace context.
  * @buffers:        Array of uC details, where each index contains a uint64_t values
  *                  with high 32-bit as length and low 32-bit for respective uC.
- * Return:          Status of the operation. 0 on success and 1 on failure.
  *
  * This function calculates and returns the length of the control and memory buffers 
  * and uC index needed for dynamic tracing based on the provided script file and map data. 
- * It returns 0 on success and 1 on failure.
  */
 DTRACE_EXPORT
 void

--- a/src/cpp/dtrace/dtrace.h
+++ b/src/cpp/dtrace/dtrace.h
@@ -22,21 +22,26 @@ extern "C" {
 #endif
 
 //---------------------------dtrace c---------------------------
-//---------------------------multiple uC dtrace---------------------------
+/*!
+ * handle to a dtrace context.
+ * Each handle represents an independent dtrace instance for a command.
+ */
+typedef void* dtrace_handle_t;
+
 /*!
  * get_dtrace_col_numbers() - Retrieves the buffer sizes required for dynamic tracing.
  *
  * @script_file:    Script file containing the probe and action details.
  * @map_data:       Map data containing details of control code.
  * @buffers_length: Number of uC details in the buffers array.
- * Return:          Status of the operation. 0 on success and 1 on failure.
+ * Return:          Handle to the dtrace context, or NULL on failure.
  *
  * This function calculates and returns the length of uC for dynamic tracing based
  * on the provided script file and map data. It returns 0 on success and 1 on failure.
  * Does not include the log level parameter, log_level is set to error by default.
  */
 DTRACE_EXPORT
-uint32_t 
+dtrace_handle_t 
 get_dtrace_col_numbers(const char* script_file, const char* map_data, 
     uint32_t* buffers_length);
 
@@ -47,19 +52,20 @@ get_dtrace_col_numbers(const char* script_file, const char* map_data,
  * @map_data:       Map data containing details of control code.
  * @buffers_length: Number of uC details in the buffers array.
  * @log_level:      Log level for debugging.
- * Return:          Status of the operation. 0 on success and 1 on failure.
+ * Return:          Handle to the dtrace context, or NULL on failure.
  *
  * This function calculates and returns the length of uC for dynamic tracing based
  * on the provided script file and map data. It returns 0 on success and 1 on failure.
  */
 DTRACE_EXPORT
-uint32_t 
+dtrace_handle_t 
 get_dtrace_col_numbers_with_log(const char* script_file, const char* map_data, 
     uint32_t* buffers_length, uint32_t log_level);
 
 /*!
  * get_dtrace_buffer_size() - Retrieves the buffer sizes required for dynamic tracing.
  *
+ * @dtrace_handle:  Handle to the dtrace context.
  * @buffers:        Array of uC details, where each index contains a uint64_t values
  *                  with high 32-bit as length and low 32-bit for respective uC.
  * Return:          Status of the operation. 0 on success and 1 on failure.
@@ -70,11 +76,12 @@ get_dtrace_col_numbers_with_log(const char* script_file, const char* map_data,
  */
 DTRACE_EXPORT
 void
-get_dtrace_buffer_size(uint64_t* buffers);
+get_dtrace_buffer_size(dtrace_handle_t dtrace_handle, uint64_t* buffers);
 
 /*!
  * populate_dtrace_buffer() - Creates a dynamic tracing buffers.
  *
+ * @dtrace_handle:          Handle to the dtrace context.
  * @control_buffer:         Address for control buffer and memory buffer containing 
  *                          probe and action details and mem action details for multiple uC.
  * @dtrace_buffer_dma:      Physical address of the buffer, used to patch mem action host address
@@ -84,19 +91,21 @@ get_dtrace_buffer_size(uint64_t* buffers);
  */
 DTRACE_EXPORT
 void 
-populate_dtrace_buffer(uint32_t* dtrace_buffer, uint64_t dtrace_buffer_dma);
+populate_dtrace_buffer(dtrace_handle_t dtrace_handle, uint32_t* dtrace_buffer, 
+    uint64_t dtrace_buffer_dma);
 
 /*!
  * get_dtrace_result_file() - Creates a result file for dynamic tracing.
  *
- * @result_file:  Output file where the readable result will be written.
+ * @dtrace_handle:    Handle to the dtrace context.
+ * @result_file:      Output file where the readable result will be written.
  *
  * This function creates a result file by processing the result buffer and mem buffer, 
  * and writes the output to the specified result file.
  */
 DTRACE_EXPORT
 void 
-get_dtrace_result_file(const char* result_file);
+get_dtrace_result_file(dtrace_handle_t dtrace_handle, const char* result_file);
 
 #ifdef __cplusplus
 }

--- a/test/dtrace_test/dtrace_test.cpp
+++ b/test/dtrace_test/dtrace_test.cpp
@@ -21,9 +21,9 @@ static const uint64_t TRACE_CTRL_CODE_BASE = 0x200000;
 static const uint64_t TRACE_CTRL_CODE_SIZE = 16384; // 8kB
 static const uint32_t word_byte_shift = 32;
 static const uint32_t mask_32 = 0xFFFFFFFF; // NOLINT(cppcoreguidelines-avoid-magic-numbers)
-using get_dtrace_col_numbers_t = uint32_t (*)(const char*, const char*, uint32_t*, uint32_t);
-using get_dtrace_buffer_size_t = uint32_t (*)(uint64_t*);
-using populate_dtrace_buffer_t = void (*)(uint32_t*, uint64_t);
+using get_dtrace_col_numbers_t = void* (*)(const char*, const char*, uint32_t*, uint32_t);
+using get_dtrace_buffer_size_t = void (*)(void*, uint64_t*);
+using populate_dtrace_buffer_t = void (*)(void*, uint32_t*, uint64_t);
 
 int 
 run_dtrace_test(const std::string& dtrace_lib_path, const std::string& script_file, 
@@ -35,22 +35,22 @@ run_dtrace_test(const std::string& dtrace_lib_path, const std::string& script_fi
     }
 
     // load dtrace compiler
-    void* dtrace_handle = dlopen(dtrace_lib_path.c_str(), RTLD_LAZY);
-    if (!dtrace_handle) {
+    void* dtrace_lib_handle = dlopen(dtrace_lib_path.c_str(), RTLD_LAZY);
+    if (!dtrace_lib_handle) {
         std::cerr << "[ERROR]: failed to load dtrace library" << std::endl;
         return 1;
     }
 
     // load and check functions from dtrace compiler
     auto get_dtrace_col_numbers = 
-        reinterpret_cast<get_dtrace_col_numbers_t>(dlsym(dtrace_handle, "get_dtrace_col_numbers_with_log"));
+        reinterpret_cast<get_dtrace_col_numbers_t>(dlsym(dtrace_lib_handle, "get_dtrace_col_numbers_with_log"));
     auto get_dtrace_buffer_size = 
-        reinterpret_cast<get_dtrace_buffer_size_t>(dlsym(dtrace_handle, "get_dtrace_buffer_size"));
+        reinterpret_cast<get_dtrace_buffer_size_t>(dlsym(dtrace_lib_handle, "get_dtrace_buffer_size"));
     auto populate_dtrace_buffer = 
-        reinterpret_cast<populate_dtrace_buffer_t>(dlsym(dtrace_handle, "populate_dtrace_buffer"));
+        reinterpret_cast<populate_dtrace_buffer_t>(dlsym(dtrace_lib_handle, "populate_dtrace_buffer"));
     if (!get_dtrace_col_numbers || !get_dtrace_buffer_size || !populate_dtrace_buffer) {
         std::cerr << "[ERROR]: failed to load dtrace functions" << std::endl;
-        dlclose(dtrace_handle);
+        dlclose(dtrace_lib_handle);
         return 1;
     }
 
@@ -58,22 +58,20 @@ run_dtrace_test(const std::string& dtrace_lib_path, const std::string& script_fi
     uint32_t buffers_length = 0;
     uint32_t dtrace_log_level = 1; // default log level
     // get dtrace number of column using get_dtrace_col_numbers api from libdtrace.so
-    uint32_t status = 
+    void* dtrace_handle = 
         get_dtrace_col_numbers(script_file.c_str(), map_file.c_str(), &buffers_length, dtrace_log_level);
-    if (status != 0) {
-        std::cerr << "[ERROR]: dtrace failed with status: " << status << std::endl;
-        dlclose(dtrace_handle);
+    if (!dtrace_handle) {
+        std::cerr << "[ERROR]: dtrace compiler failed" << std::endl;
+        dlclose(dtrace_lib_handle);
         return 1;
     }
-
-    if (status == 0) 
-    {
+    else {
         // allocate dtrace information buffer
         std::unique_ptr<uint32_t[]> dtrace_buffer = std::make_unique<uint32_t[]>(TRACE_CTRL_CODE_SIZE); // NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
         std::unique_ptr<uint64_t[]> buffers = std::make_unique<uint64_t[]>(buffers_length); // NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
 
         // get dtrace information using get_dtrace_buffer_size api from libdtrace.so
-        get_dtrace_buffer_size(buffers.get());
+        get_dtrace_buffer_size(dtrace_handle, buffers.get());
 
         for (uint32_t i = 0; i < buffers_length; ++i) {
             auto length = static_cast<uint32_t>(buffers[i] >> word_byte_shift);
@@ -82,7 +80,7 @@ run_dtrace_test(const std::string& dtrace_lib_path, const std::string& script_fi
         }
 
         // create dtrace buffer using populate_dtrace_buffer api from libdtrace.so
-        populate_dtrace_buffer(dtrace_buffer.get(), TRACE_CTRL_CODE_BASE);
+        populate_dtrace_buffer(dtrace_handle, dtrace_buffer.get(), TRACE_CTRL_CODE_BASE);
 
         // create control_buffer.dat file
         if (dtrace_buffer_length > 0) 
@@ -92,14 +90,8 @@ run_dtrace_test(const std::string& dtrace_lib_path, const std::string& script_fi
                 static_cast<std::streamsize>(dtrace_buffer_length * sizeof(uint32_t)));
             control_buffer_file.close();
         }
-        dlclose(dtrace_handle);
+        dlclose(dtrace_lib_handle);
         return 0;
-    } 
-    else 
-    {
-        std::cerr << "[ERROR]: dtrace complier failed" << std::endl;
-        dlclose(dtrace_handle);
-        return 1;
     }
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

runlist support limitation- previous global state design only showed results for the last command in a runlist

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

Encountered during runlist testcase execution with multiple commands and dynamic tracing enabled

#### How problem was solved, alternative solutions (if any) and why they were rejected

Handle-based dynamic tracing API design- dynamic tracing library provided handle-based APIs that create independent contexts per command

#### Risks (if any) associated the changes in the commit

Low

#### What has been tested and how, request additional testing if necessary

simnow baremetal environment runlist testcase

#### Documentation impact (if any)

NA
