### PR TITLE
dynamic tracing compiler refactor for json output support

### DIFF
--- a/src/cpp/dtrace/CMakeLists.txt
+++ b/src/cpp/dtrace/CMakeLists.txt
@@ -46,10 +46,6 @@ set_target_properties(dtrace_library_objects PROPERTIES
   POSITION_INDEPENDENT_CODE ON
   )
 
-add_library(cert_dtrace SHARED
-  $<TARGET_OBJECTS:dtrace_library_objects>
-  )
-
 add_library(cert_dtrace_static STATIC
   $<TARGET_OBJECTS:dtrace_library_objects>
   )
@@ -60,8 +56,8 @@ if (NOT WIN32)
   set_target_properties(cert_dtrace_static PROPERTIES OUTPUT_NAME "cert_dtrace")
 endif()
 
-# As long as we support static linking of targets that depend on static cert,
-# the cert static library must be released.
+# As long as we support static linking of targets that depend on static cert dtrace,
+# the cert dtrace static library must be released.
 install(TARGETS cert_dtrace_static
   EXPORT aiebu-targets
   ARCHIVE DESTINATION ${AIEBU_INSTALL_LIB_DIR} COMPONENT ${AIEBU_DEV_COMPONENT}

--- a/src/cpp/dtrace/action/action_control.cpp
+++ b/src/cpp/dtrace/action/action_control.cpp
@@ -20,7 +20,6 @@ action(uint32_t probe_type, std::string probe_name)
     , m_probe_name(std::move(probe_name))
     , m_control_location(0)
     , m_mem_location(0)
-    , m_output_format(dtrace::get_output_format())
 {
 }
 

--- a/src/cpp/dtrace/action/action_control.cpp
+++ b/src/cpp/dtrace/action/action_control.cpp
@@ -20,6 +20,7 @@ action(uint32_t probe_type, std::string probe_name)
     , m_probe_name(std::move(probe_name))
     , m_control_location(0)
     , m_mem_location(0)
+    , m_output_format(dtrace::get_output_format())
 {
 }
 

--- a/src/cpp/dtrace/action/action_control.h
+++ b/src/cpp/dtrace/action/action_control.h
@@ -6,6 +6,7 @@
 
 // This file contains the declaration of the action control class and action classes.
 #include "common/regex_wrapper.h"
+#include "json/nlohmann/json.hpp"
 #include "dtrace/utils.h"
 #ifdef CERT_TRACE_CONTROL_H
 #include "trace_control.h"
@@ -21,6 +22,9 @@
 
 namespace dtrace::action
 {
+
+using json = nlohmann::ordered_json;
+
 //-------------------------Action Types-------------------------//
 /**
  * @class action_type
@@ -191,7 +195,6 @@ protected:
     uint32_t m_control_location;
     uint32_t m_mem_location;
     std::string m_result;
-    dtrace::dtrace_output_format m_output_format;
     void set_location(const std::vector<uint32_t>& buffer, bool is_mem_buffer);
 
 public:
@@ -200,14 +203,18 @@ public:
     virtual void actionize(
         uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint32_t>& mem_buffer
     ) = 0;
-    virtual std::string serialize(
+    // Python output format
+    virtual void serialize(
         std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
-        const std::unordered_map<uint32_t, uint32_t>& mapping
+        const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output
+    ) const = 0;
+    // JSON output format
+    virtual void serialize(
+        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer,
+        const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output
     ) const = 0;
     virtual uint64_t get_mem_host_addr() const { return 0; }
     uint32_t get_location(bool is_mem_buffer) const;
-    std::string get_probe_name() const { return m_probe_name; }
-    std::string get_action_name() const { return m_result; }
     std::string create_string() const;
     static std::string strip(const std::string& token);
 };
@@ -230,9 +237,17 @@ public:
     void actionize(
         uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint32_t>& mem_buffer
     ) override;
-    std::string serialize(
-        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
+    uint32_t serialize_helper(
+        std::vector<uint32_t>& result_buffer,
         const std::unordered_map<uint32_t, uint32_t>& mapping
+    ) const;
+    void serialize(
+        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
+        const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output
+    ) const override;
+    void serialize(
+        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer,
+        const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output
     ) const override;
 };
 
@@ -254,9 +269,13 @@ public:
     void actionize(
         uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint32_t>& mem_buffer
     ) override;
-    std::string serialize(
+    void serialize(
         std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
-        const std::unordered_map<uint32_t, uint32_t>& mapping
+        const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output
+    ) const override;
+    void serialize(
+        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer,
+        const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output
     ) const override;
 };
 
@@ -286,9 +305,14 @@ public:
     void actionize(
         uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint32_t>& mem_buffer
     ) override;
-    std::string serialize(
+    void serialize_helper(std::vector<uint32_t>& mem_buffer) const;
+    void serialize(
         std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
-        const std::unordered_map<uint32_t, uint32_t>& mapping
+        const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output
+    ) const override;
+    void serialize(
+        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer,
+        const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output
     ) const override;
     uint32_t get_mode() const { return m_mode; }
 };
@@ -311,9 +335,17 @@ public:
     void actionize(
         uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint32_t>& mem_buffer
     ) override;
-    std::string serialize(
-        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
+    uint64_t serialize_helper(
+        std::vector<uint32_t>& result_buffer,
         const std::unordered_map<uint32_t, uint32_t>& mapping
+    ) const;
+    void serialize(
+        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
+        const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output
+    ) const override;
+    void serialize(
+        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer,
+        const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output
     ) const override;
 };
 
@@ -335,9 +367,17 @@ public:
     void actionize(
         uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint32_t>& mem_buffer
     ) override;
-    std::string serialize(
-        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
+    uint64_t serialize_helper(
+        std::vector<uint32_t>& result_buffer, 
         const std::unordered_map<uint32_t, uint32_t>& mapping
+    ) const;
+    void serialize(
+        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
+        const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output
+    ) const override;
+    void serialize(
+        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer,
+        const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output
     ) const override;
 };
 
@@ -359,9 +399,17 @@ public:
     void actionize(
         uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint32_t>& mem_buffer
     ) override;
-    std::string serialize(
-        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
+    uint32_t serialize_helper(
+        std::vector<uint32_t>& result_buffer,
         const std::unordered_map<uint32_t, uint32_t>& mapping
+    ) const;
+    void serialize(
+        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
+        const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output
+    ) const override;
+    void serialize(
+        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer,
+        const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output
     ) const override;
 };
 
@@ -383,9 +431,13 @@ public:
     void actionize(
         uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint32_t>& mem_buffer
     ) override;
-    std::string serialize(
+    void serialize(
         std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
-        const std::unordered_map<uint32_t, uint32_t>& mapping
+        const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output
+    ) const override;
+    void serialize(
+        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer,
+        const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output
     ) const override;
 };
 
@@ -407,9 +459,17 @@ public:
     void actionize(
         uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint32_t>& mem_buffer
     ) override;
-    std::string serialize(
-        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
+    uint32_t serialize_helper(
+        std::vector<uint32_t>& result_buffer, 
         const std::unordered_map<uint32_t, uint32_t>& mapping
+    ) const;
+    void serialize(
+        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer,
+        const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output
+    ) const override;
+    void serialize(
+        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer,
+        const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output
     ) const override;
 };
 
@@ -438,9 +498,13 @@ public:
     void actionize(
         uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint32_t>& mem_buffer
     ) override;
-    std::string serialize(
+    void serialize(
         std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
-        const std::unordered_map<uint32_t, uint32_t>& mapping
+        const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output
+    ) const override;
+    void serialize(
+        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer,
+        const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output
     ) const override;
 };
 
@@ -469,10 +533,14 @@ public:
         uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint32_t>& mem_buffer
     ) override;
     std::pair<std::string, uint32_t> get_opcode(const uint32_t& value)  const;
-    std::string format(const std::vector<uint32_t>& result_buffer) const;
-    std::string serialize(
+    std::string serialize_helper(const std::vector<uint32_t>& result_buffer) const;
+    void serialize(
         std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
-        const std::unordered_map<uint32_t, uint32_t>& mapping
+        const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output
+    ) const override;
+    void serialize(
+        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer,
+        const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output
     ) const override;
 };
 
@@ -497,9 +565,13 @@ public:
     void actionize(
         uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint32_t>& mem_buffer
     ) override;
-    std::string serialize(
+    void serialize(
         std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
-        const std::unordered_map<uint32_t, uint32_t>& mapping
+        const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output
+    ) const override;
+    void serialize(
+        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer,
+        const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output
     ) const override;
 };
 
@@ -530,9 +602,17 @@ public:
     void actionize(
         uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint32_t>& mem_buffer
     ) override;
-    std::string serialize(
+    std::vector<uint32_t> serialize_helper(
         std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
         const std::unordered_map<uint32_t, uint32_t>& mapping
+    ) const;
+    void serialize(
+        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
+        const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output
+    ) const override;
+    void serialize(
+        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer,
+        const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output
     ) const override;
     uint64_t get_mem_host_addr() const override;
 };
@@ -563,9 +643,13 @@ public:
     void actionize(
         uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint32_t>& mem_buffer
     ) override;
-    std::string serialize(
+    void serialize(
         std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
-        const std::unordered_map<uint32_t, uint32_t>& mapping
+        const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output
+    ) const override;
+    void serialize(
+        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer,
+        const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output
     ) const override;
 };
 
@@ -590,9 +674,13 @@ public:
     void actionize(
         uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint32_t>& mem_buffer
     ) override;
-    std::string serialize(
+    void serialize(
         std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
-        const std::unordered_map<uint32_t, uint32_t>& mapping
+        const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output
+    ) const override;
+    void serialize(
+        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer,
+        const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output
     ) const override;
 };
 
@@ -617,9 +705,17 @@ public:
     void actionize(
         uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint32_t>& mem_buffer
     ) override;
-    std::string serialize(
-        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
+    std::vector<uint64_t> serialize_helper(
+        std::vector<uint32_t>& result_buffer, 
         const std::unordered_map<uint32_t, uint32_t>& mapping
+    ) const;
+    void serialize(
+        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
+        const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output
+    ) const override;
+    void serialize(
+        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer,
+        const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output
     ) const override;
 };
 
@@ -644,9 +740,17 @@ public:
     void actionize(
         uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint32_t>& mem_buffer
     ) override;
-    std::string serialize(
-        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
+    std::vector<uint32_t> serialize_helper(
+        std::vector<uint32_t>& result_buffer, 
         const std::unordered_map<uint32_t, uint32_t>& mapping
+    ) const;
+    void serialize(
+        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
+        const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output
+    ) const override;
+    void serialize(
+        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer,
+        const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output
     ) const override;
 };
 
@@ -671,9 +775,17 @@ public:
     void actionize(
         uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint32_t>& mem_buffer
     ) override;
-    std::string serialize(
-        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
+    std::vector<uint64_t> serialize_helper(
+        std::vector<uint32_t>& result_buffer, 
         const std::unordered_map<uint32_t, uint32_t>& mapping
+    ) const;
+    void serialize(
+        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
+        const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output
+    ) const override;
+    void serialize(
+        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer,
+        const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output
     ) const override;
 };
 
@@ -698,9 +810,13 @@ public:
     void actionize(
         uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint32_t>& mem_buffer
     ) override;
-    std::string serialize(
+    void serialize(
         std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
-        const std::unordered_map<uint32_t, uint32_t>& mapping
+        const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output
+    ) const override;
+    void serialize(
+        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer,
+        const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output
     ) const override;
 };
 
@@ -722,9 +838,17 @@ public:
     void actionize(
         uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint32_t>& mem_buffer
     ) override;
-    std::string serialize(
-        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
+    uint32_t serialize_helper(
+        std::vector<uint32_t>& result_buffer, 
         const std::unordered_map<uint32_t, uint32_t>& mapping
+    ) const;
+    void serialize(
+        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
+        const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output
+    ) const override;
+    void serialize(
+        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer,
+        const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output
     ) const override;
 };
 
@@ -746,9 +870,17 @@ public:
     void actionize(
         uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint32_t>& mem_buffer
     ) override;
-    std::string serialize(
-        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
+    void serialize_helper(
+        std::vector<uint32_t>& result_buffer, 
         const std::unordered_map<uint32_t, uint32_t>& mapping
+    ) const;
+    void serialize(
+        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
+        const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output
+    ) const override;
+    void serialize(
+        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer,
+        const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output
     ) const override;
 };
 

--- a/src/cpp/dtrace/action/action_control.h
+++ b/src/cpp/dtrace/action/action_control.h
@@ -5,13 +5,13 @@
 #define ACTION_CONTROL_H
 
 // This file contains the declaration of the action control class and action classes.
+#include "common/regex_wrapper.h"
 #include "dtrace/utils.h"
 #ifdef CERT_TRACE_CONTROL_H
 #include "trace_control.h"
 #endif
 
 #include <boost/property_tree/ptree.hpp>
-#include "common/regex_wrapper.h"
 
 #include <cstdint>
 #include <map>
@@ -191,12 +191,11 @@ protected:
     uint32_t m_control_location;
     uint32_t m_mem_location;
     std::string m_result;
+    dtrace::dtrace_output_format m_output_format;
     void set_location(const std::vector<uint32_t>& buffer, bool is_mem_buffer);
 
 public:
     action(uint32_t probe_type, std::string probe_name);
-    std::string create_string() const;
-    static std::string strip(const std::string& token);
     virtual ~action() = default;
     virtual void actionize(
         uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint32_t>& mem_buffer
@@ -205,8 +204,12 @@ public:
         std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
         const std::unordered_map<uint32_t, uint32_t>& mapping
     ) const = 0;
-    uint32_t get_location(bool is_mem_buffer) const;
     virtual uint64_t get_mem_host_addr() const { return 0; }
+    uint32_t get_location(bool is_mem_buffer) const;
+    std::string get_probe_name() const { return m_probe_name; }
+    std::string get_action_name() const { return m_result; }
+    std::string create_string() const;
+    static std::string strip(const std::string& token);
 };
 
 //-------------------------Read register-------------------------//

--- a/src/cpp/dtrace/action/break.cpp
+++ b/src/cpp/dtrace/action/break.cpp
@@ -60,7 +60,9 @@ serialize(std::vector<uint32_t>&, std::vector<uint32_t>&,
     const std::unordered_map<uint32_t, uint32_t>&) const
 {
     std::ostringstream output_action;
-    output_action << "#" << " " << m_token << "\n";
+    if (m_output_format == dtrace::dtrace_output_format::python)
+        output_action << "#" << " " << m_token << "\n";
+
     return output_action.str();
 }
 

--- a/src/cpp/dtrace/action/break.cpp
+++ b/src/cpp/dtrace/action/break.cpp
@@ -50,20 +50,29 @@ actionize(uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint
  * @param result_buffer
  * @param mem_buffer
  * @param mapping
- *
- * @return 
- *  String representing the serialized break action.
+ * @param script_output
  */
-std::string
+void
 break_action::
 serialize(std::vector<uint32_t>&, std::vector<uint32_t>&, 
-    const std::unordered_map<uint32_t, uint32_t>&) const
+    const std::unordered_map<uint32_t, uint32_t>&, std::ostream&) const
 {
-    std::ostringstream output_action;
-    if (m_output_format == dtrace::dtrace_output_format::python)
-        output_action << "#" << " " << m_token << "\n";
+}
 
-    return output_action.str();
+//-------------------------break_action::serialize-------------------------//
+/**
+ * serialize() - Serializes the break action into json format.
+ *
+ * @param result_buffer
+ * @param mem_buffer
+ * @param mapping
+ * @param json_output
+ */
+void
+break_action::
+serialize(std::vector<uint32_t>&, std::vector<uint32_t>&, 
+    const std::unordered_map<uint32_t, uint32_t>&, json&) const
+{
 }
 
 } // namespace dtrace::action

--- a/src/cpp/dtrace/action/count.cpp
+++ b/src/cpp/dtrace/action/count.cpp
@@ -26,7 +26,7 @@ count_action(std::string token, uint32_t probe_type, const std::string& probe_na
     std::stringstream token_stream(token);
     std::string item;
     while (std::getline(token_stream, item, '='))
-        fields.push_back(strip(item));
+        fields.push_back(action::strip(item));
 
     if (fields.size() != 2)
         DTRACE_ERROR("DTRACE_ACTION_INVALID_TOKEN", 
@@ -83,9 +83,19 @@ serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&,
 {
     std::ostringstream output_action;
     uint32_t location = mapping.at(get_location(false));
-    output_action << "  " << m_result << " = " << result_buffer[location] << "\n";
+
+    if (m_output_format == dtrace::dtrace_output_format::python)
+    {
+        output_action << "  " << m_result << " = " << 
+            (result_buffer[location] - dtrace::dtrace_ctrl::result_value_init) << "\n";
+    }
+    else if (m_output_format == dtrace::dtrace_output_format::json)
+    {
+        output_action << (result_buffer[location] - dtrace::dtrace_ctrl::result_value_init);
+    } 
+
     // reset value after serialization
-    result_buffer[location] = 0;
+    result_buffer[location] = dtrace::dtrace_ctrl::result_value_init;
     return output_action.str();
 }
 

--- a/src/cpp/dtrace/action/count.cpp
+++ b/src/cpp/dtrace/action/count.cpp
@@ -65,6 +65,29 @@ actionize(uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint
     control_buffer.push_back(dtrace::dtrace_ctrl::result_value_init);
 }
 
+//-------------------------count_action::serialize_helper-------------------------//
+/**
+ * serialize_helper() - Helper function to serialize action.
+ *
+ * @param result_buffer
+ * @param mapping
+ *
+ * @return 
+ *  The value from the result buffer based on the location mapping and
+ *  resets the value in the result buffer after serialization.
+ */
+uint32_t
+count_action::
+serialize_helper(std::vector<uint32_t>& result_buffer, 
+    const std::unordered_map<uint32_t, uint32_t>& mapping) const
+{
+    uint32_t location = mapping.at(get_location(false));
+    uint32_t result = result_buffer[location] - dtrace::dtrace_ctrl::result_value_init;
+    // reset value after serialization
+    result_buffer[location] = dtrace::dtrace_ctrl::result_value_init;
+    return result;
+}
+
 //-------------------------count_action::serialize-------------------------//
 /**
  * serialize() - Serializes the count action into a string format.
@@ -72,31 +95,35 @@ actionize(uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint
  * @param result_buffer
  * @param mem_buffer
  * @param mapping
- *
- * @return 
- *  String representing the serialized count action.
+ * @param script_output
  */
-std::string
+void
 count_action::
 serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&, 
-    const std::unordered_map<uint32_t, uint32_t>& mapping) const
+    const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output) const
 {
-    std::ostringstream output_action;
-    uint32_t location = mapping.at(get_location(false));
+    uint32_t result = count_action::serialize_helper(result_buffer, mapping);
+    // serialize string format
+    script_output << "  " << m_result << " = " << result << "\n";
+}
 
-    if (m_output_format == dtrace::dtrace_output_format::python)
-    {
-        output_action << "  " << m_result << " = " << 
-            (result_buffer[location] - dtrace::dtrace_ctrl::result_value_init) << "\n";
-    }
-    else if (m_output_format == dtrace::dtrace_output_format::json)
-    {
-        output_action << (result_buffer[location] - dtrace::dtrace_ctrl::result_value_init);
-    } 
-
-    // reset value after serialization
-    result_buffer[location] = dtrace::dtrace_ctrl::result_value_init;
-    return output_action.str();
+//-------------------------count_action::serialize-------------------------//
+/**
+ * serialize() - Serializes the count action into json format.
+ *
+ * @param result_buffer
+ * @param mem_buffer
+ * @param mapping
+ * @param json_output
+ */
+void
+count_action::
+serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&, 
+    const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output) const
+{
+    uint32_t result = count_action::serialize_helper(result_buffer, mapping);
+    // serialize json format
+    json_output[m_probe_name][m_result] = result;
 }
 
 } // namespace dtrace::action

--- a/src/cpp/dtrace/action/host_timestamp.cpp
+++ b/src/cpp/dtrace/action/host_timestamp.cpp
@@ -26,7 +26,7 @@ host_timestamp_action(std::string token, uint32_t probe_type, const std::string&
     std::stringstream token_stream(token);
     std::string item;
     while (std::getline(token_stream, item, '='))
-        fields.push_back(strip(item));
+        fields.push_back(action::strip(item));
 
     if (fields.size() != 2)
         DTRACE_ERROR("DTRACE_ACTION_INVALID_TOKEN", 
@@ -89,10 +89,19 @@ serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&,
     uint64_t high = 
         static_cast<uint64_t>(result_buffer[location_h]) << dtrace::dtrace_ctrl::forth_byte_shift;
     uint64_t low = result_buffer[location_l];
-    output_action << "  " << m_result << " = " << (high + low) << "\n";
+
+    if (m_output_format == dtrace::dtrace_output_format::python)
+    {
+        output_action << "  " << m_result << " = " << (high + low) << "\n";
+    }
+    else if (m_output_format == dtrace::dtrace_output_format::json)
+    {
+        output_action << (high + low);
+    }
+
     // reset value after serialization
-    result_buffer[location_h] = 0;
-    result_buffer[location_l] = 0;
+    result_buffer[location_h] = dtrace::dtrace_ctrl::result_value_init;
+    result_buffer[location_l] = dtrace::dtrace_ctrl::result_value_init;
     return output_action.str();
 }
 

--- a/src/cpp/dtrace/action/host_timestamp.cpp
+++ b/src/cpp/dtrace/action/host_timestamp.cpp
@@ -67,6 +67,33 @@ actionize(uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint
     control_buffer.push_back(dtrace::dtrace_ctrl::result_value_init);
 }
 
+//-------------------------host_timestamp_action::serialize_helper-------------------------//
+/**
+ * serialize_helper() - Helper function to serialize action.
+ *
+ * @param result_buffer
+ * @param mapping
+ *
+ * @return 
+ *  The value from the result buffer based on the location mapping and
+ *  resets the value in the result buffer after serialization.
+ */
+uint64_t
+host_timestamp_action::
+serialize_helper(std::vector<uint32_t>& result_buffer, 
+    const std::unordered_map<uint32_t, uint32_t>& mapping) const
+{
+    uint32_t location_h = mapping.at(get_location(false));
+    uint32_t location_l = mapping.at(get_location(false) + 1);
+    uint64_t high = 
+        static_cast<uint64_t>(result_buffer[location_h]) << dtrace::dtrace_ctrl::forth_byte_shift;
+    uint64_t low = result_buffer[location_l];
+    // reset value after serialization
+    result_buffer[location_h] = dtrace::dtrace_ctrl::result_value_init;
+    result_buffer[location_l] = dtrace::dtrace_ctrl::result_value_init;
+    return (high + low);
+}
+
 //-------------------------host_timestamp_action::serialize-------------------------//
 /**
  * serialize() - Serializes the timestamp action into a string format.
@@ -74,35 +101,35 @@ actionize(uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint
  * @param result_buffer
  * @param mem_buffer
  * @param mapping
- *
- * @return 
- *  String representing the serialized timestamp action.
+ * @param script_output
  */
-std::string
+void
 host_timestamp_action::
 serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&, 
-    const std::unordered_map<uint32_t, uint32_t>& mapping) const
+    const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output) const
 {
-    std::ostringstream output_action;
-    uint32_t location_h = mapping.at(get_location(false));
-    uint32_t location_l = mapping.at(get_location(false) + 1);
-    uint64_t high = 
-        static_cast<uint64_t>(result_buffer[location_h]) << dtrace::dtrace_ctrl::forth_byte_shift;
-    uint64_t low = result_buffer[location_l];
+    uint64_t result = host_timestamp_action::serialize_helper(result_buffer, mapping);
+    // serialize string format
+    script_output << "  " << m_result << " = " << result << "\n";
+}
 
-    if (m_output_format == dtrace::dtrace_output_format::python)
-    {
-        output_action << "  " << m_result << " = " << (high + low) << "\n";
-    }
-    else if (m_output_format == dtrace::dtrace_output_format::json)
-    {
-        output_action << (high + low);
-    }
-
-    // reset value after serialization
-    result_buffer[location_h] = dtrace::dtrace_ctrl::result_value_init;
-    result_buffer[location_l] = dtrace::dtrace_ctrl::result_value_init;
-    return output_action.str();
+//-------------------------host_timestamp_action::serialize-------------------------//
+/**
+ * serialize() - Serializes the timestamp action into json format.
+ *
+ * @param result_buffer
+ * @param mem_buffer
+ * @param mapping
+ * @param json_output
+ */
+void
+host_timestamp_action::
+serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&, 
+    const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output) const
+{
+    uint64_t result = host_timestamp_action::serialize_helper(result_buffer, mapping);
+    // serialize json format
+    json_output[m_probe_name][m_result] = result;
 }
 
 } // namespace dtrace::action

--- a/src/cpp/dtrace/action/host_timestamps.cpp
+++ b/src/cpp/dtrace/action/host_timestamps.cpp
@@ -26,7 +26,7 @@ host_timestamps_action(std::string token, uint32_t probe_type, const std::string
     std::stringstream token_stream(token);
     std::string item;
     while (std::getline(token_stream, item, '='))
-        fields.push_back(strip(item));
+        fields.push_back(action::strip(item));
 
     if (fields.size() != 2)
         DTRACE_ERROR("DTRACE_ACTION_INVALID_TOKEN", 
@@ -97,28 +97,37 @@ host_timestamps_action::
 serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&, 
     const std::unordered_map<uint32_t, uint32_t>& mapping) const
 {
-    
     std::vector<uint64_t> result;
-    for (uint32_t i = 0; i < m_length; ++i) {
+    for (uint32_t i = 0; i < m_length; ++i) 
+    {
         // action location + length word + high and low value
         uint32_t location = mapping.at(get_location(false)) + 1 + i*2;
         uint64_t high = static_cast<uint64_t>(result_buffer[location]) << dtrace::dtrace_ctrl::forth_byte_shift;
         uint64_t low = result_buffer[location + 1];
         result.push_back(high + low);
         // reset value after serialization
-        result_buffer[location] = 0;
-        result_buffer[location + 1] = 0;
+        result_buffer[location] = dtrace::dtrace_ctrl::result_value_init;
+        result_buffer[location + 1] = dtrace::dtrace_ctrl::result_value_init;
+    }
+
+    std::ostringstream result_values;
+    for (size_t i = 0; i < result.size(); ++i) 
+    {
+        result_values << result[i];
+        if (i != result.size() - 1)
+            result_values << ", ";
     }
 
     std::ostringstream output_action;
-    output_action << "  " << m_result << " = [";
-    for (size_t i = 0; i < result.size(); ++i) {
-        output_action << result[i];
-        if (i != result.size() - 1)
-            output_action << ", ";
+    if (m_output_format == dtrace::dtrace_output_format::python)
+    {
+        output_action << "  " << m_result << " = [" << result_values.str() << "]\n";
     }
-    output_action << "]\n";
-    
+    else if (m_output_format == dtrace::dtrace_output_format::json)
+    {
+        output_action << result_values.str();
+    }
+
     return output_action.str();
 }
 

--- a/src/cpp/dtrace/action/host_timestamps.cpp
+++ b/src/cpp/dtrace/action/host_timestamps.cpp
@@ -81,20 +81,20 @@ actionize(uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint
     }
 }
 
-//-------------------------host_timestamps_action::serialize-------------------------//
+//-------------------------host_timestamps_action::serialize_helper-------------------------//
 /**
- * serialize() - Serializes the timestamp action into a string format.
+ * serialize_helper() - Helper function to serialize action.
  *
  * @param result_buffer
- * @param mem_buffer
  * @param mapping
  *
  * @return 
- *  String representing the serialized timestamp action.
+ *  The value from the result buffer based on the location mapping and
+ *  resets the value in the result buffer after serialization.
  */
-std::string
+std::vector<uint64_t>
 host_timestamps_action::
-serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&, 
+serialize_helper(std::vector<uint32_t>& result_buffer, 
     const std::unordered_map<uint32_t, uint32_t>& mapping) const
 {
     std::vector<uint64_t> result;
@@ -109,26 +109,56 @@ serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&,
         result_buffer[location] = dtrace::dtrace_ctrl::result_value_init;
         result_buffer[location + 1] = dtrace::dtrace_ctrl::result_value_init;
     }
+    return result;
+}
 
-    std::ostringstream result_values;
+//-------------------------host_timestamps_action::serialize-------------------------//
+/**
+ * serialize() - Serializes the timestamp action into a string format.
+ *
+ * @param result_buffer
+ * @param mem_buffer
+ * @param mapping
+ * @param script_output
+ */
+void
+host_timestamps_action::
+serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&, 
+    const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output) const
+{
+    std::vector<uint64_t> result = host_timestamps_action::serialize_helper(result_buffer, mapping);
+    // serialize string format
+    script_output << "  " << m_result << " = [";
     for (size_t i = 0; i < result.size(); ++i) 
     {
-        result_values << result[i];
+        script_output << result[i];
         if (i != result.size() - 1)
-            result_values << ", ";
+            script_output << ", ";
     }
+    script_output << "]\n";
+}
 
-    std::ostringstream output_action;
-    if (m_output_format == dtrace::dtrace_output_format::python)
-    {
-        output_action << "  " << m_result << " = [" << result_values.str() << "]\n";
-    }
-    else if (m_output_format == dtrace::dtrace_output_format::json)
-    {
-        output_action << result_values.str();
-    }
+//-------------------------host_timestamps_action::serialize-------------------------//
+/**
+ * serialize() - Serializes the timestamp action into json format.
+ *
+ * @param result_buffer
+ * @param mem_buffer
+ * @param mapping
+ * @param json_output
+ */
+void
+host_timestamps_action::
+serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&, 
+    const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output) const
+{
+    std::vector<uint64_t> result = host_timestamps_action::serialize_helper(result_buffer, mapping);
+    // serialize json format
+    json json_result = json::array();
+    for (uint32_t i = 0; i < result.size(); ++i)
+        json_result.push_back(result[i]);
 
-    return output_action.str();
+    json_output[m_probe_name][m_result] = json_result;
 }
 
 } // namespace dtrace::action

--- a/src/cpp/dtrace/action/mask_write_register.cpp
+++ b/src/cpp/dtrace/action/mask_write_register.cpp
@@ -127,21 +127,19 @@ actionize(uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint
     }
 }
 
-//-------------------------mask_write_reg_action::serialize-------------------------//
+//-------------------------mask_write_reg_action::serialize_helper-------------------------//
 /**
- * serialize() - Serializes the register mask write action into a string format.
+ * serialize_helper() - Helper function to serialize action.
  *
- * @param result_buffer
  * @param mem_buffer
- * @param mapping
  *
  * @return 
- *  String representing the serialized register mask write action.
+ *  The value from the result buffer based on the location mapping and
+ *  resets the value in the result buffer after serialization.
  */
-std::string
+void
 mask_write_reg_action::
-serialize(std::vector<uint32_t>&, std::vector<uint32_t>& mem_buffer, 
-    const std::unordered_map<uint32_t, uint32_t>&) const
+serialize_helper(std::vector<uint32_t>& mem_buffer) const
 {
     if (m_mode == 2)
     {
@@ -151,12 +149,40 @@ serialize(std::vector<uint32_t>&, std::vector<uint32_t>& mem_buffer,
         for (uint32_t i = index; i < index+length; ++i)
             mem_buffer[i] = m_write_buffer_values[i - index];
     }
+}
 
-    std::ostringstream output_action;
-    if (m_output_format == dtrace::dtrace_output_format::python)
-        output_action << "  " << "#" << " " << m_action_name << "\n";
+//-------------------------mask_write_reg_action::serialize-------------------------//
+/**
+ * serialize() - Serializes the register mask write action into a string format.
+ *
+ * @param result_buffer
+ * @param mem_buffer
+ * @param mapping
+ * @param script_output
+ */
+void
+mask_write_reg_action::
+serialize(std::vector<uint32_t>&, std::vector<uint32_t>& mem_buffer, 
+    const std::unordered_map<uint32_t, uint32_t>&, std::ostream&) const
+{
+    mask_write_reg_action::serialize_helper(mem_buffer);
+}
 
-    return output_action.str();
+//-------------------------mask_write_reg_action::serialize-------------------------//
+/**
+ * serialize() - Serializes the timestamp action into json format.
+ *
+ * @param result_buffer
+ * @param mem_buffer
+ * @param mapping
+ * @param json_output
+ */
+void
+mask_write_reg_action::
+serialize(std::vector<uint32_t>&, std::vector<uint32_t>& mem_buffer, 
+    const std::unordered_map<uint32_t, uint32_t>&, json&) const
+{
+    mask_write_reg_action::serialize_helper(mem_buffer);
 }
 
 } // namespace dtrace::action

--- a/src/cpp/dtrace/action/mask_write_register.cpp
+++ b/src/cpp/dtrace/action/mask_write_register.cpp
@@ -145,7 +145,6 @@ serialize(std::vector<uint32_t>&, std::vector<uint32_t>& mem_buffer,
 {
     if (m_mode == 2)
     {
-        std::ostringstream readable_result;
         uint32_t index = get_location(true);
         auto length = static_cast<uint32_t>(m_write_buffer_values.size());
         // reset value after serialization

--- a/src/cpp/dtrace/action/mask_write_register.cpp
+++ b/src/cpp/dtrace/action/mask_write_register.cpp
@@ -28,7 +28,7 @@ mask_write_reg_action(std::string token, uint32_t probe_type, const std::string&
     std::stringstream token_stream(token);
     std::string item;
     while (std::getline(token_stream, item, '='))
-        fields.push_back(strip(item));
+        fields.push_back(action::strip(item));
 
     aiebu::smatch action;
     if (!aiebu::regex_match(fields[0], action, action_name::action_regex))
@@ -41,7 +41,7 @@ mask_write_reg_action(std::string token, uint32_t probe_type, const std::string&
     // Validate and parse the length argument
     std::stringstream argument_stream(argument_string);
     while (std::getline(argument_stream, item, ','))
-        m_arguments.push_back(strip(item));
+        m_arguments.push_back(action::strip(item));
 
     if (m_arguments.size() < 3)
         DTRACE_ERROR("DTRACE_ACTION_INVALID_TOKEN_ARGUMENTS", 
@@ -56,7 +56,6 @@ mask_write_reg_action(std::string token, uint32_t probe_type, const std::string&
         // check if write buffer name exists in the map and get the values
         if (buffer_map.find(write_buffer_name) != buffer_map.end())
         {
-            m_result = write_buffer_name;
             m_write_buffer_values = buffer_map.at(write_buffer_name).second;
 
             // set mode and value argument based on HIGH or LOW
@@ -144,24 +143,20 @@ mask_write_reg_action::
 serialize(std::vector<uint32_t>&, std::vector<uint32_t>& mem_buffer, 
     const std::unordered_map<uint32_t, uint32_t>&) const
 {
-    std::ostringstream output_action;
-    output_action << "  " << "#" << " " << m_action_name << "\n";
     if (m_mode == 2)
     {
         std::ostringstream readable_result;
         uint32_t index = get_location(true);
         auto length = static_cast<uint32_t>(m_write_buffer_values.size());
+        // reset value after serialization
         for (uint32_t i = index; i < index+length; ++i)
-        {
-            readable_result << "  0x" << std::hex << mem_buffer[i];
-            if (i < index+length - 1)
-                readable_result << "\n";
-
-            // reset value after serialization
-            mem_buffer[i] = 0;
-        }
-        output_action << "  " << m_result << " = \"\"\"\n" << readable_result.str() << "\"\"\"\n";
+            mem_buffer[i] = m_write_buffer_values[i - index];
     }
+
+    std::ostringstream output_action;
+    if (m_output_format == dtrace::dtrace_output_format::python)
+        output_action << "  " << "#" << " " << m_action_name << "\n";
+
     return output_action.str();
 }
 

--- a/src/cpp/dtrace/action/operation.cpp
+++ b/src/cpp/dtrace/action/operation.cpp
@@ -59,7 +59,9 @@ serialize(std::vector<uint32_t>&, std::vector<uint32_t>&,
     const std::unordered_map<uint32_t, uint32_t>&) const
 {
     std::ostringstream output_action;
-    output_action << "  " << m_token << "\n";
+    if (m_output_format == dtrace::dtrace_output_format::python)
+        output_action << "  " << m_token << "\n";
+
     return output_action.str();
 }
 

--- a/src/cpp/dtrace/action/operation.cpp
+++ b/src/cpp/dtrace/action/operation.cpp
@@ -44,25 +44,36 @@ actionize(uint32_t, std::vector<uint32_t>&, std::vector<uint32_t>&)
 
 //-------------------------operation_action::serialize-------------------------//
 /**
- * serialize() - Serializes the print action into a string format.
+ * serialize() - Serializes the operation action into a string format.
  *
  * @param result_buffer
  * @param mem_buffer
  * @param mapping
- *
- * @return 
- *  String representing the serialized print action.
+ * @param script_output
  */
-std::string
+void
 operation_action::
 serialize(std::vector<uint32_t>&, std::vector<uint32_t>&, 
-    const std::unordered_map<uint32_t, uint32_t>&) const
+    const std::unordered_map<uint32_t, uint32_t>&, std::ostream& script_output) const
 {
-    std::ostringstream output_action;
-    if (m_output_format == dtrace::dtrace_output_format::python)
-        output_action << "  " << m_token << "\n";
+    // serialize string format
+    script_output << "  " << m_token << "\n";
+}
 
-    return output_action.str();
+//-------------------------operation_action::serialize-------------------------//
+/**
+ * serialize() - Serializes the operation action into json format.
+ *
+ * @param result_buffer
+ * @param mem_buffer
+ * @param mapping
+ * @param json_output
+ */
+void
+operation_action::
+serialize(std::vector<uint32_t>&, std::vector<uint32_t>&, 
+    const std::unordered_map<uint32_t, uint32_t>&, json&) const
+{
 }
 
 } // namespace dtrace::action

--- a/src/cpp/dtrace/action/print.cpp
+++ b/src/cpp/dtrace/action/print.cpp
@@ -94,26 +94,36 @@ actionize(uint32_t, std::vector<uint32_t>&, std::vector<uint32_t>&)
  * @param result_buffer
  * @param mem_buffer
  * @param mapping
- *
- * @return 
- *  String representing the serialized print action.
+ * @param script_output
  */
-std::string
+void
 print_action::
 serialize(std::vector<uint32_t>&, std::vector<uint32_t>&, 
-    const std::unordered_map<uint32_t, uint32_t>&) const
+    const std::unordered_map<uint32_t, uint32_t>&, std::ostream& script_output) const
 {
-    std::ostringstream output_action;
-    if (m_output_format == dtrace::dtrace_output_format::python)
+    // serialize string format
+    for (const auto& [key, value] : m_built_ins)
     {
-        for (const auto& [key, value] : m_built_ins)
-        {
-            if (m_token.find(key) != std::string::npos)
-                output_action << "  " << key << " = " << '"' << value << '"' << "\n";
-        }
-        output_action << "  " << m_token << "\n";
+        if (m_token.find(key) != std::string::npos)
+            script_output << "  " << key << " = " << '"' << value << '"' << "\n";
     }
-    return output_action.str();
+    script_output << "  " << m_token << "\n";
+}
+
+//-------------------------print_action::serialize-------------------------//
+/**
+ * serialize() - Serializes the print action into json format.
+ *
+ * @param result_buffer
+ * @param mem_buffer
+ * @param mapping
+ * @param json_output
+ */
+void
+print_action::
+serialize(std::vector<uint32_t>&, std::vector<uint32_t>&, 
+    const std::unordered_map<uint32_t, uint32_t>&, json&) const
+{
 }
 
 } // namespace dtrace::action

--- a/src/cpp/dtrace/action/print.cpp
+++ b/src/cpp/dtrace/action/print.cpp
@@ -33,7 +33,7 @@ print_action(std::string token, uint32_t probe_type, const std::string& probe_na
     std::stringstream token_stream(m_token);
     std::string item;
     while (std::getline(token_stream, item, '='))
-        fields.push_back(strip(item));
+        fields.push_back(action::strip(item));
 
     std::string temp = fields[0];
     size_t position = temp.find('(');
@@ -46,7 +46,7 @@ print_action(std::string token, uint32_t probe_type, const std::string& probe_na
     std::string argument_string = temp.substr(position + 1, temp.length() - position - 2);
     std::stringstream argument_stream(argument_string);
     while (std::getline(argument_stream, item, ','))
-        m_arguments.push_back(strip(item));
+        m_arguments.push_back(action::strip(item));
 
     if (m_arguments.size() < 1)
         DTRACE_ERROR("DTRACE_ACTION_INVALID_TOKEN_ARGUMENTS", 
@@ -104,12 +104,15 @@ serialize(std::vector<uint32_t>&, std::vector<uint32_t>&,
     const std::unordered_map<uint32_t, uint32_t>&) const
 {
     std::ostringstream output_action;
-    for (const auto& [key, value] : m_built_ins)
+    if (m_output_format == dtrace::dtrace_output_format::python)
     {
-        if (m_token.find(key) != std::string::npos)
-            output_action << "  " << key << " = " << '"' << value << '"' << "\n";
+        for (const auto& [key, value] : m_built_ins)
+        {
+            if (m_token.find(key) != std::string::npos)
+                output_action << "  " << key << " = " << '"' << value << '"' << "\n";
+        }
+        output_action << "  " << m_token << "\n";
     }
-    output_action << "  " << m_token << "\n";
     return output_action.str();
 }
 

--- a/src/cpp/dtrace/action/printa.cpp
+++ b/src/cpp/dtrace/action/printa.cpp
@@ -33,20 +33,20 @@ printa_action(std::string token, uint32_t probe_type, const std::string& probe_n
     std::string item;
 
     while (std::getline(token_stream, item, '='))
-        fields.push_back(strip(item));
+        fields.push_back(action::strip(item));
 
-    std::string temp = fields[0];
-    size_t position = temp.find('(');
-    if (position == std::string::npos)
-        DTRACE_ERROR("DTRACE_ACTION_INVALID_TOKEN_FORMAT", 
-            "Invalid token: '" << token << "' Expected 'print(fmt)'");
+    aiebu::smatch action;
+    if (!aiebu::regex_match(fields[0], action, action_name::action_regex))
+        DTRACE_ERROR("DTRACE_ACTION_INVALID_TOKEN", 
+            "Invalid token: '" << token << "' Expected 'printa(fmt)'");
 
-    m_action_name = temp.substr(0, position);
+    m_action_name = action[1];
+    std::string argument_string = action[2];
+
     // Validate and parse the length argument
-    std::string argument_string = temp.substr(position + 1, temp.length() - position - 2);
     std::stringstream argument_stream(argument_string);
     while (std::getline(argument_stream, item, ','))
-        m_arguments.push_back(strip(item));
+        m_arguments.push_back(action::strip(item));
 
     if (m_arguments.size() < 1)
         DTRACE_ERROR("DTRACE_ACTION_INVALID_TOKEN_ARGUMENTS", 
@@ -190,7 +190,9 @@ serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&,
     const std::unordered_map<uint32_t, uint32_t>&) const
 {
     std::ostringstream output_action;
-    output_action << "  " << "print(\"\"\"\n" << format(result_buffer) << "  " << "\"\"\")\n";
+    if (m_output_format == dtrace::dtrace_output_format::python)
+        output_action << "  " << "print(\"\"\"\n" << format(result_buffer) << "  " << "\"\"\")\n";
+
     return output_action.str();
 }
 

--- a/src/cpp/dtrace/action/printa.cpp
+++ b/src/cpp/dtrace/action/printa.cpp
@@ -98,9 +98,9 @@ get_opcode(const uint32_t& value) const
     return {"", dtrace::dtrace_ctrl::mask_8};
 }
 
-//-------------------------printa_action::format-------------------------//
+//-------------------------printa_action::serialize_helper-------------------------//
 /**
- * format() - Formats and prints the results from the result buffer.
+ * serialize_helper() - Formats and prints the results from the result buffer.
  *
  * @param result_buffer 
  *  A vector of uint32_t values containing the result data.
@@ -111,7 +111,7 @@ get_opcode(const uint32_t& value) const
  */
 std::string
 printa_action::
-format(const std::vector<uint32_t>& result_buffer) const
+serialize_helper(const std::vector<uint32_t>& result_buffer) const
 {
     constexpr int name_width = 50;
     constexpr int samples_width = 16;
@@ -180,20 +180,31 @@ format(const std::vector<uint32_t>& result_buffer) const
  * @param result_buffer
  * @param mem_buffer
  * @param mapping
- *
- * @return 
- *  String representing the serialized profile print action.
+ * @param script_output
  */
-std::string
+void
 printa_action::
 serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&, 
-    const std::unordered_map<uint32_t, uint32_t>&) const
+    const std::unordered_map<uint32_t, uint32_t>&, std::ostream& script_output) const
 {
-    std::ostringstream output_action;
-    if (m_output_format == dtrace::dtrace_output_format::python)
-        output_action << "  " << "print(\"\"\"\n" << format(result_buffer) << "  " << "\"\"\")\n";
+    // serialize string format
+    script_output << "  " << "print(\"\"\"\n" << printa_action::serialize_helper(result_buffer) << "  " << "\"\"\")\n";
+}
 
-    return output_action.str();
+//-------------------------printa_action::serialize-------------------------//
+/**
+ * serialize() - Serializes the profile print action into json format.
+ *
+ * @param result_buffer
+ * @param mem_buffer
+ * @param mapping
+ * @param json_output
+ */
+void
+printa_action::
+serialize(std::vector<uint32_t>&, std::vector<uint32_t>&, 
+    const std::unordered_map<uint32_t, uint32_t>&, json&) const
+{
 }
 
 } // namespace dtrace::action

--- a/src/cpp/dtrace/action/profile.cpp
+++ b/src/cpp/dtrace/action/profile.cpp
@@ -69,20 +69,29 @@ actionize(uint32_t, std::vector<uint32_t>&, std::vector<uint32_t>&)
  * @param result_buffer
  * @param mem_buffer
  * @param mapping
- *
- * @return 
- *  String representing the serialized profile action.
+ * @param script_output
  */
-std::string
+void
 profile_action::
 serialize(std::vector<uint32_t>&, std::vector<uint32_t>&, 
-    const std::unordered_map<uint32_t, uint32_t>&) const
+    const std::unordered_map<uint32_t, uint32_t>&, std::ostream&) const
 {
-    std::ostringstream output_action;
-    if (m_output_format == dtrace::dtrace_output_format::python)
-        output_action << "#" << " " << m_token << "\n";
+}
 
-    return output_action.str();
+//-------------------------profile_action::serialize-------------------------//
+/**
+ * serialize() - Serializes the profile action into json format.
+ *
+ * @param result_buffer
+ * @param mem_buffer
+ * @param mapping
+ * @param json_output
+ */
+void
+profile_action::
+serialize(std::vector<uint32_t>&, std::vector<uint32_t>&, 
+    const std::unordered_map<uint32_t, uint32_t>&, json&) const
+{
 }
 
 } // namespace dtrace::action

--- a/src/cpp/dtrace/action/profile.cpp
+++ b/src/cpp/dtrace/action/profile.cpp
@@ -27,13 +27,11 @@ profile_action(std::string token, uint32_t probe_type, const std::string& probe_
     std::stringstream token_stream(m_token);
     std::string item;
     while (std::getline(token_stream, item, '='))
-        fields.push_back(strip(item));
+        fields.push_back(action::strip(item));
 
     if (fields.size() != 2)
         DTRACE_ERROR("DTRACE_ACTION_INVALID_TOKEN_FORMAT", 
             "Invalid token: '" << m_token << "' Expected 'val = opcode()'");
-
-    m_result = fields[0];
 
     aiebu::smatch action;
     if (!aiebu::regex_match(fields[1], action, action_name::action_regex))
@@ -45,7 +43,7 @@ profile_action(std::string token, uint32_t probe_type, const std::string& probe_
 
     std::stringstream argument_stream(argument_string);
     while (std::getline(argument_stream, item, ','))
-        m_arguments.push_back(strip(item));
+        m_arguments.push_back(action::strip(item));
 
 }
 
@@ -81,7 +79,9 @@ serialize(std::vector<uint32_t>&, std::vector<uint32_t>&,
     const std::unordered_map<uint32_t, uint32_t>&) const
 {
     std::ostringstream output_action;
-    output_action << "#" << " " << m_token << "\n";
+    if (m_output_format == dtrace::dtrace_output_format::python)
+        output_action << "#" << " " << m_token << "\n";
+
     return output_action.str();
 }
 

--- a/src/cpp/dtrace/action/read_handshake.cpp
+++ b/src/cpp/dtrace/action/read_handshake.cpp
@@ -87,6 +87,35 @@ actionize(uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint
     control_buffer.push_back(dtrace::dtrace_ctrl::result_value_init);
 }
 
+//-------------------------read_handshake_action::serialize_helper-------------------------//
+/**
+ * serialize_helper() - Helper function to serialize action.
+ *
+ * @param result_buffer
+ * @param mapping
+ *
+ * @return 
+ *  The value from the result buffer based on the location mapping and
+ *  resets the value in the result buffer after serialization.
+ */
+uint32_t
+read_handshake_action::
+serialize_helper(std::vector<uint32_t>& result_buffer, 
+    const std::unordered_map<uint32_t, uint32_t>& mapping) const
+{
+    uint32_t location = mapping.at(get_location(false));
+    uint32_t value = result_buffer[location];
+    // reset value after serialization
+    result_buffer[location] = dtrace::dtrace_ctrl::result_value_init;
+    if (value == dtrace::dtrace_ctrl::handshake_overflow)
+    {
+        std::stringstream handshake_offset;
+        handshake_offset << "0x" << std::hex << (std::stoul(m_arguments[0]) * sizeof(uint32_t));
+        DTRACE_WARNING("HANDSHAKE_OVERFLOW (" << handshake_offset.str() << ")");
+    }
+    return value;
+}
+
 //-------------------------read_handshake_action::serialize-------------------------//
 /**
  * serialize() - Serializes the handshake read action into a string format.
@@ -94,36 +123,35 @@ actionize(uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint
  * @param result_buffer
  * @param mem_buffer
  * @param mapping
- *
- * @return 
- *  String representing the serialized handshake read action.
+ * @param script_output
  */
-std::string
+void
 read_handshake_action::
 serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&, 
-    const std::unordered_map<uint32_t, uint32_t>& mapping) const
+    const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output) const
 {
-    std::ostringstream output_action;
-    uint32_t location = mapping.at(get_location(false));
+    uint32_t result = read_handshake_action::serialize_helper(result_buffer, mapping);
+    // serialize string format
+    script_output << "  " << m_result << " = " << result << "\n";
+}
 
-    if (m_output_format == dtrace::dtrace_output_format::python)
-    {
-        if (result_buffer[location] == dtrace::dtrace_ctrl::handshake_overflow)
-        {
-            std::stringstream handshake_offset;
-            handshake_offset << "0x" << std::hex << (std::stoul(m_arguments[0]) * sizeof(uint32_t));
-            output_action << "  " << "print(\"[WARNING] HANDSHAKE OVERFLOW (" << handshake_offset.str() << ")\")\n";
-        }
-        output_action << "  " << m_result << " = " << result_buffer[location] << "\n";
-    }
-    else if (m_output_format == dtrace::dtrace_output_format::json)
-    {
-        output_action << result_buffer[location];
-    } 
-
-    // reset value after serialization
-    result_buffer[location] = dtrace::dtrace_ctrl::result_value_init;
-    return output_action.str();
+//-------------------------read_handshake_action::serialize-------------------------//
+/**
+ * serialize() - Serializes the handshake read action into json format.
+ *
+ * @param result_buffer
+ * @param mem_buffer
+ * @param mapping
+ * @param json_output
+ */
+void
+read_handshake_action::
+serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&, 
+    const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output) const
+{
+    uint32_t result = read_handshake_action::serialize_helper(result_buffer, mapping);
+    // serialize json format
+    json_output[m_probe_name][m_result] = result;
 }
 
 } // namespace dtrace::action

--- a/src/cpp/dtrace/action/read_handshake.cpp
+++ b/src/cpp/dtrace/action/read_handshake.cpp
@@ -26,7 +26,7 @@ read_handshake_action(std::string token, uint32_t probe_type, const std::string&
     std::stringstream token_stream(token);
     std::string item;
     while (std::getline(token_stream, item, '='))
-        fields.push_back(strip(item));
+        fields.push_back(action::strip(item));
 
     if (fields.size() != 2)
         DTRACE_ERROR("DTRACE_ACTION_INVALID_TOKEN", 
@@ -45,7 +45,7 @@ read_handshake_action(std::string token, uint32_t probe_type, const std::string&
     // Validate and parse the length argument
     std::stringstream argument_stream(argument_string);
     while (std::getline(argument_stream, item, ','))
-        m_arguments.push_back(strip(item));
+        m_arguments.push_back(action::strip(item));
 
     if (m_arguments.size() < 1)
         DTRACE_ERROR("DTRACE_ACTION_INVALID_TOKEN_ARGUMENTS", 
@@ -105,15 +105,24 @@ serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&,
 {
     std::ostringstream output_action;
     uint32_t location = mapping.at(get_location(false));
-    if (result_buffer[location] == dtrace::dtrace_ctrl::handshake_overflow)
+
+    if (m_output_format == dtrace::dtrace_output_format::python)
     {
-        std::stringstream handshake_offset;
-        handshake_offset << "0x" << std::hex << (std::stoul(m_arguments[0]) * sizeof(uint32_t));
-        output_action << "  " << "print(\"[WARNING] HANDSHAKE OVERFLOW (" << handshake_offset.str() << ")\")\n";
+        if (result_buffer[location] == dtrace::dtrace_ctrl::handshake_overflow)
+        {
+            std::stringstream handshake_offset;
+            handshake_offset << "0x" << std::hex << (std::stoul(m_arguments[0]) * sizeof(uint32_t));
+            output_action << "  " << "print(\"[WARNING] HANDSHAKE OVERFLOW (" << handshake_offset.str() << ")\")\n";
+        }
+        output_action << "  " << m_result << " = " << result_buffer[location] << "\n";
     }
-    output_action << "  " << m_result << " = " << result_buffer[location] << "\n";
+    else if (m_output_format == dtrace::dtrace_output_format::json)
+    {
+        output_action << result_buffer[location];
+    } 
+
     // reset value after serialization
-    result_buffer[location] = 0;
+    result_buffer[location] = dtrace::dtrace_ctrl::result_value_init;
     return output_action.str();
 }
 

--- a/src/cpp/dtrace/action/read_mem.cpp
+++ b/src/cpp/dtrace/action/read_mem.cpp
@@ -31,7 +31,7 @@ read_mem_action(std::string token, uint32_t probe_type, const std::string& probe
     std::stringstream token_stream(token);
     std::string item;
     while (std::getline(token_stream, item, '='))
-        fields.push_back(strip(item));
+        fields.push_back(action::strip(item));
 
     if (fields.size() != 2)
         DTRACE_ERROR("DTRACE_ACTION_INVALID_TOKEN", 
@@ -50,7 +50,7 @@ read_mem_action(std::string token, uint32_t probe_type, const std::string& probe
     // Validate and parse the length argument
     std::stringstream argument_stream(argument_string);
     while (std::getline(argument_stream, item, ','))
-        m_arguments.push_back(strip(item));
+        m_arguments.push_back(action::strip(item));
 
     if (m_arguments.size() < 2)
         DTRACE_ERROR("DTRACE_ACTION_INVALID_TOKEN_ARGUMENTS", 
@@ -148,21 +148,34 @@ serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffe
     const std::unordered_map<uint32_t, uint32_t>& mapping) const
 {
     std::ostringstream readable_result;
+    std::ostringstream readable_json_result;
     uint32_t index = get_location(true);
     uint32_t aie_addr = result_buffer[mapping.at(get_location(false))];
     uint32_t length = result_buffer[mapping.at(get_location(false) + 1)];
     for (uint32_t i = index; i < index+length; ++i)
     {
+        readable_json_result << mem_buffer[i];
         readable_result << "  0x" << std::hex << aie_addr
-            << ": 0x" << std::hex << mem_buffer[i];
-        if (i < index+length - 1)
+                        << ": 0x" << std::hex << mem_buffer[i];
+        if (i < index+length - 1) 
+        {
+            readable_json_result << ", ";
             readable_result << "\n";
+        }
         aie_addr += dtrace::dtrace_ctrl::word_byte_size;
         // reset value after serialization
-        mem_buffer[i] = 0;
+        mem_buffer[i] = dtrace::dtrace_ctrl::result_value_init;
     }
+
     std::ostringstream output_action;
-    output_action << "  " << m_result << " = \"\"\"\n" << readable_result.str() << "\"\"\"\n";
+    if (m_output_format == dtrace::dtrace_output_format::python)
+    {
+        output_action << "  " << m_result << " = \"\"\"\n" << readable_result.str() << "\"\"\"\n";
+    }
+    else if (m_output_format == dtrace::dtrace_output_format::json)
+    {
+        output_action << readable_json_result.str();
+    }
     return output_action.str();
 }
 

--- a/src/cpp/dtrace/action/read_mem.cpp
+++ b/src/cpp/dtrace/action/read_mem.cpp
@@ -2,6 +2,7 @@
 // Copyright (C) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.
 
 #include "dtrace/action/action_control.h"
+#include <iomanip>
 #include <sstream>
 #include <stdexcept>
 
@@ -131,6 +132,35 @@ actionize(uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint
         mem_buffer.insert(mem_buffer.end(), m_length, dtrace::dtrace_ctrl::result_value_init);
 }
 
+//-------------------------read_mem_action::serialize_helper-------------------------//
+/**
+ * serialize_helper() - Helper function to serialize action.
+ *
+ * @param result_buffer
+ * @param mem_buffer
+ * @param mapping
+ *
+ * @return 
+ *  The value from the result buffer based on the location mapping and
+ *  resets the value in the result buffer after serialization.
+ */
+std::vector<uint32_t>
+read_mem_action::
+serialize_helper(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
+    const std::unordered_map<uint32_t, uint32_t>& mapping) const
+{
+    std::vector<uint32_t> result;
+    uint32_t index = get_location(true);
+    uint32_t length = result_buffer[mapping.at(get_location(false) + 1)];
+    for (uint32_t i = index; i < index+length; ++i)
+    {        
+        result.push_back(mem_buffer[i]);
+        // reset value after serialization
+        mem_buffer[i] = dtrace::dtrace_ctrl::result_value_init;
+    }
+    return result;
+}
+
 //-------------------------read_mem_action::serialize-------------------------//
 /**
  * serialize() - Serializes the read memory register action into a string format.
@@ -138,45 +168,46 @@ actionize(uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint
  * @param result_buffer
  * @param mem_buffer
  * @param mapping
- *
- * @return 
- *  String representing the serialized read memory register action.
+ * @param script_output
  */
-std::string
+void
 read_mem_action::
 serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
-    const std::unordered_map<uint32_t, uint32_t>& mapping) const
+    const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output) const
 {
-    std::ostringstream readable_result;
-    std::ostringstream readable_json_result;
-    uint32_t index = get_location(true);
-    uint32_t aie_addr = result_buffer[mapping.at(get_location(false))];
-    uint32_t length = result_buffer[mapping.at(get_location(false) + 1)];
-    for (uint32_t i = index; i < index+length; ++i)
+    std::vector<uint32_t> result = read_mem_action::serialize_helper(result_buffer, mem_buffer, mapping);
+    // serialize string format
+    script_output << "  " << m_result << " = \"[";
+    for (uint32_t i = 0; i < result.size(); ++i)
     {
-        readable_json_result << mem_buffer[i];
-        readable_result << "  0x" << std::hex << aie_addr
-                        << ": 0x" << std::hex << mem_buffer[i];
-        if (i < index+length - 1) 
-        {
-            readable_json_result << ", ";
-            readable_result << "\n";
-        }
-        aie_addr += dtrace::dtrace_ctrl::word_byte_size;
-        // reset value after serialization
-        mem_buffer[i] = dtrace::dtrace_ctrl::result_value_init;
+        script_output << "0x" << std::hex << std::setfill('0') << std::setw(8) << result[i] << std::dec;
+        if (i != result.size() - 1)
+            script_output << ", ";
     }
+    script_output << "]\"\n";
+}
 
-    std::ostringstream output_action;
-    if (m_output_format == dtrace::dtrace_output_format::python)
-    {
-        output_action << "  " << m_result << " = \"\"\"\n" << readable_result.str() << "\"\"\"\n";
-    }
-    else if (m_output_format == dtrace::dtrace_output_format::json)
-    {
-        output_action << readable_json_result.str();
-    }
-    return output_action.str();
+//-------------------------read_mem_action::serialize-------------------------//
+/**
+ * serialize() - Serializes the read memory register action into json format.
+ *
+ * @param result_buffer
+ * @param mem_buffer
+ * @param mapping
+ * @param json_output
+ */
+void
+read_mem_action::
+serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
+    const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output) const
+{
+    std::vector<uint32_t> result = read_mem_action::serialize_helper(result_buffer, mem_buffer, mapping);
+    // serialize json format
+    json json_result = json::array();
+    for (uint32_t i = 0; i < result.size(); ++i)
+        json_result.push_back(result[i]);
+
+    json_output[m_probe_name][m_result] = json_result;
 }
 
 } // namespace dtrace::action

--- a/src/cpp/dtrace/action/read_register.cpp
+++ b/src/cpp/dtrace/action/read_register.cpp
@@ -26,7 +26,7 @@ read_reg_action(std::string token, uint32_t probe_type, const std::string& probe
     std::stringstream token_stream(token);
     std::string item;
     while (std::getline(token_stream, item, '='))
-        fields.push_back(strip(item));
+        fields.push_back(action::strip(item));
 
     if (fields.size() != 2)
         DTRACE_ERROR("DTRACE_ACTION_INVALID_TOKEN", 
@@ -45,7 +45,7 @@ read_reg_action(std::string token, uint32_t probe_type, const std::string& probe
     // Validate and parse the length argument
     std::stringstream argument_stream(argument_string);
     while (std::getline(argument_stream, item, ','))
-        m_arguments.push_back(strip(item));
+        m_arguments.push_back(action::strip(item));
 
     if (m_arguments.size() < 1)
         DTRACE_ERROR("DTRACE_ACTION_INVALID_TOKEN_ARGUMENTS", 
@@ -95,9 +95,18 @@ serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&,
 {
     std::ostringstream output_action;
     uint32_t location = mapping.at(get_location(false));
-    output_action << "  " << m_result << " = " << result_buffer[location] << "\n";
+
+    if (m_output_format == dtrace::dtrace_output_format::python)
+    {
+        output_action << "  " << m_result << " = " << result_buffer[location] << "\n";
+    }
+    else if (m_output_format == dtrace::dtrace_output_format::json)
+    {
+        output_action << result_buffer[location];
+    } 
+
     // reset value after serialization
-    result_buffer[location] = 0;
+    result_buffer[location] = dtrace::dtrace_ctrl::result_value_init;
     return output_action.str();
 }
 

--- a/src/cpp/dtrace/action/read_register.cpp
+++ b/src/cpp/dtrace/action/read_register.cpp
@@ -77,6 +77,29 @@ actionize(uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint
     control_buffer.push_back(dtrace::dtrace_ctrl::result_value_init);
 }
 
+//-------------------------read_reg_action::serialize_helper-------------------------//
+/**
+ * serialize_helper() - Helper function to serialize action.
+ *
+ * @param result_buffer
+ * @param mapping
+ *
+ * @return 
+ *  The value from the result buffer based on the location mapping and
+ *  resets the value in the result buffer after serialization.
+ */
+uint32_t
+read_reg_action::
+serialize_helper(std::vector<uint32_t>& result_buffer, 
+    const std::unordered_map<uint32_t, uint32_t>& mapping) const
+{
+    uint32_t location = mapping.at(get_location(false));
+    uint32_t value = result_buffer[location];
+    // reset value after serialization
+    result_buffer[location] = dtrace::dtrace_ctrl::result_value_init;
+    return value;
+}
+
 //-------------------------read_reg_action::serialize-------------------------//
 /**
  * serialize() - Serializes the register read action into a string format.
@@ -84,30 +107,35 @@ actionize(uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint
  * @param result_buffer
  * @param mem_buffer
  * @param mapping
- *
- * @return 
- *  String representing the serialized register read action.
+ * @param script_output
  */
-std::string
+void
 read_reg_action::
 serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&, 
-    const std::unordered_map<uint32_t, uint32_t>& mapping) const
+    const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output) const
 {
-    std::ostringstream output_action;
-    uint32_t location = mapping.at(get_location(false));
+    uint32_t result = read_reg_action::serialize_helper(result_buffer, mapping);
+    // serialize string format
+    script_output << "  " << m_result << " = " << result << "\n";
+}
 
-    if (m_output_format == dtrace::dtrace_output_format::python)
-    {
-        output_action << "  " << m_result << " = " << result_buffer[location] << "\n";
-    }
-    else if (m_output_format == dtrace::dtrace_output_format::json)
-    {
-        output_action << result_buffer[location];
-    } 
-
-    // reset value after serialization
-    result_buffer[location] = dtrace::dtrace_ctrl::result_value_init;
-    return output_action.str();
+//-------------------------read_reg_action::serialize-------------------------//
+/**
+ * serialize() - Serializes the read memory register action into json format.
+ *
+ * @param result_buffer
+ * @param mem_buffer
+ * @param mapping
+ * @param json_output
+ */
+void
+read_reg_action::
+serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&, 
+    const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output) const
+{
+    uint32_t result = read_reg_action::serialize_helper(result_buffer, mapping);
+    // serialize json format
+    json_output[m_probe_name][m_result] = result;
 }
 
 } // namespace dtrace::action

--- a/src/cpp/dtrace/action/sleep.cpp
+++ b/src/cpp/dtrace/action/sleep.cpp
@@ -75,20 +75,29 @@ actionize(uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint
  * @param result_buffer
  * @param mem_buffer
  * @param mapping
- *
- * @return 
- *  String representing the serialized sleep action.
+ * @param script_output
  */
-std::string
+void
 sleep_action::
 serialize(std::vector<uint32_t>&, std::vector<uint32_t>&, 
-    const std::unordered_map<uint32_t, uint32_t>&) const
+    const std::unordered_map<uint32_t, uint32_t>&, std::ostream&) const
 {
-    std::ostringstream output_action;
-    if (m_output_format == dtrace::dtrace_output_format::python)
-        output_action << "  " << "#" << " " << m_action_name << " " << m_arguments[0] << "cycles" << "\n";
+}
 
-    return output_action.str();
+//-------------------------sleep_action::serialize-------------------------//
+/**
+ * serialize() - Serializes the sleep action into json format.
+ *
+ * @param result_buffer
+ * @param mem_buffer
+ * @param mapping
+ * @param json_output
+ */
+void
+sleep_action::
+serialize(std::vector<uint32_t>&, std::vector<uint32_t>&, 
+    const std::unordered_map<uint32_t, uint32_t>&, json&) const
+{
 }
 
 } // namespace dtrace::action

--- a/src/cpp/dtrace/action/sleep.cpp
+++ b/src/cpp/dtrace/action/sleep.cpp
@@ -26,7 +26,7 @@ sleep_action(std::string token, uint32_t probe_type, const std::string& probe_na
     std::stringstream token_stream(token);
     std::string item;
     while (std::getline(token_stream, item, '='))
-        fields.push_back(strip(item));
+        fields.push_back(action::strip(item));
 
     aiebu::smatch action;
     if (!aiebu::regex_match(fields[0], action, action_name::action_regex))
@@ -39,7 +39,7 @@ sleep_action(std::string token, uint32_t probe_type, const std::string& probe_na
     // Validate and parse the length argument
     std::stringstream argument_stream(argument_string);
     while (std::getline(argument_stream, item, ','))
-        m_arguments.push_back(strip(item));
+        m_arguments.push_back(action::strip(item));
 
     if (m_arguments.size() < 1)
         DTRACE_ERROR("DTRACE_ACTION_INVALID_TOKEN_ARGUMENTS", 
@@ -85,7 +85,9 @@ serialize(std::vector<uint32_t>&, std::vector<uint32_t>&,
     const std::unordered_map<uint32_t, uint32_t>&) const
 {
     std::ostringstream output_action;
-    output_action << "  " << "#" << " " << m_action_name << " " << m_arguments[0] << "cycles" << "\n";
+    if (m_output_format == dtrace::dtrace_output_format::python)
+        output_action << "  " << "#" << " " << m_action_name << " " << m_arguments[0] << "cycles" << "\n";
+
     return output_action.str();
 }
 

--- a/src/cpp/dtrace/action/timestamp.cpp
+++ b/src/cpp/dtrace/action/timestamp.cpp
@@ -67,6 +67,33 @@ actionize(uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint
     control_buffer.push_back(dtrace::dtrace_ctrl::result_value_init);
 }
 
+//-------------------------timestamp_action::serialize_helper-------------------------//
+/**
+ * serialize_helper() - Helper function to serialize action.
+ *
+ * @param result_buffer
+ * @param mapping
+ *
+ * @return 
+ *  The value from the result buffer based on the location mapping and
+ *  resets the value in the result buffer after serialization.
+ */
+uint64_t
+timestamp_action::
+serialize_helper(std::vector<uint32_t>& result_buffer, 
+    const std::unordered_map<uint32_t, uint32_t>& mapping) const
+{
+    uint32_t location_h = mapping.at(get_location(false));
+    uint32_t location_l = mapping.at(get_location(false) + 1);
+    uint64_t high = 
+        static_cast<uint64_t>(result_buffer[location_h]) << dtrace::dtrace_ctrl::forth_byte_shift;
+    uint64_t low = result_buffer[location_l];
+    // reset value after serialization
+    result_buffer[location_h] = dtrace::dtrace_ctrl::result_value_init;
+    result_buffer[location_l] = dtrace::dtrace_ctrl::result_value_init;
+    return (high + low);
+}
+
 //-------------------------timestamp_action::serialize-------------------------//
 /**
  * serialize() - Serializes the timestamp action into a string format.
@@ -74,35 +101,35 @@ actionize(uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint
  * @param result_buffer
  * @param mem_buffer
  * @param mapping
- *
- * @return 
- *  String representing the serialized timestamp action.
+ * @param script_output
  */
-std::string
+void
 timestamp_action::
 serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&, 
-    const std::unordered_map<uint32_t, uint32_t>& mapping) const
+    const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output) const
 {
-    std::ostringstream output_action;
-    uint32_t location_h = mapping.at(get_location(false));
-    uint32_t location_l = mapping.at(get_location(false) + 1);
-    uint64_t high = 
-        static_cast<uint64_t>(result_buffer[location_h]) << dtrace::dtrace_ctrl::forth_byte_shift;
-    uint64_t low = result_buffer[location_l];
+    uint64_t result = timestamp_action::serialize_helper(result_buffer, mapping);
+    // serialize string format
+    script_output << "  " << m_result << " = " << result << "\n";
+}
 
-    if (m_output_format == dtrace::dtrace_output_format::python)
-    {
-        output_action << "  " << m_result << " = " << (high + low) << "\n";
-    }
-    else if (m_output_format == dtrace::dtrace_output_format::json)
-    {
-        output_action << (high + low);
-    } 
-
-    // reset value after serialization
-    result_buffer[location_h] = dtrace::dtrace_ctrl::result_value_init;
-    result_buffer[location_l] = dtrace::dtrace_ctrl::result_value_init;
-    return output_action.str();
+//-------------------------timestamp_action::serialize-------------------------//
+/**
+ * serialize() - Serializes the timestamp action into json format.
+ *
+ * @param result_buffer
+ * @param mem_buffer
+ * @param mapping
+ * @param json_output
+ */
+void
+timestamp_action::
+serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&, 
+    const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output) const
+{
+    uint64_t result = timestamp_action::serialize_helper(result_buffer, mapping);
+    // serialize json format
+    json_output[m_probe_name][m_result] = result;
 }
 
 } // namespace dtrace::action

--- a/src/cpp/dtrace/action/timestamp.cpp
+++ b/src/cpp/dtrace/action/timestamp.cpp
@@ -26,7 +26,7 @@ timestamp_action(std::string token, uint32_t probe_type, const std::string& prob
     std::stringstream token_stream(token);
     std::string item;
     while (std::getline(token_stream, item, '='))
-        fields.push_back(strip(item));
+        fields.push_back(action::strip(item));
 
     if (fields.size() != 2)
         DTRACE_ERROR("DTRACE_ACTION_INVALID_TOKEN", 
@@ -89,10 +89,19 @@ serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&,
     uint64_t high = 
         static_cast<uint64_t>(result_buffer[location_h]) << dtrace::dtrace_ctrl::forth_byte_shift;
     uint64_t low = result_buffer[location_l];
-    output_action << "  " << m_result << " = " << (high + low) << "\n";
+
+    if (m_output_format == dtrace::dtrace_output_format::python)
+    {
+        output_action << "  " << m_result << " = " << (high + low) << "\n";
+    }
+    else if (m_output_format == dtrace::dtrace_output_format::json)
+    {
+        output_action << (high + low);
+    } 
+
     // reset value after serialization
-    result_buffer[location_h] = 0;
-    result_buffer[location_l] = 0;
+    result_buffer[location_h] = dtrace::dtrace_ctrl::result_value_init;
+    result_buffer[location_l] = dtrace::dtrace_ctrl::result_value_init;
     return output_action.str();
 }
 

--- a/src/cpp/dtrace/action/timestamp32.cpp
+++ b/src/cpp/dtrace/action/timestamp32.cpp
@@ -26,7 +26,7 @@ timestamp32_action(std::string token, uint32_t probe_type, const std::string& pr
     std::stringstream token_stream(token);
     std::string item;
     while (std::getline(token_stream, item, '='))
-        fields.push_back(strip(item));
+        fields.push_back(action::strip(item));
 
     if (fields.size() != 2)
         DTRACE_ERROR("DTRACE_ACTION_INVALID_TOKEN", 
@@ -83,9 +83,18 @@ serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&,
 {
     std::ostringstream output_action;
     uint32_t location = mapping.at(get_location(false));
-    output_action << "  " << m_result << " = " << result_buffer[location] << "\n";
+
+    if (m_output_format == dtrace::dtrace_output_format::python)
+    {
+        output_action << "  " << m_result << " = " << result_buffer[location] << "\n";
+    }
+    else if (m_output_format == dtrace::dtrace_output_format::json)
+    {
+        output_action << result_buffer[location];
+    } 
+
     // reset value after serialization
-    result_buffer[location] = 0;
+    result_buffer[location] = dtrace::dtrace_ctrl::result_value_init;
     return output_action.str();
 }
 

--- a/src/cpp/dtrace/action/timestamp32.cpp
+++ b/src/cpp/dtrace/action/timestamp32.cpp
@@ -65,6 +65,29 @@ actionize(uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint
     control_buffer.push_back(dtrace::dtrace_ctrl::result_value_init);
 }
 
+//-------------------------timestamp32_action::serialize_helper-------------------------//
+/**
+ * serialize_helper() - Helper function to serialize action.
+ *
+ * @param result_buffer
+ * @param mapping
+ *
+ * @return 
+ *  The value from the result buffer based on the location mapping and
+ *  resets the value in the result buffer after serialization.
+ */
+uint32_t
+timestamp32_action::
+serialize_helper(std::vector<uint32_t>& result_buffer, 
+    const std::unordered_map<uint32_t, uint32_t>& mapping) const
+{
+    uint32_t location = mapping.at(get_location(false));
+    uint32_t result = result_buffer[location];
+    // reset value after serialization
+    result_buffer[location] = dtrace::dtrace_ctrl::result_value_init;
+    return result;
+}
+
 //-------------------------timestamp32_action::serialize-------------------------//
 /**
  * serialize() - Serializes the timestamp 32-bit action into a string format.
@@ -72,30 +95,35 @@ actionize(uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint
  * @param result_buffer
  * @param mem_buffer
  * @param mapping
- *
- * @return 
- *  String representing the serialized timestamp 32-bit action.
+ * @param script_output
  */
-std::string
+void
 timestamp32_action::
 serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&, 
-    const std::unordered_map<uint32_t, uint32_t>& mapping) const
+    const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output) const
 {
-    std::ostringstream output_action;
-    uint32_t location = mapping.at(get_location(false));
+    uint32_t result = timestamp32_action::serialize_helper(result_buffer, mapping);
+    // serialize string format
+    script_output << "  " << m_result << " = " << result << "\n";
+}
 
-    if (m_output_format == dtrace::dtrace_output_format::python)
-    {
-        output_action << "  " << m_result << " = " << result_buffer[location] << "\n";
-    }
-    else if (m_output_format == dtrace::dtrace_output_format::json)
-    {
-        output_action << result_buffer[location];
-    } 
-
-    // reset value after serialization
-    result_buffer[location] = dtrace::dtrace_ctrl::result_value_init;
-    return output_action.str();
+//-------------------------timestamp32_action::serialize-------------------------//
+/**
+ * serialize() - Serializes the timestamp 32-bit action into json format.
+ *
+ * @param result_buffer
+ * @param mem_buffer
+ * @param mapping
+ * @param json_output
+ */
+void
+timestamp32_action::
+serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&, 
+    const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output) const
+{
+    uint32_t result = timestamp32_action::serialize_helper(result_buffer, mapping);
+    // serialize json format
+    json_output[m_probe_name][m_result] = result;
 }
 
 } // namespace dtrace::action

--- a/src/cpp/dtrace/action/timestamps.cpp
+++ b/src/cpp/dtrace/action/timestamps.cpp
@@ -81,22 +81,22 @@ actionize(uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint
     }
 }
 
-//-------------------------timestamps_action::serialize-------------------------//
+//-------------------------timestamps_action::serialize_helper-------------------------//
 /**
- * serialize() - Serializes the timestamp action into a string format.
+ * serialize_helper() - Helper function to serialize action.
  *
  * @param result_buffer
- * @param mem_buffer
  * @param mapping
  *
  * @return 
- *  String representing the serialized timestamp action.
+ *  The value from the result buffer based on the location mapping and
+ *  resets the value in the result buffer after serialization.
  */
-std::string
+std::vector<uint64_t>
 timestamps_action::
-serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&, 
+serialize_helper(std::vector<uint32_t>& result_buffer, 
     const std::unordered_map<uint32_t, uint32_t>& mapping) const
-{   
+{
     std::vector<uint64_t> result;
     for (uint32_t i = 0; i < m_length; ++i) 
     {
@@ -109,25 +109,55 @@ serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&,
         result_buffer[location] = dtrace::dtrace_ctrl::result_value_init;
         result_buffer[location + 1] = dtrace::dtrace_ctrl::result_value_init;
     }
+    return result;
+}
 
-    std::ostringstream result_values;
-    for (size_t i = 0; i < result.size(); ++i) 
-    {
-        result_values << result[i];
+//-------------------------timestamps_action::serialize-------------------------//
+/**
+ * serialize() - Serializes the multiple timestamp action into a string format.
+ *
+ * @param result_buffer
+ * @param mem_buffer
+ * @param mapping
+ * @param script_output
+ */
+void
+timestamps_action::
+serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&, 
+    const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output) const
+{
+    std::vector<uint64_t> result = timestamps_action::serialize_helper(result_buffer, mapping);
+    // serialize string format
+    script_output << "  " << m_result << " = [";
+    for (size_t i = 0; i < result.size(); ++i) {
+        script_output << result[i];
         if (i != result.size() - 1)
-            result_values << ", ";
+            script_output << ", ";
     }
+    script_output << "]\n";
+}
 
-    std::ostringstream output_action;
-    if (m_output_format == dtrace::dtrace_output_format::python)
-    {
-        output_action << "  " << m_result << " = [" << result_values.str() << "]\n";
-    }
-    else if (m_output_format == dtrace::dtrace_output_format::json)
-    {
-        output_action << result_values.str();
-    }
-    return output_action.str();
+//-------------------------timestamps_action::serialize-------------------------//
+/**
+ * serialize() - Serializes the multiple timestamp action into json format.
+ *
+ * @param result_buffer
+ * @param mem_buffer
+ * @param mapping
+ * @param json_output
+ */
+void
+timestamps_action::
+serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&, 
+    const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output) const
+{
+    std::vector<uint64_t> result = timestamps_action::serialize_helper(result_buffer, mapping);
+    // serialize json format
+    json json_result = json::array();
+    for (uint32_t i = 0; i < result.size(); ++i)
+        json_result.push_back(result[i]);
+
+    json_output[m_probe_name][m_result] = json_result;
 }
 
 } // namespace dtrace::action

--- a/src/cpp/dtrace/action/timestamps.cpp
+++ b/src/cpp/dtrace/action/timestamps.cpp
@@ -26,7 +26,7 @@ timestamps_action(std::string token, uint32_t probe_type, const std::string& pro
     std::stringstream token_stream(token);
     std::string item;
     while (std::getline(token_stream, item, '='))
-        fields.push_back(strip(item));
+        fields.push_back(action::strip(item));
 
     if (fields.size() != 2)
         DTRACE_ERROR("DTRACE_ACTION_INVALID_TOKEN", 
@@ -96,29 +96,37 @@ std::string
 timestamps_action::
 serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&, 
     const std::unordered_map<uint32_t, uint32_t>& mapping) const
-{
-    
+{   
     std::vector<uint64_t> result;
-    for (uint32_t i = 0; i < m_length; ++i) {
+    for (uint32_t i = 0; i < m_length; ++i) 
+    {
         // action location + length word + high and low value
         uint32_t location = mapping.at(get_location(false)) + 1 + i*2;
         uint64_t high = static_cast<uint64_t>(result_buffer[location]) << dtrace::dtrace_ctrl::forth_byte_shift;
         uint64_t low = result_buffer[location + 1];
         result.push_back(high + low);
         // reset value after serialization
-        result_buffer[location] = 0;
-        result_buffer[location + 1] = 0;
+        result_buffer[location] = dtrace::dtrace_ctrl::result_value_init;
+        result_buffer[location + 1] = dtrace::dtrace_ctrl::result_value_init;
+    }
+
+    std::ostringstream result_values;
+    for (size_t i = 0; i < result.size(); ++i) 
+    {
+        result_values << result[i];
+        if (i != result.size() - 1)
+            result_values << ", ";
     }
 
     std::ostringstream output_action;
-    output_action << "  " << m_result << " = [";
-    for (size_t i = 0; i < result.size(); ++i) {
-        output_action << result[i];
-        if (i != result.size() - 1)
-            output_action << ", ";
+    if (m_output_format == dtrace::dtrace_output_format::python)
+    {
+        output_action << "  " << m_result << " = [" << result_values.str() << "]\n";
     }
-    output_action << "]\n";
-    
+    else if (m_output_format == dtrace::dtrace_output_format::json)
+    {
+        output_action << result_values.str();
+    }
     return output_action.str();
 }
 

--- a/src/cpp/dtrace/action/timestamps32.cpp
+++ b/src/cpp/dtrace/action/timestamps32.cpp
@@ -76,20 +76,20 @@ actionize(uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint
     control_buffer.insert(control_buffer.end(), m_length, dtrace::dtrace_ctrl::result_value_init);
 }
 
-//-------------------------timestamps32_action::serialize-------------------------//
+//-------------------------timestamps32_action::serialize_helper-------------------------//
 /**
- * serialize() - Serializes the multiple timestamp 32-bit action into a string format.
+ * serialize_helper() - Helper function to serialize action.
  *
  * @param result_buffer
- * @param mem_buffer
  * @param mapping
  *
  * @return 
- *  String representing the serialized multiple timestamp 32-bit action.
+ *  The value from the result buffer based on the location mapping and
+ *  resets the value in the result buffer after serialization.
  */
-std::string
+std::vector<uint32_t>
 timestamps32_action::
-serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&, 
+serialize_helper(std::vector<uint32_t>& result_buffer, 
     const std::unordered_map<uint32_t, uint32_t>& mapping) const
 {
     std::vector<uint32_t> result;
@@ -101,25 +101,56 @@ serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&,
         // reset value after serialization
         result_buffer[location] = dtrace::dtrace_ctrl::result_value_init;
     }
+    return result;
+}
 
-    std::ostringstream result_values;
-    for (size_t i = 0; i < result.size(); ++i) 
-    {
-        result_values << result[i];
+//-------------------------timestamps32_action::serialize-------------------------//
+/**
+ * serialize() - Serializes the multiple timestamp 32-bit action into a string format.
+ *
+ * @param result_buffer
+ * @param mem_buffer
+ * @param mapping
+ * @param script_output
+ */
+void
+timestamps32_action::
+serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&, 
+    const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output) const
+{
+    std::vector<uint32_t> result = timestamps32_action::serialize_helper(result_buffer, mapping);
+    // serialize string format
+    script_output << "  " << m_result << " = [";
+    for (size_t i = 0; i < result.size(); ++i) {
+        script_output << result[i];
         if (i != result.size() - 1)
-            result_values << ", ";
+            script_output << ", ";
     }
+    script_output << "]\n";
+}
 
-    std::ostringstream output_action;
-    if (m_output_format == dtrace::dtrace_output_format::python)
-    {
-        output_action << "  " << m_result << " = [" << result_values.str() << "]\n";
-    }
-    else if (m_output_format == dtrace::dtrace_output_format::json)
-    {
-        output_action << result_values.str();
-    }
-    return output_action.str();
+
+//-------------------------timestamps32_action::serialize-------------------------//
+/**
+ * serialize() - Serializes the multiple timestamp 32-bit action into json format.
+ *
+ * @param result_buffer
+ * @param mem_buffer
+ * @param mapping
+ * @param json_output
+ */
+void
+timestamps32_action::
+serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&, 
+    const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output) const
+{
+    std::vector<uint32_t> result = timestamps32_action::serialize_helper(result_buffer, mapping);
+    // serialize json format
+    json json_result = json::array();
+    for (uint32_t i = 0; i < result.size(); ++i)
+        json_result.push_back(result[i]);
+
+    json_output[m_probe_name][m_result] = json_result;
 }
 
 } // namespace dtrace::action

--- a/src/cpp/dtrace/action/timestamps32.cpp
+++ b/src/cpp/dtrace/action/timestamps32.cpp
@@ -26,7 +26,7 @@ timestamps32_action(std::string token, uint32_t probe_type, const std::string& p
     std::stringstream token_stream(token);
     std::string item;
     while (std::getline(token_stream, item, '='))
-        fields.push_back(strip(item));
+        fields.push_back(action::strip(item));
 
     if (fields.size() != 2)
         DTRACE_ERROR("DTRACE_ACTION_INVALID_TOKEN", 
@@ -92,24 +92,33 @@ timestamps32_action::
 serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&, 
     const std::unordered_map<uint32_t, uint32_t>& mapping) const
 {
-    
     std::vector<uint32_t> result;
-    for (uint32_t i = 0; i < m_length; ++i) {
+    for (uint32_t i = 0; i < m_length; ++i) 
+    {
         // action location + length word + timestamp value
         uint32_t location = mapping.at(get_location(false)) + 1 + i;
         result.push_back(result_buffer[location]);
         // reset value after serialization
-        result_buffer[location] = 0;
+        result_buffer[location] = dtrace::dtrace_ctrl::result_value_init;
+    }
+
+    std::ostringstream result_values;
+    for (size_t i = 0; i < result.size(); ++i) 
+    {
+        result_values << result[i];
+        if (i != result.size() - 1)
+            result_values << ", ";
     }
 
     std::ostringstream output_action;
-    output_action << "  " << m_result << " = [";
-    for (size_t i = 0; i < result.size(); ++i) {
-        output_action << result[i];
-        if (i != result.size() - 1)
-            output_action << ", ";
+    if (m_output_format == dtrace::dtrace_output_format::python)
+    {
+        output_action << "  " << m_result << " = [" << result_values.str() << "]\n";
     }
-    output_action << "]\n";
+    else if (m_output_format == dtrace::dtrace_output_format::json)
+    {
+        output_action << result_values.str();
+    }
     return output_action.str();
 }
 

--- a/src/cpp/dtrace/action/write_handshake.cpp
+++ b/src/cpp/dtrace/action/write_handshake.cpp
@@ -26,7 +26,7 @@ write_handshake_action(std::string token, uint32_t probe_type, const std::string
     std::stringstream token_stream(token);
     std::string item;
     while (std::getline(token_stream, item, '='))
-        fields.push_back(strip(item));
+        fields.push_back(action::strip(item));
 
     aiebu::smatch action;
     if (!aiebu::regex_match(fields[0], action, action_name::action_regex))
@@ -39,7 +39,7 @@ write_handshake_action(std::string token, uint32_t probe_type, const std::string
     // Validate and parse the length argument
     std::stringstream argument_stream(argument_string);
     while (std::getline(argument_stream, item, ','))
-        m_arguments.push_back(strip(item));
+        m_arguments.push_back(action::strip(item));
 
     if (m_arguments.size() < 2)
         DTRACE_ERROR("DTRACE_ACTION_INVALID_TOKEN_ARGUMENTS", 
@@ -97,21 +97,29 @@ write_handshake_action::
 serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&, 
     const std::unordered_map<uint32_t, uint32_t>& mapping) const
 {
-    std::ostringstream output_action;
+    std::stringstream handshake_offset;
     uint32_t location = mapping.at(get_location(false));
-    if (result_buffer[location] == dtrace::dtrace_ctrl::handshake_overflow)
+    bool handshake_overflow = (result_buffer[location] == dtrace::dtrace_ctrl::handshake_overflow);
+    if (handshake_overflow)
     {
-        std::stringstream handshake_offset;
         handshake_offset << "0x" << std::hex << (std::stoul(m_arguments[0]) * sizeof(uint32_t));
-        output_action << "  " << "print(\"[WARNING] HANDSHAKE OVERFLOW (" << handshake_offset.str() << ")\")\n";
         // reset value after serialization
         result_buffer[location] = std::stoul(m_arguments[1], nullptr, dtrace::dtrace_ctrl::hexadecimal_base);
     }
-    else
-    {
-        output_action << "  " << "#" << " " << m_action_name << "\n";
-    }
 
+    std::ostringstream output_action;
+    if (m_output_format == dtrace::dtrace_output_format::python)
+    {
+        if (result_buffer[location] == dtrace::dtrace_ctrl::handshake_overflow)
+            output_action << "  " << "print(\"[WARNING] HANDSHAKE OVERFLOW (" << handshake_offset.str() << ")\")\n";
+        else
+            output_action << "  " << "#" << " " << m_action_name << "\n";
+    }
+    else if (m_output_format == dtrace::dtrace_output_format::json)
+    {
+        if (handshake_overflow)
+            DTRACE_WARNING("HANDSHAKE_OVERFLOW (" << handshake_offset.str() << ")");
+    }
     return output_action.str();
 }
 

--- a/src/cpp/dtrace/action/write_handshake.cpp
+++ b/src/cpp/dtrace/action/write_handshake.cpp
@@ -81,6 +81,34 @@ actionize(uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint
     control_buffer.push_back(std::stoul(m_arguments[1], nullptr, dtrace::dtrace_ctrl::hexadecimal_base));
 }
 
+//-------------------------write_handshake_action::serialize_helper-------------------------//
+/**
+ * serialize_helper() - Helper function to serialize action.
+ *
+ * @param result_buffer
+ * @param mapping
+ *
+ * @return 
+ *  The value from the result buffer based on the location mapping and
+ *  resets the value in the result buffer after serialization.
+ */
+void
+write_handshake_action::
+serialize_helper(std::vector<uint32_t>& result_buffer, 
+    const std::unordered_map<uint32_t, uint32_t>& mapping) const
+{
+    uint32_t location = mapping.at(get_location(false));
+    uint32_t value = result_buffer[location];
+    // reset value after serialization
+    result_buffer[location] = std::stoul(m_arguments[1], nullptr, dtrace::dtrace_ctrl::hexadecimal_base);
+    if (value == dtrace::dtrace_ctrl::handshake_overflow)
+    {
+        std::stringstream handshake_offset;
+        handshake_offset << "0x" << std::hex << (std::stoul(m_arguments[0]) * sizeof(uint32_t));
+        DTRACE_WARNING("HANDSHAKE_OVERFLOW (" << handshake_offset.str() << ")");
+    }
+}
+
 //-------------------------write_handshake_action::serialize-------------------------//
 /**
  * serialize() - Serializes the handshake write action into a string format.
@@ -88,39 +116,31 @@ actionize(uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint
  * @param result_buffer
  * @param mem_buffer
  * @param mapping
- *
- * @return 
- *  String representing the serialized handshake write action.
+ * @param script_output
  */
-std::string
+void
 write_handshake_action::
 serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&, 
-    const std::unordered_map<uint32_t, uint32_t>& mapping) const
+    const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream&) const
 {
-    std::stringstream handshake_offset;
-    uint32_t location = mapping.at(get_location(false));
-    bool handshake_overflow = (result_buffer[location] == dtrace::dtrace_ctrl::handshake_overflow);
-    if (handshake_overflow)
-    {
-        handshake_offset << "0x" << std::hex << (std::stoul(m_arguments[0]) * sizeof(uint32_t));
-        // reset value after serialization
-        result_buffer[location] = std::stoul(m_arguments[1], nullptr, dtrace::dtrace_ctrl::hexadecimal_base);
-    }
+    write_handshake_action::serialize_helper(result_buffer, mapping);
+}
 
-    std::ostringstream output_action;
-    if (m_output_format == dtrace::dtrace_output_format::python)
-    {
-        if (handshake_overflow)
-            output_action << "  " << "print(\"[WARNING] HANDSHAKE OVERFLOW (" << handshake_offset.str() << ")\")\n";
-        else
-            output_action << "  " << "#" << " " << m_action_name << "\n";
-    }
-    else if (m_output_format == dtrace::dtrace_output_format::json)
-    {
-        if (handshake_overflow)
-            DTRACE_WARNING("HANDSHAKE_OVERFLOW (" << handshake_offset.str() << ")");
-    }
-    return output_action.str();
+//-------------------------write_handshake_action::serialize-------------------------//
+/**
+ * serialize() - Serializes the handshake write action into json format.
+ *
+ * @param result_buffer
+ * @param mem_buffer
+ * @param mapping
+ * @param json_output
+ */
+void
+write_handshake_action::
+serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&, 
+    const std::unordered_map<uint32_t, uint32_t>& mapping, json&) const
+{
+    write_handshake_action::serialize_helper(result_buffer, mapping);
 }
 
 } // namespace dtrace::action

--- a/src/cpp/dtrace/action/write_handshake.cpp
+++ b/src/cpp/dtrace/action/write_handshake.cpp
@@ -110,7 +110,7 @@ serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&,
     std::ostringstream output_action;
     if (m_output_format == dtrace::dtrace_output_format::python)
     {
-        if (result_buffer[location] == dtrace::dtrace_ctrl::handshake_overflow)
+        if (handshake_overflow)
             output_action << "  " << "print(\"[WARNING] HANDSHAKE OVERFLOW (" << handshake_offset.str() << ")\")\n";
         else
             output_action << "  " << "#" << " " << m_action_name << "\n";

--- a/src/cpp/dtrace/action/write_mem.cpp
+++ b/src/cpp/dtrace/action/write_mem.cpp
@@ -27,7 +27,7 @@ write_mem_action(std::string token, uint32_t probe_type, const std::string& prob
     std::stringstream token_stream(token);
     std::string item;
     while (std::getline(token_stream, item, '='))
-        fields.push_back(strip(item));
+        fields.push_back(action::strip(item));
 
     aiebu::smatch action;
     if (!aiebu::regex_match(fields[0], action, action_name::action_regex))
@@ -39,7 +39,7 @@ write_mem_action(std::string token, uint32_t probe_type, const std::string& prob
 
     std::stringstream argument_stream(argument_string);
     while (std::getline(argument_stream, item, ','))
-        m_arguments.push_back(strip(item));
+        m_arguments.push_back(action::strip(item));
 
     // Validate and parse the length argument
     if (m_arguments.size() < 3)
@@ -112,7 +112,9 @@ serialize(std::vector<uint32_t>&, std::vector<uint32_t>&,
     const std::unordered_map<uint32_t, uint32_t>&) const
 {
     std::ostringstream output_action;
-    output_action << "  " << "#" << " " << m_action_name << "\n";
+    if (m_output_format == dtrace::dtrace_output_format::python)
+        output_action << "  " << "#" << " " << m_action_name << "\n";
+
     return output_action.str();
 }
 

--- a/src/cpp/dtrace/action/write_mem.cpp
+++ b/src/cpp/dtrace/action/write_mem.cpp
@@ -97,25 +97,34 @@ actionize(uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint
 
 //-------------------------write_mem_action::serialize-------------------------//
 /**
- * serialize() - Serializes the write memory register action into a string format.
+ * serialize() - Serializes the write register memory action into a string format.
  *
  * @param result_buffer
  * @param mem_buffer
  * @param mapping
- *
- * @return 
- *  String representing the serialized write memory register action.
+ * @param script_output
  */
-std::string
+void
 write_mem_action::
 serialize(std::vector<uint32_t>&, std::vector<uint32_t>&, 
-    const std::unordered_map<uint32_t, uint32_t>&) const
+    const std::unordered_map<uint32_t, uint32_t>&, std::ostream&) const
 {
-    std::ostringstream output_action;
-    if (m_output_format == dtrace::dtrace_output_format::python)
-        output_action << "  " << "#" << " " << m_action_name << "\n";
+}
 
-    return output_action.str();
+//-------------------------write_mem_action::serialize-------------------------//
+/**
+ * serialize() - Serializes the write register memory action into json format.
+ *
+ * @param result_buffer
+ * @param mem_buffer
+ * @param mapping
+ * @param json_output
+ */
+void
+write_mem_action::
+serialize(std::vector<uint32_t>&, std::vector<uint32_t>&, 
+    const std::unordered_map<uint32_t, uint32_t>&, json&) const
+{
 }
 
 } // namespace dtrace::action

--- a/src/cpp/dtrace/action/write_register.cpp
+++ b/src/cpp/dtrace/action/write_register.cpp
@@ -26,7 +26,7 @@ write_reg_action(std::string token, uint32_t probe_type, const std::string& prob
     std::stringstream token_stream(token);
     std::string item;
     while (std::getline(token_stream, item, '='))
-        fields.push_back(strip(item));
+        fields.push_back(action::strip(item));
 
     aiebu::smatch action;
     if (!aiebu::regex_match(fields[0], action, action_name::action_regex))
@@ -39,7 +39,7 @@ write_reg_action(std::string token, uint32_t probe_type, const std::string& prob
     // Validate and parse the length argument
     std::stringstream argument_stream(argument_string);
     while (std::getline(argument_stream, item, ','))
-        m_arguments.push_back(strip(item));
+        m_arguments.push_back(action::strip(item));
 
     if (m_arguments.size() < 2)
         DTRACE_ERROR("DTRACE_ACTION_INVALID_TOKEN_ARGUMENTS", 
@@ -87,7 +87,9 @@ serialize(std::vector<uint32_t>&, std::vector<uint32_t>&,
     const std::unordered_map<uint32_t, uint32_t>&) const
 {
     std::ostringstream output_action;
-    output_action << "  " << "#" << " " << m_action_name << "\n";
+    if (m_output_format == dtrace::dtrace_output_format::python)
+        output_action << "  " << "#" << " " << m_action_name << "\n";
+
     return output_action.str();
 }
 

--- a/src/cpp/dtrace/action/write_register.cpp
+++ b/src/cpp/dtrace/action/write_register.cpp
@@ -72,25 +72,35 @@ actionize(uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint
 
 //-------------------------write_reg_action::serialize-------------------------//
 /**
- * serialize() - Serializes the register write action into a string format.
+ * serialize() - Serializes the write register action into a string format.
  *
  * @param result_buffer
  * @param mem_buffer
  * @param mapping
- *
- * @return 
- *  String representing the serialized register write action.
+ * @param script_output
  */
-std::string
+void
 write_reg_action::
 serialize(std::vector<uint32_t>&, std::vector<uint32_t>&, 
-    const std::unordered_map<uint32_t, uint32_t>&) const
+    const std::unordered_map<uint32_t, uint32_t>&, std::ostream&) const
 {
-    std::ostringstream output_action;
-    if (m_output_format == dtrace::dtrace_output_format::python)
-        output_action << "  " << "#" << " " << m_action_name << "\n";
-
-    return output_action.str();
 }
+
+//-------------------------write_reg_action::serialize-------------------------//
+/**
+ * serialize() - Serializes the write register action into json format.
+ *
+ * @param result_buffer
+ * @param mem_buffer
+ * @param mapping
+ * @param json_output
+ */
+void
+write_reg_action::
+serialize(std::vector<uint32_t>&, std::vector<uint32_t>&, 
+    const std::unordered_map<uint32_t, uint32_t>&, json&) const
+{
+}
+
 
 } // namespace dtrace::action

--- a/src/cpp/dtrace/control/control.cpp
+++ b/src/cpp/dtrace/control/control.cpp
@@ -2,6 +2,7 @@
 // Copyright (C) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.
 
 // This file defines the control class which is responsible for creating control buffers and result files.
+#include "json/nlohmann/json.hpp"
 #include "control.h"
 
 #include <fstream>
@@ -16,23 +17,11 @@
 
 namespace dtrace
 {
+// variable to store output format
+dtrace_output_format g_current_output_format = dtrace_output_format::python; // NOLINT
 
-//-------------------------Log Level-------------------------//
-// variable to store the current log level
-// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-static dtrace_log_level g_current_log_level = dtrace_log_level::dtrace_error;
-
-// Function to set the log level
-void set_log_level(uint32_t log_level) 
-{
-    g_current_log_level = static_cast<dtrace_log_level>(log_level);
-}
-
-// Function to get the current log level
-dtrace_log_level get_current_log_level() 
-{
-    return g_current_log_level;
-}
+// variable to store current log level
+dtrace_log_level g_current_log_level = dtrace_log_level::dtrace_error;  // NOLINT
 
 //-------------------------control::control-------------------------//
 /**
@@ -47,15 +36,15 @@ dtrace_log_level get_current_log_level()
  * file, and setting up control and memory buffers based on the parsed data.
  */
 control::
-control(std::string script_file, const std::string& map_data, uint32_t log_level)
+control(std::string script_file, const std::string& map_data)
     : m_pager(true)
     , m_parser(map_data)
+    , m_output_format(dtrace::get_output_format())
     , m_num_uCs(0)
     , m_mem_action_present(false)
 {
-    // Set the log level
-    dtrace::set_log_level(log_level);
-    DTRACE_INFO("DTRACE LOG LEVEL " << log_level);
+    DTRACE_INFO("DTRACE LOG LEVEL " << static_cast<int>(dtrace::get_current_log_level()));
+    DTRACE_INFO("DTRACE OUTPUT FORMAT " << static_cast<int>(m_output_format));
 
     // Read the script file
     // Open file in "at end" mode to check size
@@ -357,35 +346,105 @@ create_result_file(std::unordered_map<uint32_t, std::vector<uint32_t>>& result_b
             actions.emplace_back(action, uC_index);
     }
 
-    // Create python script
-    std::ofstream script_output(output_file);
-    if (!script_output)
-        DTRACE_ERROR("DTRACE_CONTROL_RESULT_FILE_NOT_FOUND", "result file: " << output_file);
-        
-    script_output << "#! /usr/bin/env python3\n";
-    script_output << "import sys\n\n";
-    script_output << "if __name__ == '__main__':\n";
-    for (const auto& item : actions)
+    if (m_output_format == dtrace::dtrace_output_format::python)
     {
-        const auto& action = item.first;
-        uint32_t loop_uC_index = item.second;
-        try 
+        // Create python script
+        std::ofstream script_output(output_file);
+        if (!script_output)
+            DTRACE_ERROR("DTRACE_CONTROL_RESULT_FILE_NOT_FOUND", "result file: " << output_file);
+            
+        script_output << "#! /usr/bin/env python3\n";
+        script_output << "import sys\n\n";
+        script_output << "if __name__ == '__main__':\n";
+        for (const auto& item : actions)
         {
-            script_output << action->serialize(
-                result_buffers.at(loop_uC_index), 
-                mem_buffers.at(loop_uC_index), 
-                m_pager.get_action_location_mapping(loop_uC_index)
-            );
-        } 
-        catch (const std::exception& e) 
-        {
-            DTRACE_ERROR("DTRACE_ACTION_SERIALIZE_FAILED", "Failed to serialize action " 
-                << action->create_string() << " for uC index " << loop_uC_index << ". Exception: " << e.what() 
-            );
+            const auto& action = item.first;
+            uint32_t loop_uC_index = item.second;
+            try 
+            {
+                script_output << action->serialize(
+                    result_buffers.at(loop_uC_index), 
+                    mem_buffers.at(loop_uC_index), 
+                    m_pager.get_action_location_mapping(loop_uC_index)
+                );
+            } 
+            catch (const std::exception& e) 
+            {
+                DTRACE_ERROR("DTRACE_ACTION_SERIALIZE_FAILED", "Failed to serialize action " 
+                    << action->create_string() << " for uC index " << loop_uC_index << ". Exception: " << e.what() 
+                );
+            }
         }
+        script_output << "  " << "sys.exit(0)\n";
+        script_output.close();
     }
-    script_output << "  " << "sys.exit(0)\n";
-    script_output.close();
+    else if (m_output_format == dtrace::dtrace_output_format::json)
+    {
+        // Create JSON output
+        using json = nlohmann::ordered_json;
+        json json_result = json::object();
+
+        for (const auto& item : actions)
+        {
+            const auto& action = item.first;
+            uint32_t loop_uC_index = item.second;
+            try
+            {
+                std::string action_key = action->get_action_name();
+                if (action_key.empty())
+                    continue; // Empty action keys
+
+                std::string probe_name = action->get_probe_name();
+                // Serialize action to get the value for the key-value pair in JSON
+                std::string action_value = action->serialize(
+                    result_buffers.at(loop_uC_index),
+                    mem_buffers.at(loop_uC_index),
+                    m_pager.get_action_location_mapping(loop_uC_index)
+                );
+
+                // Build JSON
+                if (action_value.empty())
+                    continue; // skip actions with no JSON output
+
+                // Parse action value for serialize json result and add to probe tree accordingly
+                if (action_value.find(',') != std::string::npos)
+                {
+                    json json_array = json::array();
+                    std::stringstream result_stream(action_value);
+                    std::string token;
+                    while (std::getline(result_stream, token, ','))
+                        json_array.push_back(std::stoull(dtrace::action::action::strip(token)));
+
+                    json_result[probe_name][action_key] = json_array;
+                }
+                else
+                {
+                    json_result[probe_name][action_key] = 
+                        std::stoull(dtrace::action::action::strip(action_value));
+                }
+            }
+            catch (const std::exception& e)
+            {
+                DTRACE_ERROR("DTRACE_ACTION_SERIALIZE_FAILED", "Failed to serialize action "
+                    << action->create_string() << " for uC index " << loop_uC_index << ". Exception: " << e.what()
+                );
+            }
+        }
+
+        // Write JSON to file
+        std::ofstream json_output(output_file);
+        if (!json_output)
+            DTRACE_ERROR("DTRACE_CONTROL_RESULT_FILE_NOT_FOUND", "result file: " << output_file);
+
+        json_output << json_result.dump(4) << "\n";
+        json_output.close();
+    }
+    else 
+    {
+        DTRACE_ERROR("DTRACE_OUTPUT_FORMAT_NOT_SUPPORTED", 
+            "Output format " << static_cast<int>(m_output_format) << " not supported yet."
+        );
+    }
 }
 
 } // namespace dtrace

--- a/src/cpp/dtrace/control/control.cpp
+++ b/src/cpp/dtrace/control/control.cpp
@@ -362,10 +362,12 @@ create_result_file(std::unordered_map<uint32_t, std::vector<uint32_t>>& result_b
             uint32_t loop_uC_index = item.second;
             try 
             {
-                script_output << action->serialize(
+                // Serialize action to build python script
+                action->serialize(
                     result_buffers.at(loop_uC_index), 
                     mem_buffers.at(loop_uC_index), 
-                    m_pager.get_action_location_mapping(loop_uC_index)
+                    m_pager.get_action_location_mapping(loop_uC_index),
+                    script_output
                 );
             } 
             catch (const std::exception& e) 
@@ -382,7 +384,7 @@ create_result_file(std::unordered_map<uint32_t, std::vector<uint32_t>>& result_b
     {
         // Create JSON output
         using json = nlohmann::ordered_json;
-        json json_result = json::object();
+        json json_output = json::object();
 
         for (const auto& item : actions)
         {
@@ -390,38 +392,13 @@ create_result_file(std::unordered_map<uint32_t, std::vector<uint32_t>>& result_b
             uint32_t loop_uC_index = item.second;
             try
             {
-                std::string action_key = action->get_action_name();
-                if (action_key.empty())
-                    continue; // Empty action keys
-
-                std::string probe_name = action->get_probe_name();
-                // Serialize action to get the value for the key-value pair in JSON
-                std::string action_value = action->serialize(
+                // Serialize action to build JSON result
+                action->serialize(
                     result_buffers.at(loop_uC_index),
                     mem_buffers.at(loop_uC_index),
-                    m_pager.get_action_location_mapping(loop_uC_index)
+                    m_pager.get_action_location_mapping(loop_uC_index),
+                    json_output
                 );
-
-                // Build JSON
-                if (action_value.empty())
-                    continue; // skip actions with no JSON output
-
-                // Parse action value for serialize json result and add to probe tree accordingly
-                if (action_value.find(',') != std::string::npos)
-                {
-                    json json_array = json::array();
-                    std::stringstream result_stream(action_value);
-                    std::string token;
-                    while (std::getline(result_stream, token, ','))
-                        json_array.push_back(std::stoull(dtrace::action::action::strip(token)));
-
-                    json_result[probe_name][action_key] = json_array;
-                }
-                else
-                {
-                    json_result[probe_name][action_key] = 
-                        std::stoull(dtrace::action::action::strip(action_value));
-                }
             }
             catch (const std::exception& e)
             {
@@ -432,12 +409,12 @@ create_result_file(std::unordered_map<uint32_t, std::vector<uint32_t>>& result_b
         }
 
         // Write JSON to file
-        std::ofstream json_output(output_file);
-        if (!json_output)
+        std::ofstream json_file(output_file);
+        if (!json_file)
             DTRACE_ERROR("DTRACE_CONTROL_RESULT_FILE_NOT_FOUND", "result file: " << output_file);
 
-        json_output << json_result.dump(4) << "\n";
-        json_output.close();
+        json_file << json_output.dump(4) << "\n";
+        json_file.close();
     }
     else 
     {

--- a/src/cpp/dtrace/control/control.h
+++ b/src/cpp/dtrace/control/control.h
@@ -39,9 +39,10 @@ private:
     std::unordered_map<uint32_t, std::vector<uint32_t>> m_control_buffers;
     std::unordered_map<uint32_t, std::vector<uint32_t>> m_mem_buffers;
     std::unordered_map<uint32_t, std::vector<uint32_t>> m_mem_action_locations;
+    dtrace::dtrace_output_format m_output_format;
 
 public:
-    control(std::string script_file, const std::string& map_data, uint32_t log_level);
+    control(std::string script_file, const std::string& map_data);
     uint32_t m_num_uCs;
     std::set<uint32_t> m_control_uC_indices;
     bool m_mem_action_present;

--- a/src/cpp/dtrace/dtrace.cpp
+++ b/src/cpp/dtrace/dtrace.cpp
@@ -54,8 +54,16 @@ create_dtrace_handle(const dtrace_config_t* config)
     try
     {
         // Validate dtrace config
-        if (!config) {
+        if (!config) 
+        {
             std::cerr << "[DTRACE] [ERROR] : Invalid dtrace config";
+            return nullptr;
+        }
+
+        // Validate script file path and map data
+        if (!config->script_file || !config->map_data)
+        {
+            std::cerr << "[DTRACE] [ERROR] : Invalid dtrace config data";
             return nullptr;
         }
 

--- a/src/cpp/dtrace/dtrace.cpp
+++ b/src/cpp/dtrace/dtrace.cpp
@@ -49,17 +49,27 @@ struct dtrace_command_handle {
 };
 
 dtrace_handle_t
-create_dtrace_handle(const char* script_file, const char* map_data, uint32_t log_level)
+create_dtrace_handle(const dtrace_config_t* config)
 {
     try
     {
+        // Validate dtrace config
+        if (!config) {
+            std::cerr << "[DTRACE] [ERROR] : Invalid dtrace config";
+            return nullptr;
+        }
+
         // Create new dtrace handle
         auto handle = std::make_unique<dtrace_command_handle>();
 
+        // Set the log level and output format
+        dtrace::set_log_level(config->log_level);
+        dtrace::set_output_format(config->output_fmt);
+
         // Initialize the memory host address map and dtrace compiler control object
-        // and set the log level
-        handle->g_control =
-            std::make_unique<dtrace::control>(script_file, map_data, log_level);
+        handle->g_control = std::make_unique<dtrace::control>(
+            config->script_file, config->map_data
+        );
 
         // Returns an opaque raw handle.
         // Transfer ownership to caller; caller must call destroy_dtrace_handle().
@@ -113,7 +123,8 @@ get_dtrace_buffer_size(dtrace_handle_t dtrace_handle, uint64_t* buffers)
             auto length = static_cast<uint32_t>(
                 l_dtrace_buffer_info.control_buffer.size() + l_dtrace_buffer_info.mem_buffer.size());
             // Update the control buffer and memory buffer length and uC index in buffers array
-            buffers[buffer_index] = (static_cast<uint64_t>(length) << 32) | uC_index; // NOLINT(cppcoreguidelines-avoid-magic-numbers)
+            buffers[buffer_index] = 
+                (static_cast<uint64_t>(length) << dtrace::dtrace_ctrl::forth_byte_shift) | uC_index;
             buffer_index++;
 
             handle->g_dtrace_buffer_info_map[uC_index] = std::move(l_dtrace_buffer_info);

--- a/src/cpp/dtrace/dtrace.h
+++ b/src/cpp/dtrace/dtrace.h
@@ -28,7 +28,7 @@ extern "C" {
  * handle to a dynamic tracing context.
  * Each handle represents an independent dynamic tracing instance for a command.
  */
-typedef void* dtrace_handle_t;
+typedef void* dtrace_handle_t;  // NOLINT
 
 /*!
  * @struct dtrace_config_t
@@ -38,7 +38,7 @@ typedef void* dtrace_handle_t;
  * @details
  * This structure contains configuration parameters for dtrace operation.
  */
-typedef struct {
+typedef struct {           // NOLINT
   const char* script_file; // Script file containing the probe and action details
   const char* map_data;    // Map data containing details of control code
   uint32_t log_level;      // Log level for debugging (default: dtrace_error)

--- a/src/cpp/dtrace/dtrace.h
+++ b/src/cpp/dtrace/dtrace.h
@@ -5,6 +5,8 @@
 #define TRACE_H
 
 // This header file contains the public APIs for creating control buffer, memory buffer, and result file
+#include "utils.h"
+
 #include <cstdint>
 #include <iostream>
 #include <string>
@@ -29,18 +31,31 @@ extern "C" {
 typedef void* dtrace_handle_t;
 
 /*!
+ * @struct dtrace_config_t
+ *
+ * @brief Configuration for creating a dtrace handle.
+ *
+ * @details
+ * This structure contains configuration parameters for dtrace operation.
+ */
+typedef struct {
+  const char* script_file; // Script file containing the probe and action details
+  const char* map_data;    // Map data containing details of control code
+  uint32_t log_level;      // Log level for debugging (default: dtrace_error)
+  uint32_t output_fmt;     // Output format for result file (default: python)
+} dtrace_config_t;
+
+/*!
  * create_dtrace_handle() - Creates a handle to the dynamic tracing context.
  *
- * @script_file:    Script file containing the probe and action details.
- * @map_data:       Map data containing details of control code.
- * @log_level:      Log level for debugging.
+ * @config:   Configuration structure containing dtrace parameters.
  *
  * @return Opaque raw handle to the dynamic tracing context owned by the caller, or NULL on failure.
  * @note The caller must release this handle by calling destroy_dtrace_handle().
  */
 DTRACE_EXPORT
 dtrace_handle_t
-create_dtrace_handle(const char* script_file, const char* map_data, uint32_t log_level);
+create_dtrace_handle(const dtrace_config_t* config);
 
 /*!
  * get_dtrace_col_numbers() - Retrieves the buffer sizes required for dynamic tracing.

--- a/src/cpp/dtrace/utils.h
+++ b/src/cpp/dtrace/utils.h
@@ -4,7 +4,8 @@
 #ifndef DTRACE_UTILS_H
 #define DTRACE_UTILS_H
 
-// This file contains the declaration of the log level and expressions for dtrace.
+// This file contains the declaration of the log levels, output format enums, and 
+// logging utilities for dtrace.
 #ifdef CERT_TRACE_CONTROL_H
 #include "trace_control.h"
 #endif
@@ -15,13 +16,95 @@
 #include <stdexcept>
 #include <string>
 
-// Log Levels Enum
-enum class dtrace_log_level {
-    dtrace_error = 1,
-    dtrace_warning = 2,
-    dtrace_info = 3
+namespace dtrace
+{
+//-------------------------Output Result Format-------------------------//
+// Output result format Enum
+enum class dtrace_output_format {
+    python = 0,  // Python output format (default)
+    json = 1     // JSON output format
 };
 
+// variable to store the current output format
+extern dtrace_output_format g_current_output_format;
+
+// Function to set the output format
+inline dtrace_output_format get_output_format()
+{
+    return g_current_output_format;
+}
+
+inline void set_output_format(uint32_t output_format)
+{
+    g_current_output_format = static_cast<dtrace_output_format>(output_format);
+}
+
+//-------------------------Log Level-------------------------//
+// Log Levels Enum
+enum class dtrace_log_level {
+    dtrace_error = 0,
+    dtrace_warning = 1,
+    dtrace_info = 2
+};
+
+// variable to store the current log level
+extern dtrace_log_level g_current_log_level;
+
+// Function to set the log level
+inline dtrace_log_level get_current_log_level() 
+{
+    return g_current_log_level;
+}
+
+inline void set_log_level(uint32_t log_level) 
+{
+    g_current_log_level = static_cast<dtrace_log_level>(log_level);
+}
+
+//-------------------------Control Constants-------------------------//
+/**
+ * @class dtrace_ctrl
+ *
+ * @brief
+ * dtrace::dtrace_ctrl defines constants used to create control block and action control.
+ *
+ * @details
+ * The class provides a set of static constexpr values that are used for different
+ * purposes such as page size, byte shifts, action sizes, and masks in dtrace compiler.
+ * The trace_page_size is conditionally defined based on the CERT_TRACE_CONTROL_H macro.
+ */
+class dtrace_ctrl
+{
+public:
+#ifdef CERT_TRACE_CONTROL_H
+    static constexpr uint32_t trace_page_size = PROFILE_PAGE_SIZE_TEST; // Page size for trace buffer when CERT_TRACE_CONTROL_H is defined
+#else
+    static constexpr uint32_t trace_page_size = 4096;                   // Default page size for trace buffer
+#endif
+    static constexpr uint32_t first_byte_shift = 8;                     // First byte for word
+    static constexpr uint32_t second_byte_shift = 16;                   // Second byte for word
+    static constexpr uint32_t third_byte_shift = 24;                    // Third byte for word
+    static constexpr uint32_t forth_byte_shift = 32;                    // Fourth byte for word
+    static constexpr uint32_t word_byte_size = 4;                       // Size of a word in bytes
+    static constexpr uint32_t page_length_check = 0x2000;               // Value used to check the page length
+    static constexpr uint32_t placeholder_value = 0x12345678;           // Placeholder value
+    static constexpr uint32_t mask_high_bit = 0x80000000;               // Mask for the high bit
+    static constexpr uint32_t mask_8 = 0xFF;                            // Mask for 8-bit unsigned integers
+    static constexpr uint32_t mask_16 = 0xFFFF;                         // Mask for 16-bit unsigned integers
+    static constexpr uint32_t mask_32 = 0xFFFFFFFF;                     // Mask for 32-bit unsigned integers
+    static constexpr uint32_t empty_buffer_check = 0xFFFFFFFF;          // Check for empty buffer
+    static constexpr uint32_t handshake_overflow = 0xFBADBEEF;          // Value used to check handshake overflow
+    static constexpr uint32_t result_value_init = 0xFBADCAFE;           // Initial value for action result
+    static constexpr uint32_t decimal_base = 10;                        // Base for decimal numbers
+    static constexpr uint32_t hexadecimal_base = 16;                    // Base for hexadecimal numbers
+    static constexpr uint32_t decimal_hexadecimal_base = 0;             // Base for both decimal and hexadecimal numbers
+    static constexpr uint32_t label_annotation_length = 10;             // Length of label annotation
+    static constexpr uint32_t label_line_length = 4;                    // Length of label line
+};
+
+} // namespace dtrace
+
+// -------------------------Logging Macros-------------------------//
 // Logging Prefix
 #define DTRACE_PREFIX "[DTRACE] "
 
@@ -40,7 +123,7 @@ enum class dtrace_log_level {
 #ifndef DTRACE_WARNING
 #define DTRACE_WARNING(fmt) \
     do { /* NOLINT(cppcoreguidelines-avoid-do-while) */ \
-        if (dtrace::get_current_log_level() >= dtrace_log_level::dtrace_warning) { \
+        if (dtrace::get_current_log_level() >= dtrace::dtrace_log_level::dtrace_warning) { \
             std::ostringstream output; \
             output << DTRACE_PREFIX "[WARNING] " << __func__ << ":" << __LINE__ << ": " << fmt << "\n"; \
             std::cout << output.str(); \
@@ -52,7 +135,7 @@ enum class dtrace_log_level {
 #ifndef DTRACE_INFO
 #define DTRACE_INFO(fmt) \
     do { /* NOLINT(cppcoreguidelines-avoid-do-while) */ \
-        if (dtrace::get_current_log_level() >= dtrace_log_level::dtrace_info) { \
+        if (dtrace::get_current_log_level() >= dtrace::dtrace_log_level::dtrace_info) { \
             std::ostringstream output; \
             output << DTRACE_PREFIX "[INFO] " << __func__ << ":" << __LINE__ << ": " << fmt << "\n"; \
             std::cout << output.str(); \
@@ -60,53 +143,4 @@ enum class dtrace_log_level {
     } while (0)
 #endif
 
-namespace dtrace
-{
-//-------------------------Utils-------------------------//
-//-------------------------Log Level-------------------------//
-void set_log_level(uint32_t log_level);
-dtrace_log_level get_current_log_level();
-
-//-------------------------Control-------------------------//
-/**
- * @class dtrace_ctrl
- *
- * @brief
- * dtrace::dtrace_ctrl defines constants used to create control block and action control.
- *
- * @details
- * The class provides a set of static constexpr values that are used for different
- * purposes such as page size, byte shifts, action sizes, and  masks in dtrace compiler.
- * The trace_page_size is conditionally defined based on the CERT_TRACE_CONTROL_H macro.
- */
-class dtrace_ctrl
-{
-public:
-#ifdef CERT_TRACE_CONTROL_H
-    static constexpr uint32_t trace_page_size = PROFILE_PAGE_SIZE_TEST;                     // Page size for trace buffer when CERT_TRACE_CONTROL_H is defined  
-#else   
-    static constexpr uint32_t trace_page_size = 4096;                                       // Default page size for trace buffer
-#endif
-    static constexpr uint32_t first_byte_shift = 8;                                         // First byte for word
-    static constexpr uint32_t second_byte_shift = 16;                                       // Second byte for word
-    static constexpr uint32_t third_byte_shift = 24;                                        // Third byte for word
-    static constexpr uint32_t forth_byte_shift = 32;                                        // Fourth byte for word
-    static constexpr uint32_t word_byte_size = 4;                                           // Size of a word in bytes
-    static constexpr uint32_t page_length_check = 0x2000;                                   // Value used to check the page length
-    static constexpr uint32_t placeholder_value = 0x12345678;                               // Placeholder value
-    static constexpr uint32_t mask_high_bit = 0x80000000;                                   // Mask for the high bit
-    static constexpr uint32_t mask_8 = 0xFF;                                                // Mask for 8-bit unsigned integers    
-    static constexpr uint32_t mask_16 = 0xFFFF;                                             // Mask for 16-bit unsigned integers    
-    static constexpr uint32_t mask_32 = 0xFFFFFFFF;                                         // Mask for 32-bit unsigned integers    
-    static constexpr uint32_t empty_buffer_check = 0xFFFFFFFF;                              // Check for empty buffer
-    static constexpr uint32_t handshake_overflow = 0xFBADBEEF;                              // Value used to check handshake overflow
-    static constexpr uint32_t result_value_init = 0xFBADCAFE;                               // Initial value for action result
-    static constexpr uint32_t decimal_base = 10;                                            // Base for decimal numbers
-    static constexpr uint32_t hexadecimal_base = 16;                                        // Base for hexadecimal numbers
-    static constexpr uint32_t decimal_hexadecimal_base = 0;                                 // Base for both decimal and hexadecimal numbers
-    static constexpr uint32_t label_annotation_length = 10;                                 // Length of label annotation
-    static constexpr uint32_t label_line_length = 4;                                        // Length of label line                                                                             
-};
-
-} // namespace dtrace
 #endif // DTRACE_UTILS_H

--- a/src/cpp/dtrace/utils.h
+++ b/src/cpp/dtrace/utils.h
@@ -26,7 +26,7 @@ enum class dtrace_output_format {
 };
 
 // variable to store the current output format
-extern dtrace_output_format g_current_output_format;
+extern dtrace_output_format g_current_output_format; // NOLINT
 
 // Function to set the output format
 inline dtrace_output_format get_output_format()
@@ -48,7 +48,7 @@ enum class dtrace_log_level {
 };
 
 // variable to store the current log level
-extern dtrace_log_level g_current_log_level;
+extern dtrace_log_level g_current_log_level; // NOLINT
 
 // Function to set the log level
 inline dtrace_log_level get_current_log_level() 

--- a/test/dtrace_test/CMakeLists.txt
+++ b/test/dtrace_test/CMakeLists.txt
@@ -4,64 +4,41 @@
 project(dtrace_test)
 
 set(DTRACE_TESTNAME "dtrace_test")
-set(DTRACE_SOURCE_DIR "${AIEBU_BINARY_DIR}/src/cpp/dtrace")
 
 add_executable(${DTRACE_TESTNAME} dtrace_test.cpp)
+add_dependencies(${DTRACE_TESTNAME} cert_dtrace_static)
+target_link_libraries(${DTRACE_TESTNAME} PRIVATE cert_dtrace_static)
+target_include_directories(${DTRACE_TESTNAME} PRIVATE ${AIEBU_SOURCE_DIR}/src/cpp/dtrace)
 
-add_dependencies(${DTRACE_TESTNAME} cert_dtrace)
-
-target_link_libraries(${DTRACE_TESTNAME} PRIVATE ${CMAKE_DL_LIBS})
-
-if (MSVC)
-  set(DTRACE_LIBRARY_PATH "${DTRACE_SOURCE_DIR}/$<CONFIG>/cert_dtrace.dll")
-else()
-  set(DTRACE_LIBRARY_PATH "${DTRACE_SOURCE_DIR}/libcert_dtrace.so")
-endif()
-
-add_custom_command(OUTPUT control_buffer_single.dat
-  COMMAND ${DTRACE_TESTNAME} "${DTRACE_LIBRARY_PATH}" "${AIEBU_SOURCE_DIR}/test/dtrace_test/single_col" "control_buffer_single.dat"
-  DEPENDS "${DTRACE_TESTNAME}"
-  COMMENT "Control block for single column dtrace test"
+add_test(NAME "dtrace_single_column"
+  COMMAND ${DTRACE_TESTNAME} "${AIEBU_SOURCE_DIR}/test/dtrace_test/single_col" "${CMAKE_CURRENT_BINARY_DIR}/control_buffer_single.dat"
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   )
 
-add_custom_target(dtracesinglecolumn ALL
-  DEPENDS control_buffer_single.dat
-  )
-
-add_test(NAME "dtrace_single_column"
+add_test(NAME "dtrace_single_column_md5sum"
   COMMAND cmake -P "${AIEBU_SOURCE_DIR}/cmake/md5sum-compare.cmake" "${CMAKE_CURRENT_BINARY_DIR}/control_buffer_single.dat" "${AIEBU_SOURCE_DIR}/test/dtrace_test/single_col/gold.md5"
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   )
+set_tests_properties("dtrace_single_column_md5sum" PROPERTIES DEPENDS "dtrace_single_column")
 
-add_custom_command(OUTPUT control_buffer_multi.dat
-  COMMAND ${DTRACE_TESTNAME} "${DTRACE_LIBRARY_PATH}" "${AIEBU_SOURCE_DIR}/test/dtrace_test/multi_col" "control_buffer_multi.dat"
-  DEPENDS "${DTRACE_TESTNAME}"
-  COMMENT "Control block for multi column dtrace test"
+add_test(NAME "dtrace_multi_column"
+  COMMAND ${DTRACE_TESTNAME} "${AIEBU_SOURCE_DIR}/test/dtrace_test/multi_col" "${CMAKE_CURRENT_BINARY_DIR}/control_buffer_multi.dat"
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   )
 
-add_custom_target(dtracemulticolumn ALL
-  DEPENDS control_buffer_multi.dat
-  )
-
-add_test(NAME "dtrace_multi_column"
+add_test(NAME "dtrace_multi_column_md5sum"
   COMMAND cmake -P "${AIEBU_SOURCE_DIR}/cmake/md5sum-compare.cmake" "${CMAKE_CURRENT_BINARY_DIR}/control_buffer_multi.dat" "${AIEBU_SOURCE_DIR}/test/dtrace_test/multi_col/gold.md5"
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   )
+set_tests_properties("dtrace_multi_column_md5sum" PROPERTIES DEPENDS "dtrace_multi_column")
 
-add_custom_command(OUTPUT control_buffer_profile.dat
-  COMMAND ${DTRACE_TESTNAME} "${DTRACE_LIBRARY_PATH}" "${AIEBU_SOURCE_DIR}/test/dtrace_test/profile" "control_buffer_profile.dat"
-  DEPENDS "${DTRACE_TESTNAME}"
-  COMMENT "Control block for profile dtrace test"
+add_test(NAME "dtrace_profile"
+  COMMAND ${DTRACE_TESTNAME} "${AIEBU_SOURCE_DIR}/test/dtrace_test/profile" "${CMAKE_CURRENT_BINARY_DIR}/control_buffer_profile.dat"
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   )
 
-add_custom_target(dtracprofile ALL
-  DEPENDS control_buffer_profile.dat
-  )
-
-add_test(NAME "dtrace_profile"
+add_test(NAME "dtrace_profile_md5sum"
   COMMAND cmake -P "${AIEBU_SOURCE_DIR}/cmake/md5sum-compare.cmake" "${CMAKE_CURRENT_BINARY_DIR}/control_buffer_profile.dat" "${AIEBU_SOURCE_DIR}/test/dtrace_test/profile/gold.md5"
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   )
+set_tests_properties("dtrace_profile_md5sum" PROPERTIES DEPENDS "dtrace_profile")

--- a/test/dtrace_test/dtrace_test.cpp
+++ b/test/dtrace_test/dtrace_test.cpp
@@ -19,7 +19,7 @@ run_dtrace_test(const std::string& script_file,
     const std::string& map_file, const std::string& output_file) 
 {
     if (!std::filesystem::exists(script_file)) {
-        std::cerr << "ERROR: test files not found: " << script_file << std::endl;
+        std::cerr << "ERROR: test files not found: " << script_file;
         return 1;
     }
 
@@ -30,13 +30,13 @@ run_dtrace_test(const std::string& script_file,
     dtrace_config_t config;
     config.script_file = script_file.c_str();
     config.map_data = map_file.c_str();
-    config.log_level = 0;  // dtrace_error
-    config.output_fmt = 0;  // python format
+    config.log_level = 0U;   // dtrace_error
+    config.output_fmt = 0U;  // python format
 
     // get dtrace handle using create_dtrace_handle api from libcert_dtrace
     void* dtrace_handle = create_dtrace_handle(&config);
     if (!dtrace_handle) {
-        std::cerr << "[ERROR]: dtrace compiler failed" << std::endl;
+        std::cerr << "[ERROR]: dtrace compiler failed";
         return 1;
     }
     else {
@@ -60,12 +60,15 @@ run_dtrace_test(const std::string& script_file,
         populate_dtrace_buffer(dtrace_handle, dtrace_buffer.get(), TRACE_CTRL_CODE_BASE);
 
         // create control_buffer.dat file
-        if (dtrace_buffer_length > 0) 
-        {
+        if (dtrace_buffer_length > 0) {
             std::ofstream control_buffer_file(output_file, std::ios::binary);
             control_buffer_file.write(reinterpret_cast<const char*>(dtrace_buffer.get()), 
                 static_cast<std::streamsize>(dtrace_buffer_length * sizeof(uint32_t)));
             control_buffer_file.close();
+        }
+        else {
+            std::cerr << "[ERROR]: dtrace compiler - failed buffer length zero";
+            return 1;
         }
 
         // destroy dtrace handle using destroy_dtrace_handle api from libcert_dtrace
@@ -78,7 +81,7 @@ int main(int argc, char** argv)
 {
     try {
         if (argc != 3) {
-            std::cerr << "Usage: " << argv[0] << " <testcase_path> <output_file>" << std::endl;
+            std::cerr << "Usage: " << argv[0] << " <testcase_path> <output_file>";
             return 1;
         }
 
@@ -100,7 +103,7 @@ int main(int argc, char** argv)
         int ret = run_dtrace_test(script_file, map_data, output_file);
         return ret;
     } catch (const std::exception& e) {
-        std::cerr << "[ERROR]: Exception: " << e.what() << std::endl;
+        std::cerr << "[ERROR]: Exception: " << e.what();
         return 1;
     }
 }

--- a/test/dtrace_test/dtrace_test.cpp
+++ b/test/dtrace_test/dtrace_test.cpp
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
 
+#include "dtrace.h"
+
 #include <iostream>
 #include <filesystem>
 #include <memory>
@@ -8,58 +10,12 @@
 #include <fstream>
 #include <vector>
 
-#ifdef _WIN32
-#include <windows.h>
-// UNICODE builds map LoadLibrary -> LoadLibraryW; use LoadLibraryA for const char* paths.
-#ifndef RTLD_LAZY
-#define RTLD_LAZY 0
-#endif
-
-static inline void*
-aiebu_dlopen(const char* path, int /*flags*/)
-{
-  return reinterpret_cast<void*>(LoadLibraryA(path));
-}
-
-#if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wcast-function-type-mismatch"
-#endif
-template<typename T>
-static inline T
-aiebu_dlsym(void* handle, const char* symbol)
-{
-  FARPROC p = GetProcAddress(static_cast<HMODULE>(handle), symbol);
-  return reinterpret_cast<T>(p);
-}
-#if defined(__clang__)
-#pragma clang diagnostic pop
-#endif
-
-static inline void
-aiebu_dlclose(void* handle)
-{
-  FreeLibrary(static_cast<HMODULE>(handle));
-}
-
-#define dlopen(path, flags) aiebu_dlopen((path), (flags))
-#define dlclose(handle)       aiebu_dlclose((handle))
-#else
-#include <dlfcn.h>
-#endif
-
 static const uint64_t TRACE_CTRL_CODE_BASE = 0x200000;
 static const uint64_t TRACE_CTRL_CODE_SIZE = 16384; // 8kB
 static const uint32_t word_byte_shift = 32;
-// static const uint32_t mask_32 = 0xFFFFFFFF; // NOLINT(cppcoreguidelines-avoid-magic-numbers)
-using create_dtrace_handle_t = void* (*)(const char*, const char*, uint32_t);
-using get_dtrace_col_numbers_t = void (*)(void*, uint32_t*);
-using get_dtrace_buffer_size_t = void (*)(void*, uint64_t*);
-using populate_dtrace_buffer_t = void (*)(void*, uint32_t*, uint64_t);
-using destroy_dtrace_handle_t = void (*)(void*);
 
 int 
-run_dtrace_test(const std::string& dtrace_lib_path, const std::string& script_file, 
+run_dtrace_test(const std::string& script_file, 
     const std::string& map_file, const std::string& output_file) 
 {
     if (!std::filesystem::exists(script_file)) {
@@ -67,65 +23,31 @@ run_dtrace_test(const std::string& dtrace_lib_path, const std::string& script_fi
         return 1;
     }
 
-    // load dtrace compiler
-    void* dtrace_lib_handle = dlopen(dtrace_lib_path.c_str(), RTLD_LAZY);
-    if (!dtrace_lib_handle) {
-        std::cerr << "[ERROR]: failed to load dtrace library" << std::endl;
-        return 1;
-    }
-
-    // load and check functions from dtrace compiler
-#ifdef _WIN32
-    auto create_dtrace_handle =
-        aiebu_dlsym<create_dtrace_handle_t>(dtrace_lib_handle, "create_dtrace_handle");
-    auto get_dtrace_col_numbers =
-        aiebu_dlsym<get_dtrace_col_numbers_t>(dtrace_lib_handle, "get_dtrace_col_numbers");
-    auto get_dtrace_buffer_size =
-        aiebu_dlsym<get_dtrace_buffer_size_t>(dtrace_lib_handle, "get_dtrace_buffer_size");
-    auto populate_dtrace_buffer =
-        aiebu_dlsym<populate_dtrace_buffer_t>(dtrace_lib_handle, "populate_dtrace_buffer");
-    auto destroy_dtrace_handle =
-        aiebu_dlsym<destroy_dtrace_handle_t>(dtrace_lib_handle, "destroy_dtrace_handle");
-#else
-    auto create_dtrace_handle =
-        reinterpret_cast<create_dtrace_handle_t>(dlsym(dtrace_lib_handle, "create_dtrace_handle"));
-    auto get_dtrace_col_numbers =
-        reinterpret_cast<get_dtrace_col_numbers_t>(dlsym(dtrace_lib_handle, "get_dtrace_col_numbers"));
-    auto get_dtrace_buffer_size =
-        reinterpret_cast<get_dtrace_buffer_size_t>(dlsym(dtrace_lib_handle, "get_dtrace_buffer_size"));
-    auto populate_dtrace_buffer =
-        reinterpret_cast<populate_dtrace_buffer_t>(dlsym(dtrace_lib_handle, "populate_dtrace_buffer"));
-    auto destroy_dtrace_handle =
-        reinterpret_cast<destroy_dtrace_handle_t>(dlsym(dtrace_lib_handle, "destroy_dtrace_handle"));
-#endif
-    if (!create_dtrace_handle || !get_dtrace_col_numbers || !get_dtrace_buffer_size || 
-        !populate_dtrace_buffer || !destroy_dtrace_handle) 
-    {
-        std::cerr << "[ERROR]: failed to load dtrace functions" << std::endl;
-        dlclose(dtrace_lib_handle);
-        return 1;
-    }
-
     uint32_t dtrace_buffer_length = 0;
     uint32_t buffers_length = 0;
-    uint32_t dtrace_log_level = 1; // default log level
-    // get dtrace handle using create_dtrace_handle api from libdtrace.so
-    void* dtrace_handle = 
-        create_dtrace_handle(script_file.c_str(), map_file.c_str(), dtrace_log_level);
+
+    // Create dtrace config
+    dtrace_config_t config;
+    config.script_file = script_file.c_str();
+    config.map_data = map_file.c_str();
+    config.log_level = 0;  // dtrace_error
+    config.output_fmt = 0;  // python format
+
+    // get dtrace handle using create_dtrace_handle api from libcert_dtrace
+    void* dtrace_handle = create_dtrace_handle(&config);
     if (!dtrace_handle) {
         std::cerr << "[ERROR]: dtrace compiler failed" << std::endl;
-        dlclose(dtrace_lib_handle);
         return 1;
     }
     else {
-        // get dtrace number of column using get_dtrace_col_numbers api from libdtrace.so
+        // get dtrace number of column using get_dtrace_col_numbers api from libcert_dtrace
         get_dtrace_col_numbers(dtrace_handle, &buffers_length);
 
         // allocate dtrace information buffer
         std::unique_ptr<uint32_t[]> dtrace_buffer = std::make_unique<uint32_t[]>(TRACE_CTRL_CODE_SIZE); // NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
         std::unique_ptr<uint64_t[]> buffers = std::make_unique<uint64_t[]>(buffers_length); // NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
 
-        // get dtrace information using get_dtrace_buffer_size api from libdtrace.so
+        // get dtrace information using get_dtrace_buffer_size api from libcert_dtrace
         get_dtrace_buffer_size(dtrace_handle, buffers.get());
 
         for (uint32_t i = 0; i < buffers_length; ++i) {
@@ -134,7 +56,7 @@ run_dtrace_test(const std::string& dtrace_lib_path, const std::string& script_fi
             dtrace_buffer_length += length;
         }
 
-        // create dtrace buffer using populate_dtrace_buffer api from libdtrace.so
+        // create dtrace buffer using populate_dtrace_buffer api from libcert_dtrace
         populate_dtrace_buffer(dtrace_handle, dtrace_buffer.get(), TRACE_CTRL_CODE_BASE);
 
         // create control_buffer.dat file
@@ -146,9 +68,8 @@ run_dtrace_test(const std::string& dtrace_lib_path, const std::string& script_fi
             control_buffer_file.close();
         }
 
-        // destroy dtrace handle using destroy_dtrace_handle api from libdtrace.so
+        // destroy dtrace handle using destroy_dtrace_handle api from libcert_dtrace
         destroy_dtrace_handle(dtrace_handle);
-        dlclose(dtrace_lib_handle);
         return 0;
     }
 }
@@ -156,15 +77,14 @@ run_dtrace_test(const std::string& dtrace_lib_path, const std::string& script_fi
 int main(int argc, char** argv) 
 {
     try {
-        if (argc != 4) {
-            std::cerr << "Usage: " << argv[0] << "<dtrace_lib_path> <testcase_path> <output_file>" << std::endl;
+        if (argc != 3) {
+            std::cerr << "Usage: " << argv[0] << " <testcase_path> <output_file>" << std::endl;
             return 1;
         }
 
-        std::string dtrace_lib_path = argv[1];
-        std::string script_file = std::string(argv[2]) + "/script.ct";
-        std::string map_file = std::string(argv[2]) + "/map.json";
-        std::string output_file = argv[3];
+        std::string script_file = std::string(argv[1]) + "/script.ct";
+        std::string map_file = std::string(argv[1]) + "/map.json";
+        std::string output_file = argv[2];
 
         if (!std::filesystem::exists(map_file)) {
             throw std::runtime_error("[ERROR]: map file does not exist: " + map_file);
@@ -177,7 +97,7 @@ int main(int argc, char** argv)
         map_file_stream.close();
         std::string map_data = std::string(map_buffer.begin(), map_buffer.end());
 
-        int ret = run_dtrace_test(dtrace_lib_path, script_file, map_data, output_file);
+        int ret = run_dtrace_test(script_file, map_data, output_file);
         return ret;
     } catch (const std::exception& e) {
         std::cerr << "[ERROR]: Exception: " << e.what() << std::endl;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

- dtrace handle creation API updated to support more arguments; added support for json output format 
- updated dtrace test to use static dtrace library and stop building shared dtrace library

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA

#### How problem was solved, alternative solutions (if any) and why they were rejected
dynamic tracing compiler refactor for json output support - 
```
{
    "begin": {
        "tss": 2855,
        "val": 1078744645
    },
    "jprobe:default:uc0:line10": {
        "cnt": 1
    },
    "jprobe:default:uc0:line24": {
        "ts": 7483
    },
    "tracepoint:uc0:id4": {
        "ts": [
            3360,
            4307,
            5081
        ]
    },
    "end": {
        "val": 2882382797,
        "buf4": [
            3735928559,
            3735928559,
            3735928559
        ],
        "tse": 8986,
    }
}
```

#### Risks (if any) associated the changes in the commit
NA

#### What has been tested and how, request additional testing if necessary
Tested on windows medusa board and the feature works as expected

#### Documentation impact (if any)
https://amd.atlassian.net/wiki/spaces/AIE/pages/779183759/cert+dynamic+tracing+dtrace+compiler+APIs
