### PR TITLE
Stop release of shared library for cert_dtrace

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-# Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
 
 # In arm compiler we dont have static libs so not building utility
 if (AIEBU_NATIVE_BUILD OR ${CMAKE_SYSTEM_PROCESSOR} STREQUAL ARM64)
@@ -103,13 +103,12 @@ add_library(aiebu_static STATIC
 if (MSVC)
   target_link_libraries(aiebu_static advapi32)
 else()
-  # On linux use xrt_coreutil.a
+  # On linux use aiebu_static.a
   set_target_properties(aiebu_static PROPERTIES OUTPUT_NAME "aiebu")
 endif()
 
 install (TARGETS aiebu_static
   EXPORT aiebu-targets
-  LIBRARY DESTINATION ${AIEBU_INSTALL_LIB_DIR} COMPONENT ${AIEBU_COMPONENT} NAMELINK_COMPONENT ${AIEBU_DEV_COMPONENT}
   ARCHIVE DESTINATION ${AIEBU_INSTALL_LIB_DIR} COMPONENT ${AIEBU_DEV_COMPONENT}
 )
 

--- a/src/cpp/dtrace/CMakeLists.txt
+++ b/src/cpp/dtrace/CMakeLists.txt
@@ -60,10 +60,10 @@ if (NOT WIN32)
   set_target_properties(cert_dtrace_static PROPERTIES OUTPUT_NAME "cert_dtrace")
 endif()
 
-
-install(TARGETS cert_dtrace cert_dtrace_static
+# As long as we support static linking of targets depend on static cert, the
+# cert static library must be released.
+install(TARGETS cert_dtrace_static
   EXPORT aiebu-targets
-  LIBRARY DESTINATION ${AIEBU_INSTALL_LIB_DIR} COMPONENT ${AIEBU_COMPONENT}
-  RUNTIME DESTINATION ${AIEBU_INSTALL_LIB_DIR} COMPONENT ${AIEBU_COMPONENT}
+  LIBRARY DESTINATION ${AIEBU_INSTALL_LIB_DIR} COMPONENT ${AIEBU_COMPONENT} NAMELINK_COMPONENT ${AIEBU_DEV_COMPONENT}
   ARCHIVE DESTINATION ${AIEBU_INSTALL_LIB_DIR} COMPONENT ${AIEBU_DEV_COMPONENT}
   )

--- a/src/cpp/dtrace/CMakeLists.txt
+++ b/src/cpp/dtrace/CMakeLists.txt
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-# Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 
 add_library(dtrace_library_objects OBJECT
   action/action_control.cpp
@@ -60,10 +60,9 @@ if (NOT WIN32)
   set_target_properties(cert_dtrace_static PROPERTIES OUTPUT_NAME "cert_dtrace")
 endif()
 
-# As long as we support static linking of targets depend on static cert, the
-# cert static library must be released.
+# As long as we support static linking of targets that depend on static cert,
+# the cert static library must be released.
 install(TARGETS cert_dtrace_static
   EXPORT aiebu-targets
-  LIBRARY DESTINATION ${AIEBU_INSTALL_LIB_DIR} COMPONENT ${AIEBU_COMPONENT} NAMELINK_COMPONENT ${AIEBU_DEV_COMPONENT}
   ARCHIVE DESTINATION ${AIEBU_INSTALL_LIB_DIR} COMPONENT ${AIEBU_DEV_COMPONENT}
   )


### PR DESCRIPTION
#### Problem solved by the commit
Consumers of cert_dtrace must statically link with libcert_dtrace.a (Linux) and cert_dtrace_static.lib (Windows)

Shared library still built for internal AIEBU test use.

