### PR TITLE
Add a benchmark label to long running tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,11 +122,13 @@ jobs:
       if: runner.os == 'Linux'
       run: |
         ctest --test-dir ${{github.workspace}}/build/Release -C Release -j 4
+        ctest --test-dir ${{github.workspace}}/build/Release -C Release -L benchmark
 
     - name: Test (Windows)
       if: runner.os == 'Windows'
       run: |
         ctest --test-dir ${{github.workspace}}/build/WBuild -C Release -j 4
+        ctest --test-dir ${{github.workspace}}/build/WBuild -C Release -L benchmark
 
     - name: Package (Linux)
       if: runner.os == 'Linux'

--- a/test/aie2-ctrlcode/transform/CMakeLists.txt
+++ b/test/aie2-ctrlcode/transform/CMakeLists.txt
@@ -25,4 +25,5 @@ add_test(NAME "aie2_fused_transform_compare"
 set_tests_properties("aie2_basic_transform" PROPERTIES DEPENDS "aie2_basic_txn")
 set_tests_properties("aie2_basic_transform_compare" PROPERTIES DEPENDS "aie2_basic_transform")
 set_tests_properties("aie2_fused_transform" PROPERTIES DEPENDS "aie2_fused_txn")
+set_tests_properties("aie2_fused_transform" PROPERTIES LABELS "benchmark")
 set_tests_properties("aie2_fused_transform_compare" PROPERTIES DEPENDS "aie2_fused_transform")

--- a/test/aie2ps-ctrlcode/eff_net_coal/CMakeLists.txt
+++ b/test/aie2ps-ctrlcode/eff_net_coal/CMakeLists.txt
@@ -4,6 +4,7 @@
 # Assemble a ctrlcode to ELF
 add_test(NAME "aie2ps_eff_net_coal_asm"
   COMMAND aiebu-asm -t aie2ps_config -j "${CMAKE_CURRENT_SOURCE_DIR}/config.json" -o eff_net_coal.elf -f disabledump)
+  set_tests_properties("aie2ps_eff_net_coal_asm" PROPERTIES LABELS "benchmark")
 
 if ((${CMAKE_SYSTEM_NAME} STREQUAL "Linux"))
   add_test(NAME "aie2ps_eff_net_coal_readelf"
@@ -23,4 +24,3 @@ if ((${CMAKE_SYSTEM_NAME} STREQUAL "Linux"))
 
   set_tests_properties("aie2ps_eff_net_coal_md5sum" PROPERTIES DEPENDS "aie2ps_eff_net_coal_asm")
 endif()
-

--- a/test/aie4-ctrlcode/compile_time/fused_hw_package_subgraph_0/CMakeLists.txt
+++ b/test/aie4-ctrlcode/compile_time/fused_hw_package_subgraph_0/CMakeLists.txt
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2026 Advanced Micro Devices, Inc.
 
-#if(CMAKE_BUILD_TYPE STREQUAL "Release")
 # Assemble control code ASM for very large asm of total size 286 MB arranged into 10K files
 add_test(NAME "aie4_compile_time"
   COMMAND aiebu-asm -t aie4_config -j "${CMAKE_CURRENT_SOURCE_DIR}/config.json" -o control.elf -f disabledump
@@ -15,4 +14,4 @@ add_test(NAME "aie4_compile_time_md5sum"
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
 set_tests_properties("aie4_compile_time_md5sum" PROPERTIES DEPENDS "aie4_compile_time")
-#endif()
+set_tests_properties("aie4_compile_time" PROPERTIES LABELS "benchmark")

--- a/test/aie4-ctrlcode/multi_graph/CMakeLists.txt
+++ b/test/aie4-ctrlcode/multi_graph/CMakeLists.txt
@@ -12,4 +12,4 @@ add_test(NAME "aie4_multi_graph_asm_md5sum"
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
 set_tests_properties("aie4_multi_graph_asm_md5sum" PROPERTIES DEPENDS "aie4_multi_graph_asm")
-set_tests_properties("aie4_multi_graph_asm" PROPERTIES LABELS memcheck)
+set_tests_properties("aie4_multi_graph_asm" PROPERTIES LABELS "memcheck;benchmark")


### PR DESCRIPTION
The benchmark labeled tests are invoked without -j switch on GitHub runner

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
