### PR TITLE
Stop releasing dtrace.h

### DIFF
--- a/src/cpp/dtrace/CMakeLists.txt
+++ b/src/cpp/dtrace/CMakeLists.txt
@@ -54,15 +54,16 @@ add_library(cert_dtrace_static STATIC
   $<TARGET_OBJECTS:dtrace_library_objects>
   )
 
+if (NOT WIN32)
+  # On linux use cert_dtrace.a.  The target name is cert_dtrace_static but the
+  # output name is cert_dtrace.
+  set_target_properties(cert_dtrace_static PROPERTIES OUTPUT_NAME "cert_dtrace")
+endif()
+
+
 install(TARGETS cert_dtrace cert_dtrace_static
   EXPORT aiebu-targets
   LIBRARY DESTINATION ${AIEBU_INSTALL_LIB_DIR} COMPONENT ${AIEBU_COMPONENT}
   RUNTIME DESTINATION ${AIEBU_INSTALL_LIB_DIR} COMPONENT ${AIEBU_COMPONENT}
   ARCHIVE DESTINATION ${AIEBU_INSTALL_LIB_DIR} COMPONENT ${AIEBU_DEV_COMPONENT}
-  )
-
-install(FILES
-  ${CMAKE_CURRENT_SOURCE_DIR}/dtrace.h
-  DESTINATION ${AIEBU_INSTALL_INCLUDE_DIR}/dtrace
-  CONFIGURATIONS Debug Release COMPONENT ${AIEBU_DEV_COMPONENT}
   )


### PR DESCRIPTION
#### Problem solved by the commit
Stop release of dtrace.h and rename static cert library

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
#### How problem was solved, alternative solutions (if any) and why they were rejected
The header is used internally by XRT, which includes directly from
aiebu submodule.   The header is not needed in customer end release.

Rename libcert_dtrace_static.a to libcert_dtrace.a at install time.

