### PR TITLE
perf optimization: return reference of data part of asm

### DIFF
--- a/src/cpp/preprocessor/asm/asm_parser.cpp
+++ b/src/cpp/preprocessor/asm/asm_parser.cpp
@@ -554,7 +554,7 @@ parse_hintmap_and_calculate_scratchpad(int group,
 
   const std::string ctx     = find_hintmap_context(group, search_context, hintmap_label);
   auto& col_data            = get_col_asmdata(static_cast<uint32_t>(group));
-  const auto all_entries    = col_data.get_label_asmdata(ctx);
+  const auto& all_entries   = col_data.get_label_asmdata_data(ctx);
   const auto words          = collect_hintmap_words(all_entries, hintmap_label);
   return hintmap_words_to_scratchpad(words, hintmap_label, group);
 }

--- a/src/cpp/preprocessor/asm/asm_parser.h
+++ b/src/cpp/preprocessor/asm/asm_parser.h
@@ -382,6 +382,12 @@ public:
     return result;
   }
 
+  const std::vector<std::shared_ptr<asm_data>>&
+  get_label_asmdata_data(const std::string& label) const
+  {
+    return m_label_data.at(label).data;
+  }
+
   std::map<std::string, section_asmdata>& get_label_data() { return m_label_data; }
 
   std::map<std::string, uint32_t>& get_labelpageindex() { return m_labelpageindex; }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
perf optimization: return reference of data part of asm

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Hintmap symbol only in section_asmdata::data  
`col_data::get_label_asmdata_data(label) const` return only data part of asm as hintmap will part of data only.

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
