### PR TITLE
fix clang build error

### DIFF
--- a/src/cpp/analyzer/aie2p_passes.h
+++ b/src/cpp/analyzer/aie2p_passes.h
@@ -24,10 +24,9 @@ template <typename opnode> opnode *allocXaie() {
 }
 
 class XAie_OpHdr_null : public aie2p_basicpass<XAie_OpHdr> {
-  std::list<basic_node<XAie_OpHdr>> &m_nodes;
+  //std::list<basic_node<XAie_OpHdr>> &m_nodes;
 public:
-  explicit XAie_OpHdr_null(std::list<basic_node<XAie_OpHdr>> &nodes)
-    : m_nodes(nodes)  {}
+  explicit XAie_OpHdr_null(std::list<basic_node<XAie_OpHdr>> &/*nodes*/) {}
 
   void transform() override;
 };


### PR DESCRIPTION
aiebu\src\cpp\analyzer\aie2p_passes.h(27,38): error: private field 'm_nodes' is not used [-Werror,-Wunused-private-field]
   27 |   std::list<basic_node<XAie_OpHdr>> &m_nodes;
      |                                      ^
1 error generated.

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
