### PR TITLE
specify the mapping between the C API to the buffer_type

### DIFF
--- a/src/cpp/assembler/aiebu_assembler.cpp
+++ b/src/cpp/assembler/aiebu_assembler.cpp
@@ -510,6 +510,46 @@ get(const std::string& name, const std::vector<std::string>& paths) const
 
 }
 
+static bool
+convert_buffer_type(enum aiebu_assembler_buffer_type c_type,
+                    aiebu::aiebu_assembler::buffer_type& cpp_type)
+{
+  switch (c_type) {
+    case aiebu_assembler_buffer_type_blob_instr_dpu:
+      cpp_type = aiebu::aiebu_assembler::buffer_type::blob_instr_dpu;
+      return true;
+    case aiebu_assembler_buffer_type_blob_instr_prepost:
+      cpp_type = aiebu::aiebu_assembler::buffer_type::blob_instr_prepost;
+      return true;
+    case aiebu_assembler_buffer_type_blob_instr_transaction:
+      cpp_type = aiebu::aiebu_assembler::buffer_type::blob_instr_transaction;
+      return true;
+    case aiebu_assembler_buffer_type_blob_control_packet:
+      cpp_type = aiebu::aiebu_assembler::buffer_type::blob_control_packet;
+      return true;
+    case aiebu_assembler_buffer_type_asm_aie2ps:
+      cpp_type = aiebu::aiebu_assembler::buffer_type::asm_aie2ps;
+      return true;
+    case aiebu_assembler_buffer_type_asm_aie2:
+      cpp_type = aiebu::aiebu_assembler::buffer_type::asm_aie2;
+      return true;
+    case aiebu_assembler_buffer_type_asm_aie4:
+      cpp_type = aiebu::aiebu_assembler::buffer_type::asm_aie4;
+      return true;
+    case aiebu_assembler_buffer_type_aie2_config:
+      cpp_type = aiebu::aiebu_assembler::buffer_type::aie2_config;
+      return true;
+    case aiebu_assembler_buffer_type_aie2ps_config:
+      cpp_type = aiebu::aiebu_assembler::buffer_type::aie2ps_config;
+      return true;
+    case aiebu_assembler_buffer_type_aie4_config:
+      cpp_type = aiebu::aiebu_assembler::buffer_type::aie4_config;
+      return true;
+    default:
+      return false;
+  }
+}
+
 int
 aiebu_assembler_get_elf(enum aiebu_assembler_buffer_type type,
                         const char* buffer1,
@@ -524,6 +564,12 @@ aiebu_assembler_get_elf(enum aiebu_assembler_buffer_type type,
                         struct pm_ctrlpkt* pm_ctrlpkts,
                         size_t pm_ctrlpkt_size)
 {
+  aiebu::aiebu_assembler::buffer_type assembler_type;
+  if (!convert_buffer_type(type, assembler_type)) {
+    aiebu::log_error() << "Invalid buffer type\n";
+    return -(static_cast<int>(aiebu::error::error_code::invalid_buffer_type));
+  }
+
   int ret = 0;
   constexpr size_t MAX_ALLOC =
     static_cast<size_t>(std::numeric_limits<std::ptrdiff_t>::max());
@@ -569,7 +615,7 @@ aiebu_assembler_get_elf(enum aiebu_assembler_buffer_type type,
       mctrlpkt[pm_ctrlpkts[i].pm_id] = std::move(v);
     }
 
-    aiebu::aiebu_assembler handler((aiebu::aiebu_assembler::buffer_type)type, v1, v2, v3, vlibs, vlibpaths, mctrlpkt);
+    aiebu::aiebu_assembler handler(assembler_type, v1, v2, v3, vlibs, vlibpaths, mctrlpkt);
     velf = handler.get_elf();
 
     if (velf.size() > MAX_ALLOC)


### PR DESCRIPTION
#### Problem solved by the commit
Fixes incorrect C API to C++ `buffer_type` conversion in `aiebu_assembler_get_elf()`.  
Previously the code used a direct enum cast, which depends on enum ordinal alignment between `aiebu.h` and `aiebu_assembler.h`. After enum expansion, this assumption no longer held and could route requests to the wrong assembler path.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
- **Bug:** `aiebu_assembler_get_elf()` could misinterpret `type` and invoke wrong internal flow (e.g. `aie4_config` interpreted as `aie2_config`), causing runtime errors such as:
  - `No such node (TXN_ctrl_code_file)` in AIE4 flow.
- **Likely introduced by:** PR **#217** (`3d3c7900`, "os_abi changes from PR# 217"), which added new C++ enum entries in `aiebu_assembler::buffer_type` without equivalent C API enum alignment.
- **Discovery:** Observed in another environment running AIE4; logs showed AIE2 config parser expectation (`TXN_ctrl_code_file`) in an AIE4 flow, indicating enum mapping mismatch.

#### How problem was solved, alternative solutions (if any) and why they were rejected
- **Implemented fix:** Replaced C-style enum cast with explicit conversion function (`switch`-based mapping) from `enum aiebu_assembler_buffer_type` to `aiebu::aiebu_assembler::buffer_type`.
- Added validation path: unknown/unsupported C enum now returns `invalid_buffer_type` early with clear error logging.
- **Alternatives considered:**
  1. Reorder/renumber C++ enum values to restore implicit alignment.
  2. Extend C enum to mirror every C++ enum insertion and continue casting.
- **Why rejected:** Both alternatives are fragile and easy to break again with future enum changes; explicit mapping is stable, readable, and ABI-safe for C API consumers.

#### Risks (if any) associated the changes in the commit
- Low risk, localized to C API entry path.
- Potential risk only if new C enum values are added in future but mapping function is not updated; this fails safely now (`invalid_buffer_type`) instead of silently selecting wrong path.

#### What has been tested and how, request additional testing if necessary
- Code-level verification:
  - Confirmed removal of direct cast usage in `aiebu_assembler_get_elf()`.
  - Confirmed all currently defined C enum values are explicitly mapped.
  - Confirmed lints on modified file are clean.
- Recommended additional testing:
  - Run C API integration tests for all `aiebu_assembler_buffer_type` values.
  - Specifically re-run failing AIE4 scenario to confirm no `TXN_ctrl_code_file` path is taken.
  - Optional negative test: pass invalid enum value and confirm `invalid_buffer_type` is returned.