### PR TITLE
Make cpp-assembler-stubs a dependency of aiebu_library_objects, which…

### DIFF
--- a/specification/aie2ps/CMakeLists.txt
+++ b/specification/aie2ps/CMakeLists.txt
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
 add_custom_target(cpp-assembler-stubs
-  DEPENDS spec-tool-deps
   COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH="${SPEC_PYTHON_PATH}"
   ${Python3_EXECUTABLE}
   ${AIEBU_SOURCE_DIR}/specification/spec_tool.py

--- a/specification/spec_tool.py
+++ b/specification/spec_tool.py
@@ -15,7 +15,6 @@
 import sys
 import yaml
 import markdown
-import markdown_graphviz_svg
 from jinja2 import Environment, FileSystemLoader
 
 
@@ -63,6 +62,7 @@ def generate_docs(spec):
 
 
 def generate_html_docs(spec):
+  import markdown_graphviz_svg
   template = _environment.get_template('docs.md')
   template.globals.update(jinja_functions)
   md = markdown.Markdown(extensions=[markdown_graphviz_svg.GraphvizBlocksExtension(), 'tables', 'fenced_code', 'toc'])

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -78,6 +78,8 @@ if (AIEBU_NATIVE_BUILD)
   #add_dependencies(aiebu_library_objects ctrlcodelib)
 endif()
 
+add_dependencies(aiebu_library_objects cpp-assembler-stubs)
+
 set_target_properties(aiebu_library_objects PROPERTIES
   CXX_VISIBILITY_PRESET hidden
   POSITION_INDEPENDENT_CODE ON


### PR DESCRIPTION
… requires isa.h tohave been generated.

Also remove not-needed spec-tool-deps dep from cpp-assembler-stubs.



<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Fixes spurious build errors due to missing cmake dep
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Build failures in downstream project

