### PR TITLE
fix: avoid overwriting when same job number is present in same file but in different label

### DIFF
--- a/src/cpp/encoder/aie2ps/report.h
+++ b/src/cpp/encoder/aie2ps/report.h
@@ -96,7 +96,9 @@ public:
   }
 
   std::string add_function(uint32_t file_idx, const std::string& name, offset_type high_pc, offset_type low_pc, uint32_t col, pageid_type pagenum) {
-    std::string key = std::to_string(file_idx) + "_" + std::to_string(col) + "_" + name;
+    // source/file/column/page do not overwrite previously recorded functions.
+    std::string key = std::to_string(file_idx) + "_" + std::to_string(col) + "_"
+                      + std::to_string(pagenum) + "_" + name;
     functions[key] = std::make_shared<Function>(file_idx, name, high_pc, low_pc, col, pagenum);
     insertion_order.push_back(key);
     return key;


### PR DESCRIPTION


<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
