### PR TITLE
fix: make hintmap label lowercase as all strings are mad lowercase

### DIFF
--- a/src/cpp/preprocessor/asm/asm_parser.cpp
+++ b/src/cpp/preprocessor/asm/asm_parser.cpp
@@ -271,6 +271,10 @@ parse_lines(const std::vector<char>& data, std::string& file)
           if (!hintmap_label.empty() && hintmap_label[0] == '@') {
             hintmap_label = hintmap_label.substr(1);
           }
+          if (!hintmap_label.empty()) {
+            std::transform(hintmap_label.begin(), hintmap_label.end(), hintmap_label.begin(),
+                           [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+          }
         }
 
         // Get save/restore labels - specific to hintmap if present, otherwise use group labels


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
