### PR TITLE
Cursor helped readelf post processing for ancient OS like RHEL 8.x

### DIFF
--- a/test/aie2ps-ctrlcode/run-readelf.sh
+++ b/test/aie2ps-ctrlcode/run-readelf.sh
@@ -11,6 +11,7 @@
 #   C (compressed), O (ordered), R (GNU retain), E (exclude)
 #
 # Normalize ELF header Machine: to match gold files (col_0.gold et al.),
-# which expect WE32100 instead of the eu-readelf name "m32".
+# which expect WE32100. Ancient versions of eu-readelf report "m32" which
+# skews the gold comparison.
 
 eu-readelf -a $1 | sed "/Key to Flags/,+3d" | sed '/^[[:space:]]*Machine:/s/m32/WE32100/' > "$2"

--- a/test/aie2ps-ctrlcode/run-readelf.sh
+++ b/test/aie2ps-ctrlcode/run-readelf.sh
@@ -9,6 +9,8 @@
 #   W (write), A (alloc), X (execute), M (merge), S (strings), I (info),
 #   L (link order), N (extra OS processing required), G (group), T (TLS),
 #   C (compressed), O (ordered), R (GNU retain), E (exclude)
+#
+# Normalize ELF header Machine: to match gold files (col_0.gold et al.),
+# which expect WE32100 instead of the eu-readelf name "m32".
 
-
-eu-readelf -a $1 | sed "/Key to Flags/,+3d" > $2
+eu-readelf -a $1 | sed "/Key to Flags/,+3d" | sed '/^[[:space:]]*Machine:/s/m32/WE32100/' > "$2"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
On older systems, readelf returns m32 instead of WE32100 which breaks gold comparison. This PR normalizes the output.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
