### PR TITLE
per optimization

### DIFF
--- a/cmake/windows.cmake
+++ b/cmake/windows.cmake
@@ -28,6 +28,15 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   add_compile_options(/Qspectre)  # compile with the Spectre mitigations switch
 endif()
 
+# Release: explicit max-speed opts (/O2; /Ot favors fast code over smaller code) and
+# no checked STL iterators. Base CMAKE_CXX_FLAGS_RELEASE from CMake is /O2 /Ob2 /DNDEBUG;
+# we restate /O2 here so Release tuning stays explicit in this file.
+# NOTE: Put /O2 and /Ot in separate genexes — a single "$<...:/O2;/Ot>" breaks because ';'
+# splits the generator-expression parse and can leak "$<1:/O2" onto the cl command line.
+add_compile_options("$<$<STREQUAL:$<CONFIG>,Release>:/O2>")
+add_compile_options("$<$<STREQUAL:$<CONFIG>,Release>:/Ot>")
+add_compile_definitions($<$<STREQUAL:$<CONFIG>,Release>:_ITERATOR_DEBUG_LEVEL=0>)
+
 add_link_options(
   /DEBUG      # instruct linker to create debugging info
   /guard:cf   # enable linker control guard feature (CFG) to prevent attackers from redirecting execution to unsafe locations

--- a/src/cpp/assembler/assembler.cpp
+++ b/src/cpp/assembler/assembler.cpp
@@ -17,6 +17,7 @@
 #include "elfwriter.h"
 #include "encoder.h"
 #include "preprocessor.h"
+#include "utils.h"
 
 #include "aiebu/aiebu_error.h"
 

--- a/src/cpp/common/assembler_state.cpp
+++ b/src/cpp/common/assembler_state.cpp
@@ -7,6 +7,8 @@
 #include "regex_wrapper.h"
 #include "aiebu/aiebu_error.h"
 
+#include <unordered_map>
+
 namespace aiebu {
 
 assembler_state::
@@ -38,7 +40,7 @@ process(bool makeunique)
   std::string clabelname;
   jobid_type cjob_id = "";
   std::map<std::string, uint32_t> apply_label_map;
-  for (auto data : m_data)
+  for (const auto& data : m_data)
   {
     if (data->isLabel())
     {
@@ -46,19 +48,21 @@ process(bool makeunique)
       clabelname = gen_label_name(makeunique, data);
 
       data->set_size(0);
-      if (m_labelmap.find(clabelname) != m_labelmap.end())
+      auto lb_it = m_labelmap.lower_bound(clabelname);
+      if (lb_it != m_labelmap.end() && lb_it->first == clabelname)
         throw error(error::error_code::invalid_asm, "Label " + clabelname + " present multiple time in asm\n");
-      m_labelmap[clabelname] = std::make_shared<label>(clabelname, m_pos, index);
+      m_labelmap.emplace_hint(lb_it, clabelname, std::make_shared<label>(clabelname, m_pos, index));
       m_labellist.emplace_back(clabelname);
     } else if (data->isOpcode()){
-      std::string name = data->get_operation().get_name();
+      const std::string& name = data->get_operation().get_name();
       if (!name.compare("start_job") || !name.compare("start_job_deferred") || !name.compare("start_cond_job_preempt"))
       {
         clabelname.clear();
         cjob_id = gen_job_name(makeunique, data, eopnum);
-        if (m_jobmap.find(cjob_id) != m_jobmap.end())
+        auto j_it = m_jobmap.lower_bound(cjob_id);
+        if (j_it != m_jobmap.end() && j_it->first == cjob_id)
           throw error(error::error_code::invalid_asm, "Job " + cjob_id + " present multiple time in asm\n");
-        m_jobmap[cjob_id] = std::make_shared<job>(cjob_id, m_pos, index, eopnum, !name.compare("start_job_deferred"));
+        m_jobmap.emplace_hint(j_it, cjob_id, std::make_shared<job>(cjob_id, m_pos, index, eopnum, !name.compare("start_job_deferred")));
         m_jobids.push_back(cjob_id);
       }
 
@@ -68,9 +72,11 @@ process(bool makeunique)
         m_jobids.push_back(EOF_ID);
       }
 
-      if ((*m_isa).count(name) > 0)
+      const auto isa_it = m_isa->find(name);
+      if (isa_it != m_isa->end())
       {
-        offset_type size = (*m_isa)[name]->serializer(data->get_operation().get_args())->size(*this);
+        const auto& op_args = data->get_operation().get_args();
+        offset_type size = isa_it->second->encoded_size_in_text(*this, op_args);
         m_pos += size;
         data->set_size(size);
         if (!name.compare("eof"))
@@ -80,8 +86,9 @@ process(bool makeunique)
           cjob_id = std::to_string(-1);
         }
       } else if (!name.compare(".eop")) {
-        m_jobmap[gen_eop_name(eopnum)] = std::make_shared<job>(gen_eop_name(eopnum), m_pos, index, eopnum, false);
-        m_jobids.push_back(gen_eop_name(eopnum));
+        const std::string eop_name = gen_eop_name(eopnum);
+        m_jobmap[eop_name] = std::make_shared<job>(eop_name, m_pos, index, eopnum, false);
+        m_jobids.push_back(eop_name);
         ++eopnum;
       } else {
         throw error(error::error_code::internal_error, "Invalid operation:" + name);
@@ -90,10 +97,7 @@ process(bool makeunique)
       if (!name.compare("local_barrier"))
       {
         barrierid_type lbid = parse_barrier(data->get_operation().get_args()[0]);
-        auto it = m_localbarriermap.find(lbid);
-        if (it == m_localbarriermap.end())
-          m_localbarriermap[lbid] = std::vector<jobid_type>();
-        m_jobmap[cjob_id].get()->m_barrierids.push_back(lbid);
+        m_jobmap[cjob_id]->m_barrierids.push_back(lbid);
         m_localbarriermap[lbid].push_back(cjob_id);
       }
 
@@ -102,9 +106,6 @@ process(bool makeunique)
         jobid_type launchjobid;
         launchjobid = gen_job_name(makeunique, data, eopnum);
         m_jobmap[cjob_id]->m_dependentjobs.push_back(launchjobid);
-        auto it = m_joblaunchmap.find(launchjobid);
-        if (it == m_joblaunchmap.end())
-          m_joblaunchmap[launchjobid] = std::vector<jobid_type>();
         m_joblaunchmap[launchjobid].push_back(cjob_id);
       }
 
@@ -125,24 +126,32 @@ process(bool makeunique)
       throw error(error::error_code::internal_error, "Unknown type found!!!");
     }
 
-    if (!clabelname.empty()
-        && data->get_operation().get_name().compare(".align")
-        && data->get_operation().get_name().compare(".eop")
-        && data->get_operation().get_name().compare("eof"))
+    if (!clabelname.empty())
     {
-      m_labelmap[clabelname]->increment_count(1);
-      m_labelmap[clabelname]->increment_size(data->get_size());
+      const std::string& opnm = data->get_operation().get_name();
+      if (opnm != ".align" && opnm != ".eop" && opnm != "eof")
+      {
+        m_labelmap[clabelname]->increment_count(1);
+        m_labelmap[clabelname]->increment_size(data->get_size());
+      }
     }
     ++index;
     data->set_section(csection);
   }
 
   //convert label and num_entries to map of label and dependent labels
+  std::unordered_map<std::string, size_t> label_index;
+  for (size_t li = 0; li < m_labellist.size(); ++li)
+    label_index.emplace(m_labellist[li], li);
+
   for (const auto& pair : apply_label_map)
   {
     if (pair.second == 1)
       continue;
-    size_t label_idx = find_label_entry(pair.first);
+    auto lit = label_index.find(pair.first);
+    if (lit == label_index.end())
+      throw error(error::error_code::internal_error, "label " + pair.first + " not found in label list!!!");
+    const size_t label_idx = lit->second;
     for (uint32_t i = 0; i < pair.second; ++i)
     {
       auto label = get_label_at(label_idx+i);

--- a/src/cpp/common/writer.h
+++ b/src/cpp/common/writer.h
@@ -76,6 +76,13 @@ public:
     return m_data;
   }
 
+  // Moves section bytes out for one-shot ELF emission; m_data becomes empty.
+  std::vector<uint8_t>
+  take_data_for_emit()
+  {
+    return std::move(m_data);
+  }
+
   const std::string&
   get_name() const
   {

--- a/src/cpp/elf/aie2/aie2_blob_elfwriter.h
+++ b/src/cpp/elf/aie2/aie2_blob_elfwriter.h
@@ -51,10 +51,11 @@ public:
        {
          auto instance_index = add_symtab_section(iname, kernel_index);
          std::vector<uint32_t> group_data = process_common_helper(instance, get_section_prefix(index));
-         // first word is GRP_COMDAT
-         group_data.insert(group_data.begin(), 1);
+         std::vector<uint32_t> grouped;
+         grouped.push_back(1);
+         grouped.insert(grouped.end(), group_data.begin(), group_data.end());
          //group_data.insert(group_data.end(), common_data.begin(), common_data.end());
-         add_group(get_group_name(index), group_data, instance_index);
+         add_group(get_group_name(index), grouped, instance_index);
          index++;
        }
     }

--- a/src/cpp/elf/aie2ps/aie2ps_elfwriter.h
+++ b/src/cpp/elf/aie2ps/aie2ps_elfwriter.h
@@ -48,9 +48,11 @@ public:
        {
          auto instance_index = add_symtab_section(iname, kernel_index);
          std::vector<uint32_t> group_data = process_common_helper(instance, get_section_prefix(index));
-         // first word is GRP_COMDAT
-         group_data.insert(group_data.begin(), 1);
-         add_group(get_group_name(index), group_data, instance_index);
+         // first word is GRP_COMDAT (prepend without O(n) insert-at-begin)
+         std::vector<uint32_t> grouped;
+         grouped.push_back(1);
+         grouped.insert(grouped.end(), group_data.begin(), group_data.end());
+         add_group(get_group_name(index), grouped, instance_index);
          index++;
        }
     }
@@ -61,7 +63,8 @@ public:
     std::memcpy(configuration_vec.data(), &col, sizeof(uint32_t));
 
     add_note(NT_XRT_PARTITION_SIZE, xrt_configuration, configuration_vec);
-    return finalize();
+    auto result = finalize();
+    return result;
   }
 };
 }

--- a/src/cpp/elf/elfwriter.cpp
+++ b/src/cpp/elf/elfwriter.cpp
@@ -3,8 +3,47 @@
 
 #include "elfwriter.h"
 #include "logger.h"
+#include "aiebu/aiebu_error.h"
+
+#include <sstream>
+#include <cstring>
 
 namespace aiebu {
+
+ELFIO::section*
+elf_writer::
+add_section_by_name(const std::string& section_name)
+{
+  if (m_elfio.sections.size() >= max_sections)
+    throw error(error::error_code::invalid_asm, "Maximum number of sections reached");
+  ELFIO::section* sec = m_elfio.sections.add(section_name);
+  m_section_by_name[section_name] = sec;
+  return sec;
+}
+
+void
+elf_writer::
+resync_section_name_map()
+{
+  for (auto& s : m_elfio.sections) {
+    const std::string& n = s->get_name();
+    if (!n.empty())
+      m_section_by_name[n] = s.get();
+  }
+}
+
+ELFIO::section*
+elf_writer::
+lookup_section(const std::string& name)
+{
+  auto it = m_section_by_name.find(name);
+  if (it != m_section_by_name.end())
+    return it->second;
+  ELFIO::section* s = m_elfio.sections[name];
+  if (s)
+    m_section_by_name.emplace(name, s);
+  return s;
+}
 
 ELFIO::section*
 elf_writer::
@@ -15,14 +54,14 @@ add_section(const elf_section& data)
   sec->set_type(data.get_type());
   sec->set_flags(data.get_flags());
   sec->set_addr_align(data.get_align());
-  const std::vector<uint8_t> buf = data.get_buffer();
+  const std::vector<uint8_t>& buf = data.get_buffer();
 
-  if(buf.size())
+  if (!buf.empty())
     sec->set_data(reinterpret_cast<const char*>(buf.data()), static_cast<ELFIO::Elf_Word>(buf.size()));
   sec->set_info( data.get_info() );
   if (!data.get_link().empty())
   {
-    const ELFIO::section* lsec = m_elfio.sections[data.get_link()];
+    const ELFIO::section* lsec = lookup_section(data.get_link());
     sec->set_link(lsec->get_index());
   }
   // set section address
@@ -43,7 +82,7 @@ add_segment(const elf_segment& data)
   seg->set_align(data.get_align());
   if (!data.get_link().empty())
   {
-    const ELFIO::section* sec = m_elfio.sections[data.get_link()];
+    const ELFIO::section* sec = lookup_section(data.get_link());
     seg->add_section_index(sec->get_index(),
                            sec->get_addr_align());
   }
@@ -64,20 +103,22 @@ add_dynsym_section(ELFIO::string_section_accessor* stra, std::vector<symbol>& sy
 {
   // Create symbol table writer
   ELFIO::symbol_section_accessor syma( m_elfio, dsym_sec );
-  std::map<std::string, ELFIO::Elf_Word> hash;
+  std::unordered_map<std::string, ELFIO::Elf_Word> hash;
   for (auto & sym : syms) {
     std::string key = sym.get_section_name() + index_string + "_" + sym.get_name() + "_" +
                       std::to_string(sym.get_size());
     auto it = hash.find(key);
     if (it == hash.end())
     {
-      const ELFIO::section* sec = m_elfio.sections[sym.get_section_name()+ index_string];
+      const ELFIO::section* sec = lookup_section(sym.get_section_name()+ index_string);
       auto index = syma.add_symbol(*stra, sym.get_name().c_str(), 0,
                                    sym.get_size(), ELFIO::STB_GLOBAL, ELFIO::STT_OBJECT,
                                    0, sec->get_index());
-      hash[key] = index;
+      hash.emplace(std::move(key), index);
+      sym.set_index(index);
     }
-    sym.set_index(hash[key]);
+    else
+      sym.set_index(it->second);
   }
 
 }
@@ -120,15 +161,13 @@ finalize()
 {
   add_note(NT_XRT_UID, ".note.xrt.UID", m_uid.calculate());
   log_info() << "UID:" << m_uid.str() << "\n";
-  std::stringstream stream;
-  stream << std::noskipws;
-  //m_elfio.save( "hello_32" );
-  m_elfio.save( stream );
-  std::vector<char> v;
-  std::copy(std::istream_iterator<char>(stream),
-            std::istream_iterator<char>( ),
-            std::back_inserter(v));
-  return v;
+  std::ostringstream oss;
+  m_elfio.save( oss );
+  const std::string bytes = oss.str();
+  std::vector<char> out(bytes.size());
+  if (!bytes.empty())
+    std::memcpy(out.data(), bytes.data(), bytes.size());
+  return out;
 }
 
 std::vector<uint32_t>
@@ -136,11 +175,15 @@ elf_writer::
 add_text_data_section(const std::vector<std::shared_ptr<writer>>& mwriter, std::vector<symbol>& syms, const std::string& index_string)
 {
   std::vector<uint32_t> section_index_list;
-  for(auto element : mwriter)
+  for (const auto& element : mwriter)
   {
     auto buffer = std::dynamic_pointer_cast<section_writer>(element);
     if (buffer->get_data().size() == 0)
       continue;
+
+    // Size must be captured before take_data_for_emit() clears the writer buffer;
+    // prev_seg_size drives the next section's virtual address via get_virtual_addr().
+    const uint64_t emit_size = buffer->get_data().size();
 
     m_uid.update(buffer->get_data());
     elf_section sec_data;
@@ -157,7 +200,7 @@ add_text_data_section(const std::vector<std::shared_ptr<writer>>& mwriter, std::
     else
       sec_data.set_flags(ELFIO::SHF_ALLOC | ELFIO::SHF_WRITE);
     sec_data.set_align(align);
-    sec_data.set_buffer(buffer->get_data());
+    sec_data.set_buffer(buffer->take_data_for_emit());
     // set section address equal to segment virtual address as segment:section has 1:1 mapping
     cur_addr = get_virtual_addr(prev_virtual_addr, prev_seg_size);
     sec_data.set_addr(cur_addr);
@@ -184,7 +227,7 @@ add_text_data_section(const std::vector<std::shared_ptr<writer>>& mwriter, std::
 
     // Update for next iteration
     prev_virtual_addr = cur_addr;
-    prev_seg_size = buffer->get_data().size();
+    prev_seg_size = emit_size;
   }
   return section_index_list;
 }
@@ -311,7 +354,7 @@ add_group(const std::string& name, const std::vector<uint32_t>& member, ELFIO::E
   if(member.size())
     sec->set_data(reinterpret_cast<const char*>(member.data()), static_cast<ELFIO::Elf_Word>(member.size()*4));
 
-  const ELFIO::section* lsec = m_elfio.sections[".symtab"];
+  const ELFIO::section* lsec = lookup_section(".symtab");
   sec->set_link(lsec->get_index());
 }
 

--- a/src/cpp/elf/elfwriter.h
+++ b/src/cpp/elf/elfwriter.h
@@ -4,9 +4,9 @@
 #ifndef _AIEBU_ELF_ELF_WRITER_H_
 #define _AIEBU_ELF_ELF_WRITER_H_
 
-#include <sstream>
-#include <iterator>
 #include <mutex>
+#include <string>
+#include <unordered_map>
 #include "writer.h"
 #include "symbol.h"
 #include "elfio/elfio.hpp"
@@ -47,7 +47,8 @@ public:
   HEADER_ACCESS_GET_SET(int, flags);
   HEADER_ACCESS_GET_SET(int, info);
   HEADER_ACCESS_GET_SET(uint64_t, align);
-  HEADER_ACCESS_GET_SET(std::vector<uint8_t>,  buffer);
+  const std::vector<uint8_t>& get_buffer() const { return m_buffer; }
+  void set_buffer(std::vector<uint8_t> val) { m_buffer = std::move(val); }
   HEADER_ACCESS_GET_SET(std::string, link);
   HEADER_ACCESS_GET_SET(uint64_t, addr);
 
@@ -91,6 +92,12 @@ protected:  // NOLINT(cppcoreguidelines-non-private-member-variables-in-classes)
   uint64_t cur_addr = 0;
   uint64_t prev_seg_size = 0;
 
+  // ELFIO::sections[name] scans all sections O(n); this map is updated on add and used on hot paths.
+  std::unordered_map<std::string, ELFIO::section*> m_section_by_name;
+
+  ELFIO::section* lookup_section(const std::string& name);
+  void resync_section_name_map();
+
   ELFIO::section* add_section(const elf_section& data);
   ELFIO::segment* add_segment(const elf_segment& data);
   ELFIO::string_section_accessor add_dynstr_section();
@@ -111,13 +118,7 @@ protected:  // NOLINT(cppcoreguidelines-non-private-member-variables-in-classes)
   void add_group(const std::string& name, const std::vector<uint32_t>& member, ELFIO::Elf_Word info_index);
   uint64_t get_virtual_addr(uint64_t in_prev_virtual_addr, uint64_t in_prev_seg_size);
   uint64_t align_address(uint64_t address);
-  // Helper function to return ELFIO::section* and take section name as input
-  ELFIO::section* add_section_by_name(const std::string& section_name) {
-    if (m_elfio.sections.size() > max_sections)
-      throw error(error::error_code::invalid_asm, "Maximum number of sections reached");
-
-    return m_elfio.sections.add(section_name);
-  }
+  ELFIO::section* add_section_by_name(const std::string& section_name);
 
 public:
 
@@ -141,6 +142,7 @@ public:
     seg->set_file_size(0x0);
     seg->set_memory_size(0x0);
 
+    resync_section_name_map();
   }
 
   // Methods to update OS ABI and version after construction (for .target directive support)

--- a/src/cpp/ops/ops.cpp
+++ b/src/cpp/ops/ops.cpp
@@ -30,6 +30,28 @@ align_op_serializer::size(assembler_state& state)
   return ((state.get_pos() % align) > 0 ) ? (align - (state.get_pos() % align)) : 0;
 }
 
+offset_type
+isa_op::encoded_size_in_text(assembler_state& state,
+                             const std::vector<std::string>& args) const
+{
+  if (!m_opname.compare(".long"))
+    return 4;
+  if (!m_opname.compare(".align")) {
+    const uint32_t align = std::stoi(args.at(0));
+    const offset_type pos = state.get_pos();
+    return ((pos % align) > 0) ? static_cast<offset_type>(align - (pos % align)) : 0;
+  }
+  if (!m_opname.compare("uc_dma_bd"))
+    return 16;
+  if (state.is_optimization_enabled_for_op(m_opname))
+    return 0;
+  offset_type result = 2;
+  constexpr uint8_t width_8 = 8;
+  for (const auto& arg : m_args)
+    result += arg.m_width / width_8;
+  return result;
+}
+
 
 std::vector<uint8_t>
 isa_op_serializer::

--- a/src/cpp/ops/ops.h
+++ b/src/cpp/ops/ops.h
@@ -276,6 +276,11 @@ public:
     else
       return std::make_shared<isa_op_serializer>(get_shared_ptr(), args);
   }
+
+  // Same result as serializer(args)->size(state) without copying args or heap
+  // allocating a serializer (hot path in assembler_state::process).
+  offset_type encoded_size_in_text(assembler_state& state,
+                                   const std::vector<std::string>& args) const;
 };
 
   inline std::unique_ptr<op_deserializer> isa_op_disasm::create_deserializer() const

--- a/src/cpp/preprocessor/asm/asm_parser.cpp
+++ b/src/cpp/preprocessor/asm/asm_parser.cpp
@@ -268,7 +268,7 @@ parse_lines(const std::vector<char>& data, std::string& file)
 
     smatch sm;
 
-    if (line[0] == '.' && operate_directive(line))
+    if (line[0] == '.' &&  line.substr(0,5).compare(".long") && operate_directive(line))
     {
       if (!get_annotation_state())
         continue;
@@ -1524,5 +1524,4 @@ read_pad_file(std::string& name, std::string& filename)
   m_parserptr->insert_scratchpad(name, static_cast<offset_type>(data.size()), data);
   return true;
 }
-
 }

--- a/src/cpp/preprocessor/asm/pager.cpp
+++ b/src/cpp/preprocessor/asm/pager.cpp
@@ -1,13 +1,93 @@
 // SPDX-License-Identifier: MIT
 // Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 #include "pager.h"
-#include "utils.h"
 
 #include "aiebu/aiebu_error.h"
 
 #include <unordered_set>
 
 namespace aiebu {
+namespace {
+
+inline bool
+opcode_is_out_of_order_list(const std::string& op_name)
+{
+  return op_name == "load_pdi" || op_name == "preempt" || op_name == "load_cores";
+}
+
+void
+extractlabels_accum(assembler_state& state,
+                    const std::shared_ptr<asm_data>& token,
+                    std::vector<std::string>& out,
+                    std::unordered_set<std::string>& seen,
+                    const std::map<std::string, std::vector<std::string>>& dependent_labelmap)
+{
+  if (!token || token->isLabel())
+    return;
+  if (opcode_is_out_of_order_list(token->get_operation().get_name()))
+    return;
+
+  const std::vector<std::string> args = token->get_operation().get_args();
+  for (const auto& arg : args) {
+    if (arg.empty() || arg[0] != '@')
+      continue;
+
+    std::string lb = arg.substr(1);
+    if (state.containscratchpads(lb))
+      continue;
+    lb = token->get_qualify_label(lb);
+
+    const auto lit = state.m_labelmap.find(lb);
+    if (lit == state.m_labelmap.end())
+      throw error(error::error_code::internal_error, "Label not found " + lb);
+
+    if (!seen.insert(lb).second)
+      continue;
+
+    out.push_back(lb);
+
+    const auto dit = dependent_labelmap.find(lb);
+    if (dit != dependent_labelmap.end()) {
+      for (const auto& dep : dit->second) {
+        if (seen.insert(dep).second)
+          out.push_back(dep);
+      }
+    }
+
+    const uint32_t index = lit->second->get_index();
+    const int32_t count = lit->second->get_count();
+    for (int32_t i = 0; i <= count; ++i) {
+      extractlabels_accum(state,
+                            state.m_data[static_cast<size_t>(index) + static_cast<size_t>(i)],
+                            out,
+                            seen,
+                            dependent_labelmap);
+    }
+  }
+}
+
+void
+extract_externallabels_accum(const std::shared_ptr<asm_data>& token,
+                             std::vector<std::string>& out,
+                             std::unordered_set<std::string>& seen)
+{
+  if (!token || token->isLabel())
+    return;
+  if (!opcode_is_out_of_order_list(token->get_operation().get_name()))
+    return;
+
+  const std::vector<std::string> args = token->get_operation().get_args();
+  for (const auto& arg : args) {
+    if (arg.empty() || arg[0] != '@')
+      continue;
+    std::string lb = arg.substr(1);
+    lb = token->get_qualify_label(lb);
+    if (seen.insert(lb).second)
+      out.push_back(lb);
+  }
+}
+
+} // namespace
 
 template <typename T>
 std::vector<T>
@@ -108,38 +188,9 @@ std::vector<std::string>
 pager::
 extractlabels(assembler_state& state, std::shared_ptr<asm_data> token)
 {
-  // Extract all labels connected to token
   std::vector<std::string> labels;
-  if (token->isLabel())
-    return labels;
-
-  auto dependent_labelmap = state.get_dependent_labelmap();
-  for (auto &arg : token->get_operation().get_args())
-  {
-    auto it = std::find(OOO.begin(), OOO.end(), token->get_operation().get_name());
-    if (arg.rfind("@") == 0 && it == OOO.end())
-    {
-      auto lb = arg.substr(1);
-      if (state.containscratchpads(lb))
-        continue;
-      lb = token->get_qualify_label(lb);
-      if (state.m_labelmap.find(lb) == state.m_labelmap.end())
-      {
-        throw error(error::error_code::internal_error, "Label not found " + lb);
-      }
-      std::vector<std::string> vlb {lb};
-      if (dependent_labelmap.find(lb) != dependent_labelmap.end())
-        vlb.insert(vlb.end(), dependent_labelmap[lb].begin(), dependent_labelmap[lb].end());
-
-      labels = union_of_lists_inorder<std::string>(labels, vlb);
-      auto index = state.m_labelmap[lb]->get_index();
-      for (auto i = 0; i <= state.m_labelmap[lb]->get_count(); ++i)
-      {
-        auto elb = extractlabels(state, state.m_data[index+i]);
-        labels = union_of_lists_inorder<std::string>(labels, elb);
-      }
-    }
-  }
+  std::unordered_set<std::string> seen;
+  extractlabels_accum(state, token, labels, seen, state.get_dependent_labelmap());
   return labels;
 }
 
@@ -147,26 +198,10 @@ std::vector<std::string>
 pager::
 extract_externallabels(assembler_state& /*state*/, std::shared_ptr<asm_data> token)
 {
-  // extract all external labels connected to token
   std::vector<std::string> labels;
-  if (token->isLabel())
-    return labels;
-
-  for (auto &arg : token->get_operation().get_args())
-  {
-    if (arg.rfind("@") != 0)
-      continue;
-
-    auto it = std::find(OOO.begin(), OOO.end(), token->get_operation().get_name());
-    if (it == OOO.end())
-      continue;
-
-    auto lb = arg.substr(1);
-    lb = token->get_qualify_label(lb);
-    std::vector<std::string> vlb {lb};
-    labels = union_of_lists_inorder<std::string>(labels, vlb);
-  }
-  return labels;  
+  std::unordered_set<std::string> seen;
+  extract_externallabels_accum(token, labels, seen);
+  return labels;
 }
 
 offset_type
@@ -183,16 +218,17 @@ extractjobsandlabels(assembler_state& state, std::shared_ptr<job> pjob,
 
   job_list = extractjobs(state, pjob);
   offset_type tsize = 0;
+  const auto& dependent_labelmap = state.get_dependent_labelmap();
+  std::unordered_set<std::string> labels_seen;
+  std::unordered_set<std::string> external_seen;
   for (auto djid : job_list)
   {
     tsize +=  state.m_jobmap[djid]->get_end() - state.m_jobmap[djid]->get_start();
     for (auto j = state.m_jobmap[djid]->get_start_index(); j < state.m_jobmap[djid]->get_end_index() + 1; ++j)
     {
-      auto token = state.m_data[j];
-      auto elb = extractlabels(state, token);
-      labels_list = union_of_lists_inorder<std::string>(labels_list, elb);
-      auto eelb = extract_externallabels(state, token);
-      external_labels_list = union_of_lists_inorder<std::string>(external_labels_list, eelb);
+      const auto& token = state.m_data[j];
+      extractlabels_accum(state, token, labels_list, labels_seen, dependent_labelmap);
+      extract_externallabels_accum(token, external_labels_list, external_seen);
     }
   }
   return tsize;
@@ -335,16 +371,14 @@ pagify(assembler_state& state, uint32_t col, std::vector<page>& pages, uint32_t 
     // get total text section size, jobs and labels releated to jobid(current job) which are not already taken in current page
     // don't return jobs/labels for a job which is already in this page a second time (note that multiple jobs might depend on
     // the same job)
-    auto tsize = extractjobsandlabels(state, pjob, job_list, labels_list, external_labels_list);
-
+    offset_type tsize = extractjobsandlabels(state, pjob, job_list, labels_list, external_labels_list);
     // calculate alignment bytes needed bet text and data section
     // NOTE: data section is always 16 Byte aligned
-    auto dsectionaligner = datasectionaligner(page_tsize + tsize);
-
+    offset_type dsectionaligner = datasectionaligner(page_tsize + tsize);
     // get data section size for jobs(related to current job)
-    auto dsize = getdatasectionsize(state, labels_list);
+    offset_type dsize = getdatasectionsize(state, labels_list);
 
-    auto jobdsectionaligner = datasectionaligner(tsize);
+    offset_type jobdsectionaligner = datasectionaligner(tsize);
 
     //check if job can fit in one page
     if ((tsize + jobdsectionaligner + dsize + EOF_SIZE + PAGE_HEADER_SIZE) > m_page_size)

--- a/src/cpp/preprocessor/asm/pager.h
+++ b/src/cpp/preprocessor/asm/pager.h
@@ -21,7 +21,6 @@ class pager
   constexpr static offset_type ALIGNMENT_4 = 4;
 
   std::map<std::string , offset_type> ALIGNMAP = {{"uc_dma_bd", ALIGNMENT_16}, {".long", ALIGNMENT_4}};
-  std::vector<std::string> OOO = {"load_pdi", "preempt", "load_cores"};
 
   template <typename T>
   std::vector<T> union_of_lists_inorder(std::vector<T> &vec1, std::vector<T>& vec2);
@@ -65,7 +64,6 @@ class pager
 public:
   pager(uint32_t page_size): m_page_size(page_size) {}  
   uint32_t pagify(assembler_state& state, uint32_t col, std::vector<page>& pages, uint32_t relative_page_index);
-
 };
 
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Improvement on multiple hot path and windows build flag changes:
 
1. MSVC / Windows CMake (cmake/windows.cmake)
Release: Explicit /O2 and /Ot (fast code vs size), each in its own $<CONFIG:Release> generator expression so CMake does not misparse a single string with ;.
_ITERATOR_DEBUG_LEVEL=0 in Release to avoid checked-iterator overhead in optimized builds.

2. Pager (pager.cpp / pager.h) - reduced paging time  ~31s → ~8s in linux
    a. Out-of-order opcodes: Replaced repeated std::find on a small opcode list with opcode_is_out_of_order_list() (string compares for load_pdi, preempt, load_cores). The old pager::OOO vector + std::find per argument is gone after cleanup.
    b. Label extraction: extractlabels / recursive label gathering no longer builds intermediate vectors and merges them with union_of_lists_inorder on every step (which implied repeated linear deduplication). The new extractlabels_accum walks arguments once per logical visit, uses an std::unordered_set<std::string> for seen, and appends to the output list only on first sight of a label. Dependent labels from dependent_labelmap are merged with the same dedup rules.
    c. External labels: extract_externallabels_accum mirrors the OOO opcode rules with set-based dedup instead of union_of_lists_inorder for single-element vectors.
    d. extractjobsandlabels: Reuses one dependent_labelmap reference, maintains labels_seen / external_seen sets across the job loop so work is not duplicated when the same label appears from multiple tokens in the same page extraction.

3. assembler_state (assembler_state.cpp / .h)
 a. Single pass over m_data: Loop uses const auto& instead of copying shared_ptrs each iteration.
 b. std::map inserts: Duplicate checks for labels and jobs use lower_bound + key equality and emplace_hint instead of find then operator[], which is cheaper when keys are roughly monotonic in the stream.
 c. ISA lookup: Uses m_isa->find(name) once and isa_it->second instead of count + operator[].
 d. Encoded size: Uses isa_op::encoded_size_in_text directly instead of going through serializer(...)->size for the common path (aligns with new sizing logic in ops).
 e. local_barrier / launch_job: Rely on operator[] on std::map for vectors instead of explicit find + empty-vector insert branches where safe.
 f. .eop naming: gen_eop_name is called once per .eop and reused for map key and push_back.
 
4. ELF writer (elfwriter.cpp / elfwriter.h, derived writers)
  a. m_section_by_name: std::unordered_map<std::string, ELFIO::section*> caches section pointers because ELFIO::sections[name] scans all sections O(n).
  b. add_section_by_name: Registers new sections in the map.
  c. lookup_section: Map hit returns immediately; on miss, falls back to ELFIO lookup and inserts into the map.
  e. resync_section_name_map: Rebuilds the map from ELFIO’s section container; iterates with for (auto& s : m_elfio.sections) and uses s->get_name() / s.get() because the range yields std::unique_ptr<section>& (not raw section&).
max_sections: Guard uses >= max_sections so the limit cannot be exceeded by one (off-by-one style fix in fix).
  f. aie2_blob_elfwriter.h / aie2ps_elfwriter.h: Group section assembly adjusted for the writer base (comments about prepend without O(n) insert-at-begin); fix drops an extra grouped.reserve that was tied to that pattern.
  g. add_dynsym_section: fix removes hash.reserve(...) on the symbol dedup map.

5. ASM parser: .long vs directives (asm_parser.cpp)
Directive handling used:
if (line[0] == '.' && line.substr(0,5).compare(".long") && operate_directive(line))

So when the first five characters are .long, compare returns 0 (false) and operate_directive is not invoked for that path—.long is left to the normal opcode / line pipeline.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)

### Base timing
Linux:        aie4_compile_time .........................   Passed   91.65 sec
Windows: aie4_compile_time .........................   Passed  219.99 sec
### 1. optimization + text -j 4:
Linux:        aie4_compile_time .........................   Passed   43.43 sec
Windows: aie4_compile_time .........................   Passed  103.42 sec
https://github.com/Xilinx/aiebu/actions/runs/24987849232/job/73165588219?pr=279

### 2. Optimization + test -j 1
Linux:       aie4_compile_time .........................   Passed   38.38 sec
Wnidows: aie4_compile_time .........................   Passed   73.61 sec
https://github.com/Xilinx/aiebu/actions/runs/24990069727/job/73173179055?pr=279

### 3. Optimization + test -j 4 + line.sutstr(0,5).compare(".long")
Linux:       aie4_compile_time .........................   Passed   40.90 sec
Windows: aie4_compile_time .........................   Passed   93.70 sec
https://github.com/Xilinx/aiebu/actions/runs/24997939800/job/73199806776?pr=279

### 4. Optimization + test -j 1 + line.sutstr(0,5).compare(".long")
Linux:        aie4_compile_time .........................   Passed   35.34 sec
Windows: aie4_compile_time .........................   Passed   62.70 sec
https://github.com/Xilinx/aiebu/actions/runs/24992903754/job/73182603051?pr=279