### PR TITLE
fix build error with -DCMAKE_BUILD_TYPE=RelWithDebInfo cannot found  …

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -118,7 +118,7 @@ install(FILES
   include/aiebu/aiebu_assembler.h
   include/aiebu/aiebu_error.h
   DESTINATION ${AIEBU_INSTALL_INCLUDE_DIR}/aiebu
-  CONFIGURATIONS Debug Release COMPONENT ${AIEBU_DEV_COMPONENT}
+  COMPONENT ${AIEBU_DEV_COMPONENT}
 )
 
 # Build dynamic tracing library


### PR DESCRIPTION
…aiebu.h

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
failed with -DCMAKE_BUILD_TYPE=RelWithDebInfo, error is aiebu.h not found
#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
