### PR TITLE
Switch to directly invoking ctest from build scripts 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,12 +121,12 @@ jobs:
     - name: Test (Linux)
       if: runner.os == 'Linux'
       run: |
-        cmake --build ${{github.workspace}}/build/Release --config Release --target test -j 4
+        ctest --test-dir ${{github.workspace}}/build/Release -C Release -j 4
 
     - name: Test (Windows)
       if: runner.os == 'Windows'
       run: |
-        cmake --build ${{github.workspace}}/build/WBuild --config Release --target run_tests -j 4
+        ctest --test-dir ${{github.workspace}}/build/WBuild -C Release -j 4
 
     - name: Package (Linux)
       if: runner.os == 'Linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
     - name: Test (Windows)
       if: runner.os == 'Windows'
       run: |
-        ctest --test-dir ${{github.workspace}}/build/WBuild -C Release -j 4
+        ctest --test-dir ${{github.workspace}}/build/WBuild -C Release -j 1
 
     - name: Package (Linux)
       if: runner.os == 'Linux'

--- a/build/build.sh
+++ b/build/build.sh
@@ -39,10 +39,10 @@ function compile {
     cmake --install $BUILDDIR/$config --config $config --prefix $BUILDDIR/$config/opt/xilinx/aiebu
 
     if [[ $run_test == "yes" ]]; then
-        cmake --build $BUILDDIR/$config --config $config --target test -j $CORE
+        ctest --test-dir $BUILDDIR/$config -C $config -j $CORE
 
         if [[ $run_memtest == "yes" ]]; then
-            cmake --build $BUILDDIR/$config --target test -j $CORE -- ARGS="-L memcheck -T memcheck"
+            ctest --test-dir $BUILDDIR/$config -C $config -L memcheck -T memcheck
         fi
     fi
 

--- a/build/build22.bat
+++ b/build/build22.bat
@@ -7,7 +7,6 @@ set SCRIPTDIR=%~dp0
 set SCRIPTDIR=%SCRIPTDIR:~0,-1%
 set BUILDDIR=%SCRIPTDIR%
 
-set CMAKEFLAGS=-DMSVC_PARALLEL_JOBS=%LOCAL_MSVC_PARALLEL_JOBS% -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 set DEBUG=1
 set RELEASE=1
 set CREATE_PACKAGE=0
@@ -92,8 +91,8 @@ if [%DEBUG%] == [1] (
    if errorlevel 1 (exit /B %errorlevel%)
 
    if [%NOCTEST%] == [0] (
-      echo cmake --build %BUILDDIR%\%PLATFORM% --config Debug --target run_tests -j %LOCAL_MSVC_PARALLEL_JOBS%
-      cmake --build %BUILDDIR%\%PLATFORM% --config Debug --target run_tests -j %LOCAL_MSVC_PARALLEL_JOBS%
+      echo ctest --test-dir %BUILDDIR%\%PLATFORM% -C Debug -j %LOCAL_MSVC_PARALLEL_JOBS%
+      ctest --test-dir %BUILDDIR%\%PLATFORM% -C Debug -j %LOCAL_MSVC_PARALLEL_JOBS%
       if errorlevel 1 (exit /B %errorlevel%)
    )
 )
@@ -108,8 +107,8 @@ if [%RELEASE%] == [1] (
    if errorlevel 1 (exit /B %errorlevel%)
 
    if [%NOCTEST%] == [0] (
-      echo cmake --build %BUILDDIR%\%PLATFORM% --config Release --target run_tests -j %LOCAL_MSVC_PARALLEL_JOBS%
-      cmake --build %BUILDDIR%\%PLATFORM% --config Release --target run_tests -j %LOCAL_MSVC_PARALLEL_JOBS%
+      echo ctest --test-dir %BUILDDIR%\%PLATFORM% -C Release -j %LOCAL_MSVC_PARALLEL_JOBS%
+      ctest --test-dir %BUILDDIR%\%PLATFORM% -C Release -j %LOCAL_MSVC_PARALLEL_JOBS%
       if errorlevel 1 (exit /B %errorlevel%)
    )
 

--- a/test/aie4-ctrlcode/compile_time/fused_hw_package_subgraph_0/CMakeLists.txt
+++ b/test/aie4-ctrlcode/compile_time/fused_hw_package_subgraph_0/CMakeLists.txt
@@ -1,16 +1,18 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2026 Advanced Micro Devices, Inc.
 
-if(CMAKE_BUILD_TYPE STREQUAL "Release")
+#if(CMAKE_BUILD_TYPE STREQUAL "Release")
 # Assemble control code ASM for very large asm of total size 286 MB arranged into 10K files
 add_test(NAME "aie4_compile_time"
   COMMAND aiebu-asm -t aie4_config -j "${CMAKE_CURRENT_SOURCE_DIR}/config.json" -o control.elf -f disabledump
+  CONFIGURATIONS Release
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
 # Compare the md5sum of ELF generated in aie4_compile_time test with that of the golden file
 add_test(NAME "aie4_compile_time_md5sum"
   COMMAND cmake -P "${AIEBU_SOURCE_DIR}/cmake/md5sum-compare.cmake" "${CMAKE_CURRENT_BINARY_DIR}/control.elf" "${CMAKE_CURRENT_SOURCE_DIR}/gold.md5"
+  CONFIGURATIONS Release
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
 set_tests_properties("aie4_compile_time_md5sum" PROPERTIES DEPENDS "aie4_compile_time")
-endif()
+#endif()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Enable feature full ctest by directly invoking ctest from build scripts. This enables
* Enable some tests in Release builds only
* Parallel jobs with -j

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA

#### How problem was solved, alternative solutions (if any) and why they were rejected
Updating CMake and build scripts

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Build and ctest validated

#### Documentation impact (if any)
NA