### PR TITLE
Bugfix: Reduce latency when dtrace enabled

### DIFF
--- a/src/cpp/dtrace/pager/pager.cpp
+++ b/src/cpp/dtrace/pager/pager.cpp
@@ -572,7 +572,7 @@ copy_actions(const std::vector<uint32_t>& source, uint32_t offset,
  * This function returns an unordered map that maps action identifiers to their
  * corresponding locations for the given uC index.
  */
-std::unordered_map<uint32_t, uint32_t> 
+const std::unordered_map<uint32_t, uint32_t>&
 pager::
 get_action_location_mapping(uint32_t uC_index) const
 {

--- a/src/cpp/dtrace/pager/pager.h
+++ b/src/cpp/dtrace/pager/pager.h
@@ -57,7 +57,7 @@ public:
     std::unordered_map<uint32_t, std::unordered_map<uint32_t, uint32_t>> m_primary_action_location_mapping;
     std::unordered_map<uint32_t, uint32_t> m_secondary_action_location_mapping;
     std::vector<uint32_t> paging(const std::vector<uint32_t>& buffer, uint32_t uC_index);
-    std::unordered_map<uint32_t, uint32_t> get_action_location_mapping(uint32_t uC_index) const;
+    const std::unordered_map<uint32_t, uint32_t>& get_action_location_mapping(uint32_t uC_index) const;
 
 private:
     uint32_t m_page_size;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
The get_action_location_mapping() returned std::unordered_map<uint32_t, uint32_t> by value, meaning every call triggered a full copy of the map allocating new memory and copying all key-value pairs.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
when dtrace enabled run.wait() time increased from 2ms to 198ms. This is caused due to calling get_action_location_mapping()
in a loop which is copying the map for every iteration as it returns by value.
#### How problem was solved, alternative solutions (if any) and why they were rejected
Changed the return type to const std::unordered_map<uint32_t, uint32_t>& — a const reference — so the function returns a direct reference to the existing map stored in m_primary_action_location_mapping, with zero copying overhead.
#### Risks (if any) associated the changes in the commit
Low
#### What has been tested and how, request additional testing if necessary
Tested by enabling dtrace observed the run.wait() time improved after the fix.

Latency improved from 198ms to 3 ms when dtrace enabled.
#### Documentation impact (if any)
No