### PR TITLE
Export public include directories from aiebu_static target

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -101,6 +101,12 @@ add_library(aiebu_static STATIC
   $<TARGET_OBJECTS:aiebu_library_objects>
   )
 
+target_include_directories(aiebu_static
+  PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+  )
+
 if (MSVC)
   target_link_libraries(aiebu_static advapi32)
 else()


### PR DESCRIPTION
## Summary

- Add `target_include_directories(PUBLIC)` with `BUILD_INTERFACE` and `INSTALL_INTERFACE` generator expressions to `aiebu_static` in `src/cpp/CMakeLists.txt`
- Consumers using `find_package(aiebu)` now automatically get the correct include paths via `target_link_libraries` without needing manual `include_directories()` or workaround variables like `AIEBU_SOURCE_DIR`

## Motivation

Currently, `aiebu_static` does not export its public include directories. This forces every consumer (cardano, flexml/vaiml2, XMC superbuild) to manually discover and add include paths via variables like `AIEBU_SOURCE_DIR` or `CARDANO_AIEBU_SOURCE_DIR`. This is fragile and breaks when switching from `add_subdirectory` to `find_package` consumption.

With this fix, `target_link_libraries(... aiebu_static)` or `target_link_libraries(... AIEBU::aiebu_static)` automatically propagates the correct include path — both at build time (`src/cpp/include`) and after install (`<prefix>/include`).

Fixes AIESW-27534.

## Test plan

- [ ] Verify `aiebu_static` consumers get `include/aiebu/aiebu.h` without explicit `include_directories()`
- [ ] Verify `find_package(aiebu)` + `target_link_libraries(... AIEBU::aiebu_static)` propagates include dirs
- [ ] Verify standalone aiebu build still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)