### PR TITLE
Fix dtrace result file creation api deleting handle

### DIFF
--- a/src/cpp/dtrace/dtrace.cpp
+++ b/src/cpp/dtrace/dtrace.cpp
@@ -221,10 +221,8 @@ get_dtrace_result_file(dtrace_handle_t dtrace_handle, const char* result_file)
 {
     try
     {
-        // dtrace handle unique pointer
-        auto handle = std::unique_ptr<dtrace_command_handle>(
-            static_cast<dtrace_command_handle*>(dtrace_handle)
-        );
+        // dtrace handle
+        auto* handle = static_cast<dtrace_command_handle*>(dtrace_handle);
 
         // Initialize the result buffers and memory buffers vector
         std::unordered_map<uint32_t, std::vector<uint32_t>> result_buffers;

--- a/src/cpp/dtrace/dtrace.cpp
+++ b/src/cpp/dtrace/dtrace.cpp
@@ -48,9 +48,8 @@ struct dtrace_command_handle {
     std::unordered_map<uint32_t, dtrace_buffer_info> g_dtrace_buffer_info_map;
 };
 
-dtrace_handle_t 
-get_dtrace_col_numbers(const char* script_file, const char* map_data, 
-    uint32_t* buffers_length)
+dtrace_handle_t
+create_dtrace_handle(const char* script_file, const char* map_data, uint32_t log_level)
 {
     try
     {
@@ -58,14 +57,9 @@ get_dtrace_col_numbers(const char* script_file, const char* map_data,
         auto handle = std::make_unique<dtrace_command_handle>();
 
         // Initialize the memory host address map and dtrace compiler control object
-        // set the log level to default error level
-        uint32_t log_level = 1;
-        handle->g_control = 
+        // and set the log level
+        handle->g_control =
             std::make_unique<dtrace::control>(script_file, map_data, log_level);
-
-        // Get the number of uC in the script file
-        uint32_t number_uC = handle->g_control->m_control_uC_indices.size();
-        *buffers_length = number_uC;
 
         return static_cast<dtrace_handle_t>(handle.release());
     }
@@ -76,30 +70,21 @@ get_dtrace_col_numbers(const char* script_file, const char* map_data,
     }
 }
 
-dtrace_handle_t 
-get_dtrace_col_numbers_with_log(const char* script_file, const char* map_data, 
-    uint32_t* buffers_length, uint32_t log_level)
+void
+get_dtrace_col_numbers(dtrace_handle_t dtrace_handle, uint32_t* buffers_length)
 {
     try
     {
-        // Create new dtrace handle
-        auto handle = std::make_unique<dtrace_command_handle>();
-
-        // Initialize the memory host address map and dtrace compiler control object
-        // and set the log level
-        handle->g_control = 
-            std::make_unique<dtrace::control>(script_file, map_data, log_level);
+        // dtrace handle
+        auto* handle = static_cast<dtrace_command_handle*>(dtrace_handle);
 
         // Get the number of uC in the script file
         uint32_t number_uC = handle->g_control->m_control_uC_indices.size();
         *buffers_length = number_uC;
-
-        return static_cast<dtrace_handle_t>(handle.release());
     }
     catch (const std::exception& e)
     {
         std::cerr << e.what();
-        return nullptr; // Failure
     }
 }
 
@@ -278,6 +263,22 @@ get_dtrace_result_file(dtrace_handle_t dtrace_handle, const char* result_file)
                 buffer.size() * sizeof(uint32_t)
             );
         }
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << e.what();
+    }
+}
+
+void
+destroy_dtrace_handle(dtrace_handle_t dtrace_handle)
+{
+    try
+    {
+        // dtrace handle destruction
+        std::unique_ptr<dtrace_command_handle> handle(
+            static_cast<dtrace_command_handle*>(dtrace_handle)
+        );
     }
     catch (const std::exception& e)
     {

--- a/src/cpp/dtrace/dtrace.h
+++ b/src/cpp/dtrace/dtrace.h
@@ -23,49 +23,41 @@ extern "C" {
 
 //---------------------------dtrace c---------------------------
 /*!
- * handle to a dtrace context.
- * Each handle represents an independent dtrace instance for a command.
+ * handle to a dynamic tracing context.
+ * Each handle represents an independent dynamic tracing instance for a command.
  */
 typedef void* dtrace_handle_t;
 
 /*!
- * get_dtrace_col_numbers() - Retrieves the buffer sizes required for dynamic tracing.
+ * create_dtrace_handle() - Creates a handle to the dynamic tracing context.
  *
  * @script_file:    Script file containing the probe and action details.
  * @map_data:       Map data containing details of control code.
- * @buffers_length: Number of uC details in the buffers array.
- * Return:          Handle to the dtrace context, or NULL on failure.
+ * @log_level:      Log level for debugging.
  *
- * This function calculates and returns the length of uC for dynamic tracing based
- * on the provided script file and map data. It returns a handle to the dtrace context.
- * Does not include the log level parameter, log_level is set to error by default.
+ * Returns a handle to the dynamic tracing context, or NULL on failure.
  */
 DTRACE_EXPORT
-dtrace_handle_t 
-get_dtrace_col_numbers(const char* script_file, const char* map_data, 
-    uint32_t* buffers_length);
+dtrace_handle_t
+create_dtrace_handle(const char* script_file, const char* map_data, uint32_t log_level);
 
 /*!
- * get_dtrace_col_numbers_with_log() - Retrieves the buffer sizes required for dynamic tracing.
+ * get_dtrace_col_numbers() - Retrieves the buffer sizes required for dynamic tracing.
  *
- * @script_file:    Script file containing the probe and action details.
- * @map_data:       Map data containing details of control code.
+ * @dtrace_handle:  Handle to the dynamic tracing context.
  * @buffers_length: Number of uC details in the buffers array.
- * @log_level:      Log level for debugging.
- * Return:          Handle to the dtrace context, or NULL on failure.
  *
  * This function calculates and returns the length of uC for dynamic tracing based
- * on the provided script file and map data. It returns a handle to the dtrace context.
+ * on the provided script file and map data.
  */
 DTRACE_EXPORT
-dtrace_handle_t 
-get_dtrace_col_numbers_with_log(const char* script_file, const char* map_data, 
-    uint32_t* buffers_length, uint32_t log_level);
+void
+get_dtrace_col_numbers(dtrace_handle_t dtrace_handle, uint32_t* buffers_length);
 
 /*!
  * get_dtrace_buffer_size() - Retrieves the buffer sizes required for dynamic tracing.
  *
- * @dtrace_handle:  Handle to the dtrace context.
+ * @dtrace_handle:  Handle to the dynamic tracing context.
  * @buffers:        Array of uC details, where each index contains a uint64_t values
  *                  with high 32-bit as length and low 32-bit for respective uC.
  *
@@ -79,7 +71,7 @@ get_dtrace_buffer_size(dtrace_handle_t dtrace_handle, uint64_t* buffers);
 /*!
  * populate_dtrace_buffer() - Creates a dynamic tracing buffers.
  *
- * @dtrace_handle:          Handle to the dtrace context.
+ * @dtrace_handle:          Handle to the dynamic tracing context.
  * @control_buffer:         Address for control buffer and memory buffer containing 
  *                          probe and action details and mem action details for multiple uC.
  * @dtrace_buffer_dma:      Physical address of the buffer, used to patch mem action host address
@@ -95,7 +87,7 @@ populate_dtrace_buffer(dtrace_handle_t dtrace_handle, uint32_t* dtrace_buffer,
 /*!
  * get_dtrace_result_file() - Creates a result file for dynamic tracing.
  *
- * @dtrace_handle:    Handle to the dtrace context.
+ * @dtrace_handle:    Handle to the dynamic tracing context.
  * @result_file:      Output file where the readable result will be written.
  *
  * This function creates a result file by processing the result buffer and mem buffer, 
@@ -104,6 +96,18 @@ populate_dtrace_buffer(dtrace_handle_t dtrace_handle, uint32_t* dtrace_buffer,
 DTRACE_EXPORT
 void 
 get_dtrace_result_file(dtrace_handle_t dtrace_handle, const char* result_file);
+
+/*!
+* destroy_dtrace_handle() - Destroys a dynamic tracing context.
+*
+* @dtrace_handle:  Handle to the dynamic tracing context.
+*
+* This function releases all resources associated with the dynamic tracing handle. 
+* After this call, handle must not be used again.
+*/
+DTRACE_EXPORT
+void
+destroy_dtrace_handle(dtrace_handle_t dtrace_handle);
 
 #ifdef __cplusplus
 }

--- a/test/dtrace_test/dtrace_test.cpp
+++ b/test/dtrace_test/dtrace_test.cpp
@@ -21,9 +21,11 @@ static const uint64_t TRACE_CTRL_CODE_BASE = 0x200000;
 static const uint64_t TRACE_CTRL_CODE_SIZE = 16384; // 8kB
 static const uint32_t word_byte_shift = 32;
 // static const uint32_t mask_32 = 0xFFFFFFFF; // NOLINT(cppcoreguidelines-avoid-magic-numbers)
-using get_dtrace_col_numbers_t = void* (*)(const char*, const char*, uint32_t*, uint32_t);
+using create_dtrace_handle_t = void* (*)(const char*, const char*, uint32_t);
+using get_dtrace_col_numbers_t = void (*)(void*, uint32_t*);
 using get_dtrace_buffer_size_t = void (*)(void*, uint64_t*);
 using populate_dtrace_buffer_t = void (*)(void*, uint32_t*, uint64_t);
+using destroy_dtrace_handle_t = void (*)(void*);
 
 int 
 run_dtrace_test(const std::string& dtrace_lib_path, const std::string& script_file, 
@@ -42,13 +44,19 @@ run_dtrace_test(const std::string& dtrace_lib_path, const std::string& script_fi
     }
 
     // load and check functions from dtrace compiler
+    auto create_dtrace_handle = 
+        reinterpret_cast<create_dtrace_handle_t>(dlsym(dtrace_lib_handle, "create_dtrace_handle"));
     auto get_dtrace_col_numbers = 
-        reinterpret_cast<get_dtrace_col_numbers_t>(dlsym(dtrace_lib_handle, "get_dtrace_col_numbers_with_log"));
+        reinterpret_cast<get_dtrace_col_numbers_t>(dlsym(dtrace_lib_handle, "get_dtrace_col_numbers"));
     auto get_dtrace_buffer_size = 
         reinterpret_cast<get_dtrace_buffer_size_t>(dlsym(dtrace_lib_handle, "get_dtrace_buffer_size"));
     auto populate_dtrace_buffer = 
         reinterpret_cast<populate_dtrace_buffer_t>(dlsym(dtrace_lib_handle, "populate_dtrace_buffer"));
-    if (!get_dtrace_col_numbers || !get_dtrace_buffer_size || !populate_dtrace_buffer) {
+    auto destroy_dtrace_handle = 
+        reinterpret_cast<destroy_dtrace_handle_t>(dlsym(dtrace_lib_handle, "destroy_dtrace_handle"));
+    if (!create_dtrace_handle || !get_dtrace_col_numbers || !get_dtrace_buffer_size || 
+        !populate_dtrace_buffer || !destroy_dtrace_handle) 
+    {
         std::cerr << "[ERROR]: failed to load dtrace functions" << std::endl;
         dlclose(dtrace_lib_handle);
         return 1;
@@ -57,15 +65,18 @@ run_dtrace_test(const std::string& dtrace_lib_path, const std::string& script_fi
     uint32_t dtrace_buffer_length = 0;
     uint32_t buffers_length = 0;
     uint32_t dtrace_log_level = 1; // default log level
-    // get dtrace number of column using get_dtrace_col_numbers api from libdtrace.so
+    // get dtrace handle using create_dtrace_handle api from libdtrace.so
     void* dtrace_handle = 
-        get_dtrace_col_numbers(script_file.c_str(), map_file.c_str(), &buffers_length, dtrace_log_level);
+        create_dtrace_handle(script_file.c_str(), map_file.c_str(), dtrace_log_level);
     if (!dtrace_handle) {
         std::cerr << "[ERROR]: dtrace compiler failed" << std::endl;
         dlclose(dtrace_lib_handle);
         return 1;
     }
     else {
+        // get dtrace number of column using get_dtrace_col_numbers api from libdtrace.so
+        get_dtrace_col_numbers(dtrace_handle, &buffers_length);
+
         // allocate dtrace information buffer
         std::unique_ptr<uint32_t[]> dtrace_buffer = std::make_unique<uint32_t[]>(TRACE_CTRL_CODE_SIZE); // NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
         std::unique_ptr<uint64_t[]> buffers = std::make_unique<uint64_t[]>(buffers_length); // NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
@@ -90,6 +101,9 @@ run_dtrace_test(const std::string& dtrace_lib_path, const std::string& script_fi
                 static_cast<std::streamsize>(dtrace_buffer_length * sizeof(uint32_t)));
             control_buffer_file.close();
         }
+
+        // destroy dtrace handle using destroy_dtrace_handle api from libdtrace.so
+        destroy_dtrace_handle(dtrace_handle);
         dlclose(dtrace_lib_handle);
         return 0;
     }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

Fix dtrace result file creation API taking ownership of the handle and deleting it on return
Added explicit `create_dtrace_handle() / destroy_dtrace_handle()` APIs to make ownership and lifecycle management explicit for callers.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

In multiple run testcase, dtrace handle was freed after the first call and same dtrace handle was reused across multiple runs, which caused SIGSEGV on the second and later calls.

#### How problem was solved, alternative solutions (if any) and why they were rejected

Stopped adopting/deleting the handle in dtrace result file creation API; use a raw pointer so the caller keeps ownership
Added explicit lifecycle APIs: `create_dtrace_handle()` to allocate and initialize context and `destroy_dtrace_handle()` to release it.

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)