### PR TITLE
Bugfix: same label used in 2 different jobs on same page cause error

### DIFF
--- a/src/cpp/preprocessor/asm/pager.cpp
+++ b/src/cpp/preprocessor/asm/pager.cpp
@@ -365,8 +365,8 @@ pagify(assembler_state& state, uint32_t col, std::vector<page>& pages, uint32_t 
     page_tsize += tsize;
     page_dsize += dsize;
     page_jobs.insert( page_jobs.end(), job_list.begin(), job_list.end() );
-    page_labels.insert( page_labels.end(), labels_list.begin(), labels_list.end() );
-    page_external_labels.insert( page_external_labels.end(), external_labels_list.begin(), external_labels_list.end() );
+    page_labels = union_of_lists_inorder<std::string>(page_labels, labels_list);
+    page_external_labels = union_of_lists_inorder<std::string>(page_external_labels, external_labels_list);
   }
 
   if (page_jobs.size())


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
When same label used in 2 different jobs on same page cause error
```Error: Label dmawrite_data_5 present multiple time in asm```

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
When same label used in 2 different jobs on same page cause error
```Error: Label dmawrite_data_5 present multiple time in asm```
#### How problem was solved, alternative solutions (if any) and why they were rejected
we take union of all labels to remove redundant
  
#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
