### PR TITLE
Minor perf improvements related to number parsing

### DIFF
--- a/src/cpp/common/assembler_state.cpp
+++ b/src/cpp/common/assembler_state.cpp
@@ -4,6 +4,7 @@
 
 #include "utils.h"
 
+#include "regex_wrapper.h"
 #include "aiebu/aiebu_error.h"
 
 #include <functional>
@@ -162,7 +163,7 @@ process(bool makeunique)
  * 4. If string is numeric string: it will convert to decimal
  */
 uint32_t assembler_state::parse_num_arg(const std::string& str) {
-  const std::unordered_map<std::string, std::function<uint32_t(const std::string&)>> handlers = {
+  static const std::unordered_map<std::string, std::function<uint32_t(const std::string&)>> handlers = {
     {"@", [this](const std::string& s) -> uint32_t {
           //If string start with '@': it can be either pad name or label name
           auto key = s.substr(1);
@@ -190,6 +191,7 @@ uint32_t assembler_state::parse_num_arg(const std::string& str) {
     }
   }
 
+  /*
   if (str.rfind("tile_") == 0)
   {
     // Parse and return perticular col and row 32bit base address eg: tile_0_1
@@ -202,13 +204,28 @@ uint32_t assembler_state::parse_num_arg(const std::string& str) {
     uint32_t col = std::stoi(str.substr(col_start));
     uint32_t row = std::stoi(str.substr(row_start));
     return (((col & col_mask) << col_shift) | (row & row_mask));
-  } else if (str.rfind("0x") == 0)
+  }
+  */
+  static const regex kTileRe{R"(^tile_(\d+)_(\d+)$)"};
+  smatch m;
+  if (regex_match(str, m, kTileRe) && (m.size() == 3))
+  {
+    constexpr static size_t row_mask = 0x1F;
+    constexpr static size_t col_mask = 0x7F;
+    constexpr static size_t col_shift = 5;
+    const uint32_t col = std::stoi(m[1].str());
+    const uint32_t row = std::stoi(m[2].str());
+    return (((col & col_mask) << col_shift) | (row & row_mask));
+  }
+  else if (str.rfind("0x") == 0)
   { //parse hex string
-    return std::stoul(str.substr(2), nullptr , HEX_BASE);
-  } else if (is_number(str))
+    return std::stoul(str, nullptr , HEX_BASE);
+  }
+  else if (is_number(str))
   { //parse numeric string
     return std::stoul(str);
-  } else {
+  }
+  else {
     throw symbol_exception();
   }
 }

--- a/src/cpp/common/assembler_state.cpp
+++ b/src/cpp/common/assembler_state.cpp
@@ -7,9 +7,6 @@
 #include "regex_wrapper.h"
 #include "aiebu/aiebu_error.h"
 
-#include <functional>
-#include <unordered_map>
-
 namespace aiebu {
 
 assembler_state::
@@ -162,28 +159,7 @@ process(bool makeunique)
  * 3. If string is hex number string (start with "0x"): it return decimal equavalent
  * 4. If string is numeric string: it will convert to decimal
  */
-uint32_t assembler_state::parse_num_arg(const std::string& str) {
-  static const std::unordered_map<std::string, std::function<uint32_t(const std::string&)>> handlers = {
-    {"@", [this](const std::string& s) -> uint32_t {
-          //If string start with '@': it can be either pad name or label name
-          auto key = s.substr(1);
-          if (m_scratchpad.find(key) != m_scratchpad.end())
-            return m_scratchpad[key]->get_base() + m_scratchpad[key]->get_offset();
-          if (m_labelmap.find(key) != m_labelmap.end())
-            return m_labelmap[key]->get_pos();
-          throw error(error::error_code::invalid_asm, "Label " + key + " not present in label map\n");
-    }},
-    {"s2mm_", [this](const std::string& s) -> uint32_t { return get_actor(s); }},
-    {"mm2s_", [this](const std::string& s) -> uint32_t { return get_actor(s); }},
-    {"mem_s2mm_", [this](const std::string& s) -> uint32_t { return get_actor(s); }},
-    {"mem_mm2s_", [this](const std::string& s) -> uint32_t { return get_actor(s); }},
-    {"shim_s2mm_", [this](const std::string& s) -> uint32_t { return get_actor(s); }},
-    {"shim_mm2s_", [this](const std::string& s) -> uint32_t { return get_actor(s); }},
-    {"tile_s2mm_", [this](const std::string& s) -> uint32_t { return get_actor(s); }},
-    {"tile_mm2s_", [this](const std::string& s) -> uint32_t { return get_actor(s); }},
-    {"shim_ctrl_mm2s_", [this](const std::string& s) -> uint32_t { return get_actor(s); }}
-  };
-
+uint32_t assembler_state::parse_num_arg(const std::string &str) const {
   // check if its pad/label/actor
   for (const auto& [prefix, handler] : handlers) {
     if (str.rfind(prefix) == 0) {
@@ -191,30 +167,15 @@ uint32_t assembler_state::parse_num_arg(const std::string& str) {
     }
   }
 
-  /*
-  if (str.rfind("tile_") == 0)
-  {
-    // Parse and return perticular col and row 32bit base address eg: tile_0_1
-    constexpr static size_t col_start = 5;
-    constexpr static size_t len_of_underscore = 1;
-    constexpr static size_t row_mask = 0x1F;
-    constexpr static size_t col_mask = 0x7F;
-    constexpr static size_t col_shift = 5;
-    size_t row_start = col_start + len_of_underscore + str.substr(col_start).rfind("_");
-    uint32_t col = std::stoi(str.substr(col_start));
-    uint32_t row = std::stoi(str.substr(row_start));
-    return (((col & col_mask) << col_shift) | (row & row_mask));
-  }
-  */
   static const regex kTileRe{R"(^tile_(\d+)_(\d+)$)"};
   smatch m;
-  if (regex_match(str, m, kTileRe) && (m.size() == 3))
+  if ((str[0] == 't') && regex_match(str, m, kTileRe) && (m.size() == 3))
   {
     constexpr static size_t row_mask = 0x1F;
     constexpr static size_t col_mask = 0x7F;
     constexpr static size_t col_shift = 5;
-    const uint32_t col = std::stoi(m[1].str());
-    const uint32_t row = std::stoi(m[2].str());
+    const uint32_t col = std::stoi(m[1]);
+    const uint32_t row = std::stoi(m[2]);
     return (((col & col_mask) << col_shift) | (row & row_mask));
   }
   else if (str.rfind("0x") == 0)

--- a/src/cpp/common/assembler_state.h
+++ b/src/cpp/common/assembler_state.h
@@ -15,6 +15,8 @@
 #include <memory>
 #include <map>
 #include <set>
+#include <functional>
+#include <unordered_map>
 
 namespace aiebu {
 
@@ -145,6 +147,7 @@ protected:
   assembler_state(const assembler_state& rhs) = default;
   assembler_state& operator=(const assembler_state& rhs) = delete;
   assembler_state(assembler_state &&s) = default;
+
 public:
   std::shared_ptr<std::map<std::string, std::shared_ptr<isa_op>>> m_isa;
   std::vector<std::shared_ptr<asm_data>>& m_data;
@@ -182,7 +185,7 @@ public:
     return (m_scratchpad.find(label) != m_scratchpad.end());
   }
 
-  uint32_t parse_num_arg(const std::string& str);
+  uint32_t parse_num_arg(const std::string& str) const;
 
   void process(bool makeunique);
 
@@ -246,6 +249,29 @@ public:
   virtual symbol::patch_schema get_shim_dma_patching() const = 0;
   virtual symbol::patch_schema get_control_packet_patching() const = 0;
   virtual ~assembler_state() = default;
+
+private:
+  const std::unordered_map<std::string, std::function<uint32_t(const std::string&)>> handlers = {
+    {"@", [this](const std::string& s) -> uint32_t {
+      //If string start with '@': it can be either pad name or label name
+      auto key = s.substr(1);
+      if (m_scratchpad.find(key) != m_scratchpad.end())
+        return m_scratchpad[key]->get_base() + m_scratchpad[key]->get_offset();
+      if (m_labelmap.find(key) != m_labelmap.end())
+        return m_labelmap[key]->get_pos();
+      throw error(error::error_code::invalid_asm, "Label " + key + " not present in label map\n");
+    }},
+    {"s2mm_", [this](const std::string& s) -> uint32_t { return get_actor(s); }},
+    {"mm2s_", [this](const std::string& s) -> uint32_t { return get_actor(s); }},
+    {"mem_s2mm_", [this](const std::string& s) -> uint32_t { return get_actor(s); }},
+    {"mem_mm2s_", [this](const std::string& s) -> uint32_t { return get_actor(s); }},
+    {"shim_s2mm_", [this](const std::string& s) -> uint32_t { return get_actor(s); }},
+    {"shim_mm2s_", [this](const std::string& s) -> uint32_t { return get_actor(s); }},
+    {"tile_s2mm_", [this](const std::string& s) -> uint32_t { return get_actor(s); }},
+    {"tile_mm2s_", [this](const std::string& s) -> uint32_t { return get_actor(s); }},
+    {"shim_ctrl_mm2s_", [this](const std::string& s) -> uint32_t { return get_actor(s); }}
+  };
+
 };
 
 

--- a/src/cpp/common/writer.h
+++ b/src/cpp/common/writer.h
@@ -56,6 +56,13 @@ public:
     m_data.insert(m_data.end(), bytes.begin(), bytes.end());
   }
 
+  void
+  write_default_bytes(unsigned int count)
+  {
+    count += m_data.size();
+    m_data.resize(count, 0x0);
+  }
+
   virtual void reserve(size_t capacity);
 
   virtual uint32_t read_word(offset_type offset) const;

--- a/src/cpp/common/writer.h
+++ b/src/cpp/common/writer.h
@@ -59,8 +59,7 @@ public:
   void
   write_default_bytes(unsigned int count)
   {
-    count += m_data.size();
-    m_data.resize(count, 0x0);
+    m_data.resize(m_data.size() + count, 0x0);
   }
 
   virtual void reserve(size_t capacity);

--- a/src/cpp/encoder/aie2ps/aie2ps_encoder.cpp
+++ b/src/cpp/encoder/aie2ps/aie2ps_encoder.cpp
@@ -24,8 +24,7 @@ fill_scratchpad(std::shared_ptr<section_writer> padwriter, const std::map<std::s
       padwriter->write_bytes(content);
     } else {
       auto size = pad.second->get_size();
-      std::vector<uint8_t> zeros(size, 0x00);
-      padwriter->write_bytes(zeros);
+      padwriter->write_default_bytes(size);
     }
   }
 }
@@ -75,14 +74,14 @@ process(std::shared_ptr<preprocessed_output> input)
     if (coldata.second->m_scratchpad.size()) {
       auto padwriter = std::make_shared<section_writer>(get_PadSectionName(colnum), code_section::data);
       fill_scratchpad(padwriter, coldata.second->m_scratchpad);
-      twriter.push_back(padwriter); 
+      twriter.push_back(padwriter);
     }
 
     for (const auto& pair : ctrlpkt_id_map) {
       auto ctrlpktwriter = std::make_shared<section_writer>(pair.second, code_section::data);
       fill_controlpkt(ctrlpktwriter, ctrlpkt[pair.second]);
       fill_control_packet_symbols(ctrlpktwriter, totalsyms);
-      twriter.push_back(ctrlpktwriter); 
+      twriter.push_back(ctrlpktwriter);
     }
   }
   // Report (only if log level is info or higher)
@@ -225,7 +224,7 @@ page_writer(page& lpage, std::map<std::string, std::shared_ptr<scratchpad_info>>
       std::vector<uint8_t> ret = (*m_isa)[name]->serializer(args)
                                                ->serialize(page_state, dsym, colnum, pagenum);
       datawriter->write_bytes(ret);
-    } else 
+    } else
       throw error(error::error_code::internal_error, "Invalid operation: " + name + " in DATA section !!!");
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Number parsing was taking up 28% of time for the aie4 multi_graph testcase. Improve speed by removing redundant string operations and making the handler table static.. 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
valgrind analysis identified the hotspot.

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
ctest validated

#### Documentation impact (if any)
NA