### PR TITLE
Drop aie-rt as a submodule for aiebu

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,5 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.
-[submodule "lib/aie-rt"]
-	path = lib/aie-rt
-	url = https://github.com/Xilinx/aie-rt.git
-	branch = release/main_aig
 [submodule "src/cpp/ELFIO"]
 	path = src/cpp/ELFIO
 	url = https://github.com/serge1/ELFIO.git

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,6 @@ Build Dependencies
  * Boost (header only) minimum version supported is 1.76
  * cxxopts (included as submodule)
  * ELFIO (included as submodule)
- * AMD aie-rt (included as submodule)
 
 Python Dependencies
 -------------------

--- a/src/cpp/aie-rt/README.rst
+++ b/src/cpp/aie-rt/README.rst
@@ -2,21 +2,27 @@
 
 ..
     comment:: SPDX-License-Identifier: MIT
-    comment:: Copyright (C) 2025 Advanced Micro Devices, Inc.
+    comment:: Copyright (C) 2025-2026 Advanced Micro Devices, Inc.
 
 =====================
 AIE-RT Usage in AIEBU
 =====================
 
-AIEBU uses a copy of aie-rt *header* files that are copied from the aie-rt
-repository and added here. Note that aiebu does use the source of aie-rt
-and hence does not link with aie-rt library.
+aiebu uses a local copy of the aie-rt *header files*, which are taken directly
+from the aie-rt repository and checked into this directory.
 
-Note to AIEBU Maintainers
-=========================
+Note that aiebu does **not** use the aie-rt source code and therefore does not
+link against the aie-rt library. Only the aie2p opcode definitions are consumed
+from aie-rt. The aie2ps and aie4 opcode definitions are implemented directly
+within aiebu.
 
-If there is a aie-rt opcode update please copy the updated aie-rt header files
-to this direcotry and update the HASH information below
+===========================
+Notes for AIEBU Maintainers
+===========================
+
+When aie2p opcode definitions are updated in aie-rt, please copy the updated
+aie-rt header files into this directory and update the HASH information listed
+below to reflect the new version.
 
 AIE-RT Snapshot
 ===============


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
aiebu's dependency on aie-rt was removed sometime back. Now remove aie-rt as a submodule.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA

#### How problem was solved, alternative solutions (if any) and why they were rejected
git submodule updates

#### Risks (if any) associated the changes in the commit
All users of aiebu already use their own copy of aie-rt

#### What has been tested and how, request additional testing if necessary
build and ctest validated

#### Documentation impact (if any)
None