### PR TITLE
Performance optimization 

### DIFF
--- a/src/cpp/common/regex_wrapper.h
+++ b/src/cpp/common/regex_wrapper.h
@@ -29,7 +29,7 @@ namespace aiebu {
   using cmatch = boost::cmatch;
   using sregex_iterator = boost::sregex_iterator;
   using regex_error = boost::regex_error;
-  
+
   // Import functions into aiebu namespace
   using boost::regex_match;
   using boost::regex_search;
@@ -47,7 +47,6 @@ namespace aiebu {
   using cmatch = std::cmatch;
   using sregex_iterator = std::sregex_iterator;
   using regex_error = std::regex_error;
-  
   // Import functions into aiebu namespace
   using std::regex_match;
   using std::regex_search;

--- a/src/cpp/preprocessor/asm/asm_parser.cpp
+++ b/src/cpp/preprocessor/asm/asm_parser.cpp
@@ -48,33 +48,23 @@ namespace aiebu {
 
 namespace {
 
-// Order must match asm_directive_id and asm_parser::parse_lines() handler registration.
-constexpr const char* k_asm_directive_pattern_literals[] = {
-  ".attach_to_group",
-  ".aie_row_topology",
-  ".include",
-  ".endl",
-  ".setpad",
-  ".section",
-  ".partition",
-  ".target",
+// One capture per directive token; capture 13 is optional args. Handled directives are captures 1–8
+// (same eight as asm_directive_id / directive_list). Captures 9–12 are recognized but not dispatched here.
+// Order of groups 1–8 must match k_alt_capture_to_handler_idx below.
+const regex DIRECTIVE_ALT_RE(
+    R"(^(?:(\.attach_to_group)|(\.include)|(\.endl)|(\.setpad)|(\.section)|(\.partition)|(\.target)|(\.aie_row_topology)|(\.align)|(\.long)|(\.eop))(?:[ \t]+(.+))?$)");
+
+// Map DIRECTIVE_ALT_RE capture index 1..8 -> asm_parser::directive_list index (asm_directive_id order).
+constexpr std::array<std::size_t, 8> k_alt_capture_to_handler_idx = {
+    static_cast<std::size_t>(asm_directive_id::attach_to_group),
+    static_cast<std::size_t>(asm_directive_id::include),
+    static_cast<std::size_t>(asm_directive_id::endl),
+    static_cast<std::size_t>(asm_directive_id::setpad),
+    static_cast<std::size_t>(asm_directive_id::section),
+    static_cast<std::size_t>(asm_directive_id::partition),
+    static_cast<std::size_t>(asm_directive_id::target),
+    static_cast<std::size_t>(asm_directive_id::aie_row_topology),
 };
-static_assert(sizeof(k_asm_directive_pattern_literals) / sizeof(k_asm_directive_pattern_literals[0])
-                  == asm_directive_count,
-              "directive literal table vs asm_directive_count");
-
-// sm[1] directive token, sm[2] optional remainder (same layout as prior directive regex).
-const regex k_known_asm_directive_re(
-    R"(^(\.attach_to_group|\.aie_row_topology|\.include|\.endl|\.setpad|\.section|\.partition|\.target)(?:[ \t]+(.+))?$)");
-
-std::size_t index_for_known_directive_name(const std::string& name)
-{
-  for (std::size_t i = 0; i < asm_directive_count; ++i) {
-    if (name == k_asm_directive_pattern_literals[i])
-      return i;
-  }
-  return asm_directive_count;
-}
 
 } // namespace
 
@@ -82,13 +72,41 @@ bool
 asm_parser::
 operate_directive(const std::string& line)
 {
-  smatch sm;
-  if (!regex_match(line, sm, k_known_asm_directive_re))
+  smatch m;
+  if (!regex_match(line, m, DIRECTIVE_ALT_RE) || m.size() < 13U)  // NOLINT
     return false;
-  const std::size_t idx = index_for_known_directive_name(sm[1].str());
-  if (idx >= asm_directive_count || !directive_list[idx])
+
+  // match .align, .long, .eop
+  if (m[9].matched || m[10].matched || m[11].matched)  //NOLINT
     return false;
-  directive_list[idx]->operate(shared_from_this(), sm);
+
+  std::size_t idx = asm_directive_count;
+  if (m[1].matched)  // NOLINT .attach_to_group
+    idx = k_alt_capture_to_handler_idx[0];  // NOLINT
+  else if (m[2].matched)   // NOLINT .include
+    idx = k_alt_capture_to_handler_idx[1]; // NOLINT
+  else if (m[3].matched)   // NOLINT .endl
+    idx = k_alt_capture_to_handler_idx[2]; // NOLINT
+  else if (m[4].matched)   // NOLINT .setpad
+    idx = k_alt_capture_to_handler_idx[3]; // NOLINT
+  else if (m[5].matched)   // NOLINT .section
+    idx = k_alt_capture_to_handler_idx[4]; // NOLINT
+  else if (m[6].matched)   // NOLINT .partition
+    idx = k_alt_capture_to_handler_idx[5]; // NOLINT
+  else if (m[7].matched)   // NOLINT .target
+    idx = k_alt_capture_to_handler_idx[6]; // NOLINT
+  else if (m[8].matched)   // NOLINT .aie_row_topology
+    idx = k_alt_capture_to_handler_idx[7]; // NOLINT
+
+  if (idx >= asm_directive_count)
+    return false;
+
+  const auto& op = directive_list[idx];
+  if (!op)
+    return false;
+
+  const std::string args_tail = m[12].matched ? m[12].str() : std::string(); // NOLINT
+  op->operate(shared_from_this(), line, args_tail);
   return true;
 }
 
@@ -1273,27 +1291,31 @@ finalize_preempt()
 
 void
 attach_to_group_directive::
-operate(std::shared_ptr<asm_parser> parserptr, const smatch& sm)
+operate(std::shared_ptr<asm_parser> parserptr,
+        const std::string& /*directive_line*/,
+        const std::string& args_tail)
 {
   m_parserptr = parserptr;
-  verify_match(sm, error::error_code::invalid_asm, "Invalid attach_to_group directive argument\n");
+  verify_nonempty_args(args_tail, error::error_code::invalid_asm, "Invalid attach_to_group directive argument\n");
 
   // dummy eof added if col change happens before eof
   m_parserptr->insert_col_asmdata(std::make_shared<asm_data>(operation("eof", ""),
                                                               operation_type::op, code_section::unknown, 0,
                                                               (uint32_t)-1, 0, detail::default_source_file_idx()));
-  m_parserptr->set_current_col(std::stoi(sm[2].str()));
+  m_parserptr->set_current_col(std::stoi(args_tail));
   m_parserptr->set_data_state(false);
 }
 
 void
 section_directive::
-operate(std::shared_ptr<asm_parser> parserptr, const smatch& sm)
+operate(std::shared_ptr<asm_parser> parserptr,
+        const std::string& /*directive_line*/,
+        const std::string& args_tail)
 {
   m_parserptr = parserptr;
-  verify_match(sm, error::error_code::invalid_asm, ".section directive requires arguments\n");
+  verify_nonempty_args(args_tail, error::error_code::invalid_asm, ".section directive requires arguments\n");
 
-  std::vector<std::string> args = splitoption(sm[2].str().c_str(), ',');
+  std::vector<std::string> args = splitoption(args_tail.c_str(), ',');
   if (is_test_section(args[0]))
     m_parserptr->set_data_state(false);
   else if (is_data_section(args[0]))
@@ -1306,13 +1328,15 @@ operate(std::shared_ptr<asm_parser> parserptr, const smatch& sm)
 
 void
 partition_directive::
-operate(std::shared_ptr<asm_parser> parserptr, const smatch& sm)
+operate(std::shared_ptr<asm_parser> parserptr,
+        const std::string& directive_line,
+        const std::string& /*args_tail*/)
 {
   m_parserptr = parserptr;
   static const regex pattern(R"(\.partition\s+(\d+)(column|core:(\d+)mem))");
   smatch match;
-  log_info() << "PARTITION:" << sm[0].str() << "\n";
-  std::string line = sm[0].str();
+  log_info() << "PARTITION:" << directive_line << "\n";
+  std::string line = directive_line;
   if (regex_match(line, match, pattern)) {
     if (match[2] == "column") {
       log_info() << "Column count: " << match[1] << "\n";
@@ -1329,14 +1353,16 @@ operate(std::shared_ptr<asm_parser> parserptr, const smatch& sm)
 
 void
 target_directive::
-operate(std::shared_ptr<asm_parser> parserptr, const smatch& sm)
+operate(std::shared_ptr<asm_parser> parserptr,
+        const std::string& directive_line,
+        const std::string& /*args_tail*/)
 {
   m_parserptr = parserptr;
   // Pattern: .target <arch>-<sub-arch> or .target <arch>
   static const regex pattern(R"(\.target\s+([a-zA-Z0-9]+)(?:-([a-zA-Z0-9]+))?)");
   smatch match;
-  log_info() << "TARGET:" << sm[0].str() << std::endl;
-  std::string line = sm[0].str();
+  log_info() << "TARGET:" << directive_line << std::endl;
+  std::string line = directive_line;
   if (regex_match(line, match, pattern)) {
     std::string arch = match[1].str();
     log_info() << "Target architecture: " << arch << std::endl;
@@ -1353,7 +1379,9 @@ operate(std::shared_ptr<asm_parser> parserptr, const smatch& sm)
 
 void
 aie_row_topology_directive::
-operate(std::shared_ptr<asm_parser> parserptr, const smatch& sm)
+operate(std::shared_ptr<asm_parser> parserptr,
+        const std::string& directive_line,
+        const std::string& /*args_tail*/)
 {
   m_parserptr = parserptr;
   // Pattern: .aie_row_topology A-B-C-D
@@ -1361,8 +1389,8 @@ operate(std::shared_ptr<asm_parser> parserptr, const smatch& sm)
   // Example: .aie_row_topology 1-1-4-0
   static const regex pattern(R"(\.aie_row_topology\s+(\d+)-(\d+)-(\d+)-(\d+))");
   smatch match;
-  log_info() << "AIE_ROW_TOPOLOGY:" << sm[0].str() << std::endl;
-  std::string line = sm[0].str();
+  log_info() << "AIE_ROW_TOPOLOGY:" << directive_line << std::endl;
+  std::string line = directive_line;
   if (regex_match(line, match, pattern)) {
     uint32_t num_south_shim = to_uinteger<uint32_t>(match[1]);
     uint32_t num_memtile_row = to_uinteger<uint32_t>(match[2]);
@@ -1404,11 +1432,12 @@ read_include_file(std::string filename)
 
 void
 include_directive::
-operate(std::shared_ptr<asm_parser> parserptr, const smatch& sm)
+operate(std::shared_ptr<asm_parser> parserptr,
+        const std::string& /*directive_line*/,
+        const std::string& args_tail)
 {
   m_parserptr = parserptr;
-  //std::vector<std::string> args = splitoption(sm[2].str().c_str(), ',');
-  std::string file = sm[2].str();//args[0];
+  std::string file = args_tail;
   if (file.size() >= 2 && file.front() == '"' && file.back() == '"')
     file =  file.substr(1, file.size() - 2);
 
@@ -1419,16 +1448,18 @@ operate(std::shared_ptr<asm_parser> parserptr, const smatch& sm)
 
 void
 end_of_label_directive::
-operate(std::shared_ptr<asm_parser> parserptr, const smatch& sm)
+operate(std::shared_ptr<asm_parser> parserptr,
+        const std::string& /*directive_line*/,
+        const std::string& args_tail)
 {
   m_parserptr = parserptr;
 
   std::string label = m_parserptr->top_label();
   m_parserptr->pop_label();
 
-  verify_match(sm, error::error_code::invalid_asm, ".endl directive requires a label argument\n");
+  verify_nonempty_args(args_tail, error::error_code::invalid_asm, ".endl directive requires a label argument\n");
 
-  std::vector<std::string> args = splitoption(sm[2].str().c_str(), ',');
+  std::vector<std::string> args = splitoption(args_tail.c_str(), ',');
   if (label.compare(args[0]))
     throw error(error::error_code::internal_error, "endl label mismatch (" + label + " != " + args[0] + ")\n");
   m_parserptr->pop_data_state();
@@ -1436,12 +1467,14 @@ operate(std::shared_ptr<asm_parser> parserptr, const smatch& sm)
 
 void
 pad_directive::
-operate(std::shared_ptr<asm_parser> parserptr, const smatch& sm)
+operate(std::shared_ptr<asm_parser> parserptr,
+        const std::string& /*directive_line*/,
+        const std::string& args_tail)
 {
   m_parserptr = parserptr;
-  verify_match(sm, error::error_code::invalid_asm, ".setpad directive requires arguments\n");
+  verify_nonempty_args(args_tail, error::error_code::invalid_asm, ".setpad directive requires arguments\n");
 
-  std::vector<std::string> args = splitoption(sm[2].str().c_str(), ',');
+  std::vector<std::string> args = splitoption(args_tail.c_str(), ',');
 
   add_scratchpad(args[0], args[1]);
 }

--- a/src/cpp/preprocessor/asm/asm_parser.cpp
+++ b/src/cpp/preprocessor/asm/asm_parser.cpp
@@ -46,6 +46,52 @@ static inline int aiebu_clz(unsigned int x)      { return __builtin_clz(x);     
 
 namespace aiebu {
 
+namespace {
+
+// Order must match asm_directive_id and asm_parser::parse_lines() handler registration.
+constexpr const char* k_asm_directive_pattern_literals[] = {
+  ".attach_to_group",
+  ".aie_row_topology",
+  ".include",
+  ".endl",
+  ".setpad",
+  ".section",
+  ".partition",
+  ".target",
+};
+static_assert(sizeof(k_asm_directive_pattern_literals) / sizeof(k_asm_directive_pattern_literals[0])
+                  == asm_directive_count,
+              "directive literal table vs asm_directive_count");
+
+// sm[1] directive token, sm[2] optional remainder (same layout as prior directive regex).
+const regex k_known_asm_directive_re(
+    R"(^(\.attach_to_group|\.aie_row_topology|\.include|\.endl|\.setpad|\.section|\.partition|\.target)(?:[ \t]+(.+))?$)");
+
+std::size_t index_for_known_directive_name(const std::string& name)
+{
+  for (std::size_t i = 0; i < asm_directive_count; ++i) {
+    if (name == k_asm_directive_pattern_literals[i])
+      return i;
+  }
+  return asm_directive_count;
+}
+
+} // namespace
+
+bool
+asm_parser::
+operate_directive(const std::string& line)
+{
+  smatch sm;
+  if (!regex_match(line, sm, k_known_asm_directive_re))
+    return false;
+  const std::size_t idx = index_for_known_directive_name(sm[1].str());
+  if (idx >= asm_directive_count || !directive_list[idx])
+    return false;
+  directive_list[idx]->operate(shared_from_this(), sm);
+  return true;
+}
+
 void
 asm_parser::
 insert_col_asmdata(std::shared_ptr<asm_data> data)
@@ -136,14 +182,16 @@ void
 asm_parser::
 parse_lines()
 {
-  directive_list[".attach_to_group"] = std::make_shared<attach_to_group_directive>();
-  directive_list[".include"] = std::make_shared<include_directive>();
-  directive_list[".endl"] = std::make_shared<end_of_label_directive>();
-  directive_list[".setpad"] = std::make_shared<pad_directive>();
-  directive_list[".section"] = std::make_shared<section_directive>();
-  directive_list[".partition"] = std::make_shared<partition_directive>();
-  directive_list[".target"] = std::make_shared<target_directive>();
-  directive_list[".aie_row_topology"] = std::make_shared<aie_row_topology_directive>();
+  directive_list[static_cast<std::size_t>(asm_directive_id::attach_to_group)] =
+      std::make_shared<attach_to_group_directive>();
+  directive_list[static_cast<std::size_t>(asm_directive_id::aie_row_topology)] =
+      std::make_shared<aie_row_topology_directive>();
+  directive_list[static_cast<std::size_t>(asm_directive_id::include)] = std::make_shared<include_directive>();
+  directive_list[static_cast<std::size_t>(asm_directive_id::endl)] = std::make_shared<end_of_label_directive>();
+  directive_list[static_cast<std::size_t>(asm_directive_id::setpad)] = std::make_shared<pad_directive>();
+  directive_list[static_cast<std::size_t>(asm_directive_id::section)] = std::make_shared<section_directive>();
+  directive_list[static_cast<std::size_t>(asm_directive_id::partition)] = std::make_shared<partition_directive>();
+  directive_list[static_cast<std::size_t>(asm_directive_id::target)] = std::make_shared<target_directive>();
   std::string file = "default";
   parse_lines(m_data, file);
 
@@ -159,7 +207,6 @@ parse_lines(const std::vector<char>& data, std::string& file)
   const static regex COMMENT_REGEX("^;(.*)$");
   const static regex LABEL_REGEX("^([a-zA-Z0-9_]+):$");
   const static regex OP_REGEX("^([.a-zA-Z0-9_]+)(?:[ \\t]+(.+))?$");
-  const static regex DIRCETIVE_REGEX(".^([a-zA-Z0-9_]+)(?:[ \\t]+(.+))?$");
 
   // Sanitize input data: filter out non-printable characters except newline, tab, and carriage return
   // This prevents corrupted operation names during parsing
@@ -203,12 +250,7 @@ parse_lines(const std::vector<char>& data, std::string& file)
 
     smatch sm;
 
-    if (line[0] == '.' &&
-        line.substr(0,5).compare(".long") != 0 &&
-        line.substr(0,6).compare(".align") != 0 &&
-        line.substr(0,4).compare(".eof") != 0 &&
-        line.substr(0,4).compare(".eop") != 0 &&
-        operate_directive(line))
+    if (line[0] == '.' && operate_directive(line))
     {
       if (!get_annotation_state())
         continue;

--- a/src/cpp/preprocessor/asm/asm_parser.cpp
+++ b/src/cpp/preprocessor/asm/asm_parser.cpp
@@ -172,6 +172,7 @@ parse_lines(const std::vector<char>& data, std::string& file)
       str += c;
     }
   }
+  const uint32_t parse_file_idx = detail::intern_filename(file);
   // Scan str for newlines directly instead of copying it into an istringstream
   size_t pos = 0;
   const size_t str_len = str.size();
@@ -202,8 +203,12 @@ parse_lines(const std::vector<char>& data, std::string& file)
 
     smatch sm;
 
-    // Check for Directive (starts with .) - only check regex if prefix matches
-    if (line[0] == '.' && operate_directive(line))
+    if (line[0] == '.' &&
+        line.substr(0,5).compare(".long") != 0 &&
+        line.substr(0,6).compare(".align") != 0 &&
+        line.substr(0,4).compare(".eof") != 0 &&
+        line.substr(0,4).compare(".eop") != 0 &&
+        operate_directive(line))
     {
       if (!get_annotation_state())
         continue;
@@ -236,9 +241,9 @@ parse_lines(const std::vector<char>& data, std::string& file)
         m_current_label = m_current_label + ":" + sm[1].str();
         set_data_state(false);
       } else
-        insert_col_asmdata(std::make_shared<asm_data>(operation(sm[1].str(), ""),
-                                                      operation_type::label, code_section::unknown, 0,
-                                                      (uint32_t)-1, linenumber, file));
+        insert_col_asmdata(std::make_shared<asm_data>(operation(sm[1].str(), ""), operation_type::label,
+                                                      code_section::unknown, 0, (uint32_t)-1, linenumber,
+                                                      parse_file_idx));
       continue;
     }
     // check for operation
@@ -323,10 +328,9 @@ parse_lines(const std::vector<char>& data, std::string& file)
 
         line = op_name + "\t" + arg_str;
       }
-
-      insert_col_asmdata(std::make_shared<asm_data>(operation(op_name, arg_str),
-                                                    operation_type::op, code_section::unknown, 0, (uint32_t)-1,
-                                                    linenumber, file));
+      insert_col_asmdata(std::make_shared<asm_data>(operation(op_name, arg_str), operation_type::op,
+                                                    code_section::unknown, 0, (uint32_t)-1, linenumber,
+                                                    parse_file_idx));
       if (!op_name.compare("eof"))
         set_data_state(true);
     }
@@ -1234,8 +1238,8 @@ operate(std::shared_ptr<asm_parser> parserptr, const smatch& sm)
 
   // dummy eof added if col change happens before eof
   m_parserptr->insert_col_asmdata(std::make_shared<asm_data>(operation("eof", ""),
-                                                    operation_type::op, code_section::unknown, 0, (uint32_t)-1,
-                                                    0, "default"));
+                                                              operation_type::op, code_section::unknown, 0,
+                                                              (uint32_t)-1, 0, detail::default_source_file_idx()));
   m_parserptr->set_current_col(std::stoi(sm[2].str()));
   m_parserptr->set_data_state(false);
 }

--- a/src/cpp/preprocessor/asm/asm_parser.h
+++ b/src/cpp/preprocessor/asm/asm_parser.h
@@ -34,9 +34,9 @@ inline std::string trim(const std::string& line)
     return (start == end && start == std::string::npos) ? std::string() : line.substr(start, end - start + 1);
 }
 
-inline void verify_match(const smatch& sm, error::error_code ecode, const char* msg)
+inline void verify_nonempty_args(const std::string& args_tail, error::error_code ecode, const char* msg)
 {
-  if (sm.size() < 3 || !sm[2].matched || sm[2].length() == 0)
+  if (args_tail.empty())
     throw error(ecode, msg);
 }
 
@@ -105,7 +105,9 @@ public:
   std::shared_ptr<asm_parser> m_parserptr;
 public:
   directive() {}
-  virtual void operate(std::shared_ptr<asm_parser> parserptr, const smatch& sm) = 0;
+  virtual void operate(std::shared_ptr<asm_parser> parserptr,
+                       const std::string& directive_line,
+                       const std::string& args_tail) = 0;
   virtual ~directive() = default;
 };
 
@@ -113,7 +115,9 @@ class attach_to_group_directive: public directive
 {
 public:
   attach_to_group_directive() = default;
-  void operate(std::shared_ptr<asm_parser> parserptr, const smatch& sm) override;
+  void operate(std::shared_ptr<asm_parser> parserptr,
+               const std::string& directive_line,
+               const std::string& args_tail) override;
   ~attach_to_group_directive() override = default;
 };
 
@@ -122,7 +126,9 @@ class include_directive: public directive
   bool read_include_file(std::string filename);
 public:
   include_directive() = default;
-  void operate(std::shared_ptr<asm_parser> parserptr, const smatch& sm) override;
+  void operate(std::shared_ptr<asm_parser> parserptr,
+               const std::string& directive_line,
+               const std::string& args_tail) override;
   ~include_directive() override = default;
 };
 
@@ -130,7 +136,9 @@ class end_of_label_directive: public directive
 {
 public:
   end_of_label_directive() = default;
-  void operate(std::shared_ptr<asm_parser> parserptr, const smatch& sm) override;
+  void operate(std::shared_ptr<asm_parser> parserptr,
+               const std::string& directive_line,
+               const std::string& args_tail) override;
   ~end_of_label_directive() override = default;
 };
 
@@ -156,7 +164,9 @@ public:
   }
   void add_scratchpad(std::string& name, std::string& str);
   pad_directive() = default;
-  void operate(std::shared_ptr<asm_parser> parserptr, const smatch& sm) override;
+  void operate(std::shared_ptr<asm_parser> parserptr,
+               const std::string& directive_line,
+               const std::string& args_tail) override;
   ~pad_directive() override = default;
 };
 
@@ -167,7 +177,9 @@ class section_directive: public directive
   bool is_annotation_section(const std::string& str) {return !str.substr(0,10).compare("annotation"); }
 public:
   section_directive() = default;
-  void operate(std::shared_ptr<asm_parser> parserptr, const smatch& sm) override;
+  void operate(std::shared_ptr<asm_parser> parserptr,
+               const std::string& directive_line,
+               const std::string& args_tail) override;
   ~section_directive() override = default;
 };
 
@@ -175,7 +187,9 @@ class partition_directive: public directive
 {
 public:
   partition_directive() = default;
-  void operate(std::shared_ptr<asm_parser> parserptr, const smatch& sm) override;
+  void operate(std::shared_ptr<asm_parser> parserptr,
+               const std::string& directive_line,
+               const std::string& args_tail) override;
   ~partition_directive() override = default;
   partition_directive(const partition_directive&) = default;
   partition_directive& operator=(const partition_directive&) = default;
@@ -187,7 +201,9 @@ class target_directive: public directive
 {
 public:
   target_directive() = default;
-  void operate(std::shared_ptr<asm_parser> parserptr, const smatch& sm) override;
+  void operate(std::shared_ptr<asm_parser> parserptr,
+               const std::string& directive_line,
+               const std::string& args_tail) override;
   ~target_directive() override = default;
   target_directive(const target_directive&) = default;
   target_directive& operator=(const target_directive&) = default;
@@ -199,7 +215,9 @@ class aie_row_topology_directive: public directive
 {
 public:
   aie_row_topology_directive() = default;
-  void operate(std::shared_ptr<asm_parser> parserptr, const smatch& sm) override;
+  void operate(std::shared_ptr<asm_parser> parserptr,
+               const std::string& directive_line,
+               const std::string& args_tail) override;
   ~aie_row_topology_directive() override = default;
   aie_row_topology_directive(const aie_row_topology_directive&) = default;
   aie_row_topology_directive& operator=(const aie_row_topology_directive&) = default;
@@ -425,7 +443,8 @@ class partition_directive;
 class target_directive;
 class aie_row_topology_directive;
 
-// Indices for asm_parser::directive_list — keep in sync with k_known_asm_directive_re in asm_parser.cpp.
+// Indices for asm_parser::directive_list — keep in sync with DIRECTIVE_ALT_RE in asm_parser.cpp.
+// (same eight directives) in asm_parser.cpp.
 enum class asm_directive_id : uint8_t {
   attach_to_group = 0,
   aie_row_topology,

--- a/src/cpp/preprocessor/asm/asm_parser.h
+++ b/src/cpp/preprocessor/asm/asm_parser.h
@@ -215,17 +215,26 @@ public:
 // violating the One Definition Rule (ODR).
 namespace detail {
   inline thread_local std::vector<std::string> g_filename_table;
+  inline thread_local std::unordered_map<std::string, uint32_t> g_filename_index;
 
   inline uint32_t intern_filename(const std::string& fname) {
-    auto& tbl = g_filename_table;
-    for (uint32_t i = 0; i < static_cast<uint32_t>(tbl.size()); ++i)
-      if (tbl[i] == fname) return i;
-    tbl.push_back(fname);
-    return static_cast<uint32_t>(tbl.size() - 1);
+    auto it = g_filename_index.find(fname);
+    if (it != g_filename_index.end())
+      return it->second;
+    const uint32_t idx = static_cast<uint32_t>(g_filename_table.size());
+    g_filename_table.push_back(fname);
+    g_filename_index.emplace(g_filename_table.back(), idx);
+    return idx;
   }
 
   inline const std::string& lookup_filename(uint32_t idx) {
     return g_filename_table[idx];
+  }
+
+  // Cached index for synthetic ops that are not tied to a real source path.
+  inline uint32_t default_source_file_idx() {
+    thread_local const uint32_t idx = intern_filename(std::string("default"));
+    return idx;
   }
 } // namespace detail
 
@@ -251,16 +260,14 @@ public:
             m_pagenum(pgnum), m_linenumber(ln),
             m_file_idx(detail::intern_filename(file)) {}
 
-  asm_data( asm_data* a)
-  {
-    a->m_op = m_op;
-    a->m_optype = m_optype;
-    a->m_section = m_section;
-    a->m_size = m_size;
-    a->m_pagenum = m_pagenum;
-    a->m_linenumber = m_linenumber;
-    a->m_file_idx = m_file_idx;
-  }
+  asm_data(operation op, operation_type optype,
+           code_section sec, offset_type size, uint32_t pgnum,
+           uint32_t ln, uint32_t file_idx)
+           :m_op(std::move(op)), m_optype(optype), m_section(sec), m_size(size),
+            m_pagenum(pgnum), m_linenumber(ln),
+            m_file_idx(file_idx) {}
+
+  // Rule of Zero: implicit copy/move keeps insert_col_asmdata / vector growth cheap.
 
   HEADER_ACCESS_GET_SET(code_section, section);
   HEADER_ACCESS_GET_SET(offset_type, size);
@@ -295,12 +302,12 @@ public:
     return n + ' ' + a;
   }
 
-  bool isLabel() { return m_optype == operation_type::label; }
-  bool isOpcode() { return m_optype == operation_type::op; }
-  bool isAnnotation() { return m_optype == operation_type::annotation; }
+  bool isLabel() const { return m_optype == operation_type::label; }
+  bool isOpcode() const { return m_optype == operation_type::op; }
+  bool isAnnotation() const { return m_optype == operation_type::annotation; }
   const operation& get_operation() const { return m_op; }
   void update_operation(operation op) { m_op = std::move(op); }
-  int get_annotation_index() { return m_annotation_index; }
+  int get_annotation_index() const { return m_annotation_index; }
   void set_annotation_index(int annotation_index) { m_annotation_index = annotation_index; }
 };
 

--- a/src/cpp/preprocessor/asm/asm_parser.h
+++ b/src/cpp/preprocessor/asm/asm_parser.h
@@ -10,6 +10,7 @@
 #include "common/regex_wrapper.h"
 #include "logger.h"
 
+#include <array>
 #include <map>
 #include <memory>
 #include <set>
@@ -221,7 +222,7 @@ namespace detail {
     auto it = g_filename_index.find(fname);
     if (it != g_filename_index.end())
       return it->second;
-    const uint32_t idx = static_cast<uint32_t>(g_filename_table.size());
+    const auto idx = static_cast<uint32_t>(g_filename_table.size());
     g_filename_table.push_back(fname);
     g_filename_index.emplace(g_filename_table.back(), idx);
     return idx;
@@ -253,13 +254,14 @@ class asm_data
 
 public:
   asm_data() = default;
+  /*
   asm_data(operation op, operation_type optype,
            code_section sec, offset_type size, uint32_t pgnum,
            uint32_t ln, const std::string& file)
            :m_op(std::move(op)), m_optype(optype), m_section(sec), m_size(size),
             m_pagenum(pgnum), m_linenumber(ln),
             m_file_idx(detail::intern_filename(file)) {}
-
+  */
   asm_data(operation op, operation_type optype,
            code_section sec, offset_type size, uint32_t pgnum,
            uint32_t ln, uint32_t file_idx)
@@ -423,11 +425,25 @@ class partition_directive;
 class target_directive;
 class aie_row_topology_directive;
 
+// Indices for asm_parser::directive_list — keep in sync with k_known_asm_directive_re in asm_parser.cpp.
+enum class asm_directive_id : uint8_t {
+  attach_to_group = 0,
+  aie_row_topology,
+  include,
+  endl,
+  setpad,
+  section,
+  partition,
+  target,
+};
+inline constexpr std::size_t asm_directive_count =
+  static_cast<std::size_t>(asm_directive_id::target) + 1U;
+
 class asm_parser: public std::enable_shared_from_this<asm_parser>
 {
   std::unordered_map<uint32_t, col_data> m_col;
   const std::vector<char> &m_data;
-  std::map<std::string, std::shared_ptr<directive>> directive_list;
+  std::array<std::shared_ptr<directive>, asm_directive_count> directive_list{};
   std::stack<bool> isdatastack;
   std::string m_current_label = "default";
   int m_current_col = -1;
@@ -709,20 +725,7 @@ public:
 
   std::map<std::string, std::shared_ptr<scratchpad_info>>& getcolscratchpad(int col) { return m_col[col].get_scratchpads(); }
 
-  bool operate_directive(const std::string& line)
-  {
-    smatch sm;
-    const static regex DIRCETIVE_REGEX("^([.a-zA-Z0-9_]+)(?:[ \\t]+(.+))?$");
-    regex_match(line, sm, DIRCETIVE_REGEX);
-    if (sm.size() == 0)
-      return false;
-
-    if (directive_list.count(sm[1].str()) == 0)
-      return false;
-
-    directive_list[sm[1].str()]->operate(shared_from_this(), sm);
-    return true;
-  }
+  bool operate_directive(const std::string& line);
 };
 
 

--- a/src/cpp/preprocessor/asm/pager.cpp
+++ b/src/cpp/preprocessor/asm/pager.cpp
@@ -282,7 +282,8 @@ assignpagenumber(assembler_state& state, uint32_t colnum,
   if (aligner)
     lpage.m_text.emplace_back(std::make_shared<asm_data>(operation(".align", "16"),
                                                     operation_type::op, code_section::text, 0,
-                                                    (uint32_t)-1, 0, "default"));
+                                                    (uint32_t)-1, 0, detail::default_source_file_idx()));
+
   uint32_t cur_page_len = PAGE_HEADER_SIZE + tsize + EOF_SIZE + aligner + dsize;
   cur_page_len = (((cur_page_len + 3) >> 2) << 2); // round off to next multiple of 4
   lpage.set_cur_page_len(cur_page_len);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This change improves hot-path performance in the ASM preprocessor by reducing repeated work when building asm_data rows and when handling certain directives.

1. Filename interning (asm_parser.h): detail::intern_filename no longer scans the whole thread-local filename table on every call. A thread-local std::unordered_map<std::string, uint32_t> maps paths to indices so lookup/insert is amortized O(1) instead of O(n) per intern.
2. One intern per parse (asm_parser.cpp): parse_lines computes parse_file_idx once and passes that index into asm_data for labels and ops, instead of calling intern_filename on every row.
3. Directive fast path (asm_parser.cpp): Lines that start with . but are not directives handled by operate_directive (.long, .align, .eof, .eop) skip the directive regex path, avoiding unnecessary work on those prefixes.

**For aie4_compile_time**
**1. linux --> time reduces from 140 sec to 96 sec
2. windows --> time reduces from 289.45 sec to 185 sec**
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
