### PR TITLE
clang build errors

### DIFF
--- a/src/cpp/preprocessor/asm/asm_parser.cpp
+++ b/src/cpp/preprocessor/asm/asm_parser.cpp
@@ -15,11 +15,15 @@
 // Provide portable replacements when compiling with MSVC.
 // ---------------------------------------------------------------------------
 #if defined(_MSC_VER)
-#include <intrin.h>
-static inline int aiebu_popcount(unsigned int x)
-{
-  return static_cast<int>(__popcnt(x));
+static inline int aiebu_popcount(unsigned int x) {
+  int count = 0;
+  while (x) {
+      count += x & 1;
+      x >>= 1;
+  }
+  return count;
 }
+
 static inline int aiebu_ctz(unsigned int x)
 {
   // _BitScanForward: index of lowest set bit; x must be non-zero (caller guarantees w != 0)

--- a/test/dtrace_test/dtrace_test.cpp
+++ b/test/dtrace_test/dtrace_test.cpp
@@ -10,9 +10,40 @@
 
 #ifdef _WIN32
 #include <windows.h>
-#define dlopen(lib, flags) LoadLibrary(lib)
-#define dlsym(handle, symbol) GetProcAddress((HMODULE)(handle), (symbol))
-#define dlclose(handle) FreeLibrary((HMODULE)(handle))
+// UNICODE builds map LoadLibrary -> LoadLibraryW; use LoadLibraryA for const char* paths.
+#ifndef RTLD_LAZY
+#define RTLD_LAZY 0
+#endif
+
+static inline void*
+aiebu_dlopen(const char* path, int /*flags*/)
+{
+  return reinterpret_cast<void*>(LoadLibraryA(path));
+}
+
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcast-function-type-mismatch"
+#endif
+template<typename T>
+static inline T
+aiebu_dlsym(void* handle, const char* symbol)
+{
+  FARPROC p = GetProcAddress(static_cast<HMODULE>(handle), symbol);
+  return reinterpret_cast<T>(p);
+}
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+
+static inline void
+aiebu_dlclose(void* handle)
+{
+  FreeLibrary(static_cast<HMODULE>(handle));
+}
+
+#define dlopen(path, flags) aiebu_dlopen((path), (flags))
+#define dlclose(handle)       aiebu_dlclose((handle))
 #else
 #include <dlfcn.h>
 #endif
@@ -44,16 +75,29 @@ run_dtrace_test(const std::string& dtrace_lib_path, const std::string& script_fi
     }
 
     // load and check functions from dtrace compiler
-    auto create_dtrace_handle = 
+#ifdef _WIN32
+    auto create_dtrace_handle =
+        aiebu_dlsym<create_dtrace_handle_t>(dtrace_lib_handle, "create_dtrace_handle");
+    auto get_dtrace_col_numbers =
+        aiebu_dlsym<get_dtrace_col_numbers_t>(dtrace_lib_handle, "get_dtrace_col_numbers");
+    auto get_dtrace_buffer_size =
+        aiebu_dlsym<get_dtrace_buffer_size_t>(dtrace_lib_handle, "get_dtrace_buffer_size");
+    auto populate_dtrace_buffer =
+        aiebu_dlsym<populate_dtrace_buffer_t>(dtrace_lib_handle, "populate_dtrace_buffer");
+    auto destroy_dtrace_handle =
+        aiebu_dlsym<destroy_dtrace_handle_t>(dtrace_lib_handle, "destroy_dtrace_handle");
+#else
+    auto create_dtrace_handle =
         reinterpret_cast<create_dtrace_handle_t>(dlsym(dtrace_lib_handle, "create_dtrace_handle"));
-    auto get_dtrace_col_numbers = 
+    auto get_dtrace_col_numbers =
         reinterpret_cast<get_dtrace_col_numbers_t>(dlsym(dtrace_lib_handle, "get_dtrace_col_numbers"));
-    auto get_dtrace_buffer_size = 
+    auto get_dtrace_buffer_size =
         reinterpret_cast<get_dtrace_buffer_size_t>(dlsym(dtrace_lib_handle, "get_dtrace_buffer_size"));
-    auto populate_dtrace_buffer = 
+    auto populate_dtrace_buffer =
         reinterpret_cast<populate_dtrace_buffer_t>(dlsym(dtrace_lib_handle, "populate_dtrace_buffer"));
-    auto destroy_dtrace_handle = 
+    auto destroy_dtrace_handle =
         reinterpret_cast<destroy_dtrace_handle_t>(dlsym(dtrace_lib_handle, "destroy_dtrace_handle"));
+#endif
     if (!create_dtrace_handle || !get_dtrace_col_numbers || !get_dtrace_buffer_size || 
         !populate_dtrace_buffer || !destroy_dtrace_handle) 
     {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Fix clang issues

Issue 1.
```
aiebu_static.lib(asm_parser.obj) : error LNK2019: unresolved external symbol __popcnt referenced in function "struct std::pair<unsigned __int64,unsigned __int64> __cdecl aiebu::hintmap_words_to_scratchpad(class std::vector<unsigned int,class std::allocator<unsigned int> > const &,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &,int)" (?hintmap_words_to_scratchpad@aiebu@@YA?AU?$pair@_K_K@std@@AEBV?$vector@IV?$allocator@I@std@@@3@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@3@H@Z) [G:\xmc\build\_deps\aiebu\src\aiebu-build\src\cpp\utils\asm\aiebu-asm.vcxproj]
--
79 | G:\xmc\build\_deps\aiebu\src\aiebu-build\src\cpp\utils\asm\Release\aiebu-asm.exe : fatal error LNK1120: 1 unresolved externals [G:\xmc\build\_deps\aiebu\src\aiebu-build\src\cpp\utils\asm\aiebu-asm.vcxproj]
80 | aiebu-dump.vcxproj -> G:\xmc\build\_deps\aiebu\src\aiebu-build\src\cpp\utils\dump\Release\aiebu-dump.exe
``` 

Issue 2:
```
C:\Develop\ar\w\vitis_flexml\vitis_flexml\third-party\aiebu\test\dtrace_test\dtrace_test.cpp(40,31): error: no matching function for call to 'LoadLibraryW'
   40 |     void* dtrace_lib_handle = dlopen(dtrace_lib_path.c_str(), RTLD_LAZY);
      |                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
C:\Develop\ar\w\vitis_flexml\vitis_flexml\third-party\aiebu\test\dtrace_test\dtrace_test.cpp(13,28): note: expanded from macro 'dlopen'
   13 | #define dlopen(lib, flags) LoadLibrary(lib)
      |                            ^~~~~~~~~~~
C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\um\libloaderapi.h(605,22): note: expanded from macro 'LoadLibrary'
  605 | #define LoadLibrary  LoadLibraryW
      |                      ^~~~~~~~~~~~
C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\um\libloaderapi.h(601,1): note: candidate function not viable: no known conversion from 'const char *' to 'LPCWSTR' (aka 'const wchar_t *') for 1st argument
  601 | LoadLibraryW(
      | ^
  602 |     _In_ LPCWSTR lpLibFileName
      |          ~~~~~~~~~~~~~~~~~~~~~
C:\Develop\ar\w\vitis_flexml\vitis_flexml\third-party\aiebu\test\dtrace_test\dtrace_test.cpp(48,9): error: cast from 'FARPROC' (aka 'long long (*)()') to 'create_dtrace_handle_t' (aka 'void *(*)(const char *, const char *, unsigned int)') converts to incompatible function type [-Werror,-Wcast-function-type-mismatch]
   48 |         reinterpret_cast<create_dtrace_handle_t>(dlsym(dtrace_lib_handle, "create_dtrace_handle"));
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
C:\Develop\ar\w\vitis_flexml\vitis_flexml\third-party\aiebu\test\dtrace_test\dtrace_test.cpp(50,9): error: cast from 'FARPROC' (aka 'long long (*)()') to 'get_dtrace_col_numbers_t' (aka 'void (*)(void *, unsigned int *)') converts to incompatible function type [-Werror,-Wcast-function-type-mismatch]
   50 |         reinterpret_cast<get_dtrace_col_numbers_t>(dlsym(dtrace_lib_handle, "get_dtrace_col_numbers"));
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
C:\Develop\ar\w\vitis_flexml\vitis_flexml\third-party\aiebu\test\dtrace_test\dtrace_test.cpp(52,9): error: cast from 'FARPROC' (aka 'long long (*)()') to 'get_dtrace_buffer_size_t' (aka 'void (*)(void *, unsigned long long *)') converts to incompatible function type [-Werror,-Wcast-function-type-mismatch]
   52 |         reinterpret_cast<get_dtrace_buffer_size_t>(dlsym(dtrace_lib_handle, "get_dtrace_buffer_size"));
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
C:\Develop\ar\w\vitis_flexml\vitis_flexml\third-party\aiebu\test\dtrace_test\dtrace_test.cpp(54,9): error: cast from 'FARPROC' (aka 'long long (*)()') to 'populate_dtrace_buffer_t' (aka 'void (*)(void *, unsigned int *, unsigned long long)') converts to incompatible function type [-Werror,-Wcast-function-type-mismatch]
   54 |         reinterpret_cast<populate_dtrace_buffer_t>(dlsym(dtrace_lib_handle, "populate_dtrace_buffer"));
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
C:\Develop\ar\w\vitis_flexml\vitis_flexml\third-party\aiebu\test\dtrace_test\dtrace_test.cpp(56,9): error: cast from 'FARPROC' (aka 'long long (*)()') to 'destroy_dtrace_handle_t' (aka 'void (*)(void *)') converts to incompatible function type [-Werror,-Wcast-function-type-mismatch]
   56 |         reinterpret_cast<destroy_dtrace_handle_t>(dlsym(dtrace_lib_handle, "destroy_dtrace_handle"));
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
6 errors generated.
```
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
