### PR TITLE
Fatal error on Windows when CMake version is less than 3.24

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,11 @@
 # SPDX-License-Identifier: MIT
-# Copyright (C) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.
 cmake_minimum_required(VERSION 3.18...4.0)
 project(AIEBU HOMEPAGE_URL https://github.com/Xilinx/aiebu VERSION 1.0)
+
+if (WIN32 AND CMAKE_VERSION VERSION_LESS 3.24)
+  message(FATAL_ERROR "CMake 3.24 or higher is required on Windows")
+endif()
 
 set(CMAKE_TRY_COMPILE_TARGET_TYPE "STATIC_LIBRARY")
 include(cmake/settings.cmake)

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 
 ..
     comment:: SPDX-License-Identifier: MIT
-    comment:: Copyright (C) 2024 Advanced Micro Devices, Inc.
+    comment:: Copyright (C) 2024-2026 Advanced Micro Devices, Inc.
 
 ============================
 AIE Binary Utilities (AIEBU)
@@ -20,7 +20,7 @@ Init workspace, including submodules
 Build Dependencies
 ==================
 
- * cmake 3.18 or above
+ * cmake 3.18 or above (3.24 on windows)
  * c++17 compiler
  * Boost (header only) minimum version supported is 1.76
  * cxxopts (included as submodule)


### PR DESCRIPTION
#### Problem solved by the commit
`target_include_directories(target SYSTEM ...)` requires minimum 3.24 for full support to add `/external:I` and `/external:W0` on windows.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Some supported Linux version uses less than 3.24, but it is not possble to have conditional `cmake_minimum_required`, so resort to message fatal error and windows.

