### PR TITLE
Avoid always regenerating aie spec files

### DIFF
--- a/specification/CMakeLists.txt
+++ b/specification/CMakeLists.txt
@@ -1,20 +1,28 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2023 Advanced Micro Devices, Inc.
+set(SPEC_MARKDOWN_GRAPHVIZ_SVG
+  ${CMAKE_CURRENT_BINARY_DIR}/markdown_graphviz_svg.py
+  )
+
 if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-  add_custom_target(spec-tool-deps
+  add_custom_command(
+    OUTPUT ${SPEC_MARKDOWN_GRAPHVIZ_SVG}
     COMMAND wget -q -O markdown_graphviz_svg.py
     https://raw.githubusercontent.com/Tanami/markdown-graphviz-svg/master/src/markdown_graphviz_svg/markdown_graphviz_svg.py
-    BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/markdown_graphviz_svg.py
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     )
 else()
-  add_custom_target(spec-tool-deps
+  add_custom_command(
+    OUTPUT ${SPEC_MARKDOWN_GRAPHVIZ_SVG}
     COMMAND powershell wget -O markdown_graphviz_svg.py
     https://raw.githubusercontent.com/Tanami/markdown-graphviz-svg/master/src/markdown_graphviz_svg/markdown_graphviz_svg.py
-    BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/markdown_graphviz_svg.py
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     )
 endif()
+
+add_custom_target(spec-tool-deps
+  DEPENDS ${SPEC_MARKDOWN_GRAPHVIZ_SVG}
+  )
 
 set(SPEC_PYTHON_PATH ${CMAKE_CURRENT_BINARY_DIR})
 

--- a/specification/aie2ps/CMakeLists.txt
+++ b/specification/aie2ps/CMakeLists.txt
@@ -1,73 +1,101 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
-add_custom_target(cpp-assembler-stubs
-  DEPENDS spec-tool-deps
+set(AIE2PS_TEMPLATES_DIR ${AIEBU_SOURCE_DIR}/templates/aie2ps)
+set(AIE2PS_ASSEMBLER_STUB_TEMPLATE ${AIE2PS_TEMPLATES_DIR}/assembler_stub.h)
+set(AIE2PS_C_DEFINES_TEMPLATE ${AIE2PS_TEMPLATES_DIR}/defines.h)
+set(AIE2PS_C_STUBS_TEMPLATE ${AIE2PS_TEMPLATES_DIR}/stubs.h)
+set(AIE2PS_DOCS_HTML_TEMPLATE ${AIE2PS_TEMPLATES_DIR}/docs.html)
+set(AIE2PS_DOCS_MARKDOWN_TEMPLATE ${AIE2PS_TEMPLATES_DIR}/docs.md)
+
+add_custom_command(
+  OUTPUT ${AIEBU_SOURCE_DIR}/specification/aie2ps/isa.h
   COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH="${SPEC_PYTHON_PATH}"
   ${Python3_EXECUTABLE}
   ${AIEBU_SOURCE_DIR}/specification/spec_tool.py
   ${AIEBU_SOURCE_DIR}/specification/aie2ps/isa-spec.yaml
-  ${AIEBU_SOURCE_DIR}/templates/aie2ps generate_cpp_assembler_stubs
+  ${AIE2PS_TEMPLATES_DIR} generate_cpp_assembler_stubs
   > ${AIEBU_SOURCE_DIR}/specification/aie2ps/isa.h
-  BYPRODUCTS ${AIEBU_SOURCE_DIR}/specification/aie2ps/isa.h
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-  SOURCES ${AIEBU_SOURCE_DIR}/specification/spec_tool.py
+  DEPENDS ${SPEC_MARKDOWN_GRAPHVIZ_SVG}
+  ${AIEBU_SOURCE_DIR}/specification/spec_tool.py
   ${AIEBU_SOURCE_DIR}/specification/aie2ps/isa-spec.yaml
+  ${AIE2PS_ASSEMBLER_STUB_TEMPLATE}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  )
+add_custom_target(cpp-assembler-stubs
+  DEPENDS ${AIEBU_SOURCE_DIR}/specification/aie2ps/isa.h
   )
 
-add_custom_target(docs
-  DEPENDS spec-tool-deps
+add_custom_command(
+  OUTPUT ${AIEBU_SOURCE_DIR}/specification/aie2ps/isa-spec.md
   COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH="${SPEC_PYTHON_PATH}"
   ${Python3_EXECUTABLE}
   ${AIEBU_SOURCE_DIR}/specification/spec_tool.py
   ${AIEBU_SOURCE_DIR}/specification/aie2ps/isa-spec.yaml
-  ${AIEBU_SOURCE_DIR}/templates/aie2ps generate_docs
+  ${AIE2PS_TEMPLATES_DIR} generate_docs
   > ${AIEBU_SOURCE_DIR}/specification/aie2ps/isa-spec.md
-  BYPRODUCTS ${AIEBU_SOURCE_DIR}/specification/aie2ps/isa-spec.md
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-  SOURCES ${AIEBU_SOURCE_DIR}/specification/spec_tool.py
+  DEPENDS ${SPEC_MARKDOWN_GRAPHVIZ_SVG}
+  ${AIEBU_SOURCE_DIR}/specification/spec_tool.py
   ${AIEBU_SOURCE_DIR}/specification/aie2ps/isa-spec.yaml
+  ${AIE2PS_DOCS_MARKDOWN_TEMPLATE}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  )
+add_custom_target(docs
+  DEPENDS ${AIEBU_SOURCE_DIR}/specification/aie2ps/isa-spec.md
   )
 
-add_custom_target(html-docs
-  DEPENDS spec-tool-deps
+add_custom_command(
+  OUTPUT ${AIEBU_SOURCE_DIR}/specification/aie2ps/isa-spec.html
   COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH="${SPEC_PYTHON_PATH}"
   ${Python3_EXECUTABLE}
   ${AIEBU_SOURCE_DIR}/specification/spec_tool.py
   ${AIEBU_SOURCE_DIR}/specification/aie2ps/isa-spec.yaml
-  ${AIEBU_SOURCE_DIR}/templates/aie2ps generate_html_docs
+  ${AIE2PS_TEMPLATES_DIR} generate_html_docs
   > ${AIEBU_SOURCE_DIR}/specification/aie2ps/isa-spec.html
-  BYPRODUCTS ${AIEBU_SOURCE_DIR}/specification/aie2ps/isa-spec.html
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-  SOURCES ${AIEBU_SOURCE_DIR}/specification/spec_tool.py
+  DEPENDS ${SPEC_MARKDOWN_GRAPHVIZ_SVG}
+  ${AIEBU_SOURCE_DIR}/specification/spec_tool.py
   ${AIEBU_SOURCE_DIR}/specification/aie2ps/isa-spec.yaml
+  ${AIE2PS_DOCS_HTML_TEMPLATE}
+  ${AIE2PS_DOCS_MARKDOWN_TEMPLATE}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  )
+add_custom_target(html-docs
+  DEPENDS ${AIEBU_SOURCE_DIR}/specification/aie2ps/isa-spec.html
   )
 
-add_custom_target(c-stubs
-  DEPENDS spec-tool-deps
+add_custom_command(
+  OUTPUT ${AIEBU_SOURCE_DIR}/specification/aie2ps/isa_stubs.h
   COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH="${SPEC_PYTHON_PATH}"
   ${Python3_EXECUTABLE}
   ${AIEBU_SOURCE_DIR}/specification/spec_tool.py
   ${AIEBU_SOURCE_DIR}/specification/aie2ps/isa-spec.yaml
-  ${AIEBU_SOURCE_DIR}/templates/aie2ps generate_c_stubs
+  ${AIE2PS_TEMPLATES_DIR} generate_c_stubs
   > ${AIEBU_SOURCE_DIR}/specification/aie2ps/isa_stubs.h
-  BYPRODUCTS ${AIEBU_SOURCE_DIR}/specification/aie2ps/isa_stubs.h
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-  SOURCES ${AIEBU_SOURCE_DIR}/specification/spec_tool.py
+  DEPENDS ${SPEC_MARKDOWN_GRAPHVIZ_SVG}
+  ${AIEBU_SOURCE_DIR}/specification/spec_tool.py
   ${AIEBU_SOURCE_DIR}/specification/aie2ps/isa-spec.yaml
+  ${AIE2PS_C_STUBS_TEMPLATE}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  )
+add_custom_target(c-stubs
+  DEPENDS ${AIEBU_SOURCE_DIR}/specification/aie2ps/isa_stubs.h
   )
 
-add_custom_target(c-defines
-  DEPENDS spec-tool-deps
+add_custom_command(
+  OUTPUT ${AIEBU_SOURCE_DIR}/specification/aie2ps/isa_defines.h
   COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH="${SPEC_PYTHON_PATH}"
   ${Python3_EXECUTABLE}
   ${AIEBU_SOURCE_DIR}/specification/spec_tool.py
   ${AIEBU_SOURCE_DIR}/specification/aie2ps/isa-spec.yaml
-  ${AIEBU_SOURCE_DIR}/templates/aie2ps generate_c_defines
+  ${AIE2PS_TEMPLATES_DIR} generate_c_defines
   > ${AIEBU_SOURCE_DIR}/specification/aie2ps/isa_defines.h
-  BYPRODUCTS ${AIEBU_SOURCE_DIR}/specification/aie2ps/isa_defines.h
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-  SOURCES ${AIEBU_SOURCE_DIR}/specification/spec_tool.py
+  DEPENDS ${SPEC_MARKDOWN_GRAPHVIZ_SVG}
+  ${AIEBU_SOURCE_DIR}/specification/spec_tool.py
   ${AIEBU_SOURCE_DIR}/specification/aie2ps/isa-spec.yaml
+  ${AIE2PS_C_DEFINES_TEMPLATE}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  )
+add_custom_target(c-defines
+  DEPENDS ${AIEBU_SOURCE_DIR}/specification/aie2ps/isa_defines.h
   )
 
 add_dependencies(isa-spec-gen cpp-assembler-stubs docs html-docs c-stubs c-defines)


### PR DESCRIPTION

#### Problem solved by the commit
Replace custom targets that directly ran the spec generators with custom commands that declare their outputs and inputs. This lets CMake skip regeneration when the inputs  are unchanged.

This prevents unneeded rebuilds by targets that depend on isa.h
