### PR TITLE
dynamic tracing compiler performance optimization

### DIFF
--- a/src/cpp/dtrace/action/action_control.h
+++ b/src/cpp/dtrace/action/action_control.h
@@ -205,12 +205,12 @@ public:
     ) = 0;
     // Python output format
     virtual void serialize(
-        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
+        uint32_t* result_buffer, uint32_t* mem_buffer,
         const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output
     ) const = 0;
     // JSON output format
     virtual void serialize(
-        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer,
+        uint32_t* result_buffer, uint32_t* mem_buffer,
         const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output
     ) const = 0;
     virtual uint64_t get_mem_host_addr() const { return 0; }
@@ -238,15 +238,15 @@ public:
         uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint32_t>& mem_buffer
     ) override;
     uint32_t serialize_helper(
-        std::vector<uint32_t>& result_buffer,
+        uint32_t* result_buffer,
         const std::unordered_map<uint32_t, uint32_t>& mapping
     ) const;
     void serialize(
-        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
+        uint32_t* result_buffer, uint32_t* mem_buffer,
         const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output
     ) const override;
     void serialize(
-        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer,
+        uint32_t* result_buffer, uint32_t* mem_buffer,
         const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output
     ) const override;
 };
@@ -270,11 +270,11 @@ public:
         uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint32_t>& mem_buffer
     ) override;
     void serialize(
-        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
+        uint32_t* result_buffer, uint32_t* mem_buffer,
         const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output
     ) const override;
     void serialize(
-        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer,
+        uint32_t* result_buffer, uint32_t* mem_buffer,
         const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output
     ) const override;
 };
@@ -305,13 +305,13 @@ public:
     void actionize(
         uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint32_t>& mem_buffer
     ) override;
-    void serialize_helper(std::vector<uint32_t>& mem_buffer) const;
+    void serialize_helper(uint32_t* mem_buffer) const;
     void serialize(
-        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
+        uint32_t* result_buffer, uint32_t* mem_buffer,
         const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output
     ) const override;
     void serialize(
-        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer,
+        uint32_t* result_buffer, uint32_t* mem_buffer,
         const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output
     ) const override;
     uint32_t get_mode() const { return m_mode; }
@@ -336,15 +336,15 @@ public:
         uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint32_t>& mem_buffer
     ) override;
     uint64_t serialize_helper(
-        std::vector<uint32_t>& result_buffer,
+        uint32_t* result_buffer,
         const std::unordered_map<uint32_t, uint32_t>& mapping
     ) const;
     void serialize(
-        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
+        uint32_t* result_buffer, uint32_t* mem_buffer,
         const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output
     ) const override;
     void serialize(
-        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer,
+        uint32_t* result_buffer, uint32_t* mem_buffer,
         const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output
     ) const override;
 };
@@ -368,15 +368,15 @@ public:
         uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint32_t>& mem_buffer
     ) override;
     uint64_t serialize_helper(
-        std::vector<uint32_t>& result_buffer, 
+        uint32_t* result_buffer, 
         const std::unordered_map<uint32_t, uint32_t>& mapping
     ) const;
     void serialize(
-        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
+        uint32_t* result_buffer, uint32_t* mem_buffer,
         const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output
     ) const override;
     void serialize(
-        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer,
+        uint32_t* result_buffer, uint32_t* mem_buffer,
         const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output
     ) const override;
 };
@@ -400,15 +400,15 @@ public:
         uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint32_t>& mem_buffer
     ) override;
     uint32_t serialize_helper(
-        std::vector<uint32_t>& result_buffer,
+        uint32_t* result_buffer,
         const std::unordered_map<uint32_t, uint32_t>& mapping
     ) const;
     void serialize(
-        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
+        uint32_t* result_buffer, uint32_t* mem_buffer,
         const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output
     ) const override;
     void serialize(
-        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer,
+        uint32_t* result_buffer, uint32_t* mem_buffer,
         const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output
     ) const override;
 };
@@ -432,11 +432,11 @@ public:
         uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint32_t>& mem_buffer
     ) override;
     void serialize(
-        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
+        uint32_t* result_buffer, uint32_t* mem_buffer,
         const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output
     ) const override;
     void serialize(
-        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer,
+        uint32_t* result_buffer, uint32_t* mem_buffer,
         const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output
     ) const override;
 };
@@ -460,15 +460,15 @@ public:
         uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint32_t>& mem_buffer
     ) override;
     uint32_t serialize_helper(
-        std::vector<uint32_t>& result_buffer, 
+        uint32_t* result_buffer, 
         const std::unordered_map<uint32_t, uint32_t>& mapping
     ) const;
     void serialize(
-        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer,
+        uint32_t* result_buffer, uint32_t* mem_buffer,
         const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output
     ) const override;
     void serialize(
-        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer,
+        uint32_t* result_buffer, uint32_t* mem_buffer,
         const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output
     ) const override;
 };
@@ -499,11 +499,11 @@ public:
         uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint32_t>& mem_buffer
     ) override;
     void serialize(
-        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
+        uint32_t* result_buffer, uint32_t* mem_buffer,
         const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output
     ) const override;
     void serialize(
-        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer,
+        uint32_t* result_buffer, uint32_t* mem_buffer,
         const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output
     ) const override;
 };
@@ -533,13 +533,13 @@ public:
         uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint32_t>& mem_buffer
     ) override;
     std::pair<std::string, uint32_t> get_opcode(const uint32_t& value)  const;
-    std::string serialize_helper(const std::vector<uint32_t>& result_buffer) const;
+    std::string serialize_helper(const uint32_t* result_buffer) const;
     void serialize(
-        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
+        uint32_t* result_buffer, uint32_t* mem_buffer,
         const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output
     ) const override;
     void serialize(
-        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer,
+        uint32_t* result_buffer, uint32_t* mem_buffer,
         const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output
     ) const override;
 };
@@ -566,11 +566,11 @@ public:
         uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint32_t>& mem_buffer
     ) override;
     void serialize(
-        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
+        uint32_t* result_buffer, uint32_t* mem_buffer,
         const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output
     ) const override;
     void serialize(
-        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer,
+        uint32_t* result_buffer, uint32_t* mem_buffer,
         const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output
     ) const override;
 };
@@ -603,15 +603,15 @@ public:
         uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint32_t>& mem_buffer
     ) override;
     std::vector<uint32_t> serialize_helper(
-        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
+        uint32_t* result_buffer, uint32_t* mem_buffer,
         const std::unordered_map<uint32_t, uint32_t>& mapping
     ) const;
     void serialize(
-        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
+        uint32_t* result_buffer, uint32_t* mem_buffer,
         const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output
     ) const override;
     void serialize(
-        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer,
+        uint32_t* result_buffer, uint32_t* mem_buffer,
         const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output
     ) const override;
     uint64_t get_mem_host_addr() const override;
@@ -644,11 +644,11 @@ public:
         uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint32_t>& mem_buffer
     ) override;
     void serialize(
-        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
+        uint32_t* result_buffer, uint32_t* mem_buffer,
         const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output
     ) const override;
     void serialize(
-        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer,
+        uint32_t* result_buffer, uint32_t* mem_buffer,
         const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output
     ) const override;
 };
@@ -675,11 +675,11 @@ public:
         uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint32_t>& mem_buffer
     ) override;
     void serialize(
-        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
+        uint32_t* result_buffer, uint32_t* mem_buffer,
         const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output
     ) const override;
     void serialize(
-        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer,
+        uint32_t* result_buffer, uint32_t* mem_buffer,
         const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output
     ) const override;
 };
@@ -706,15 +706,15 @@ public:
         uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint32_t>& mem_buffer
     ) override;
     std::vector<uint64_t> serialize_helper(
-        std::vector<uint32_t>& result_buffer, 
+        uint32_t* result_buffer,
         const std::unordered_map<uint32_t, uint32_t>& mapping
     ) const;
     void serialize(
-        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
+        uint32_t* result_buffer, uint32_t* mem_buffer,
         const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output
     ) const override;
     void serialize(
-        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer,
+        uint32_t* result_buffer, uint32_t* mem_buffer,
         const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output
     ) const override;
 };
@@ -741,15 +741,15 @@ public:
         uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint32_t>& mem_buffer
     ) override;
     std::vector<uint32_t> serialize_helper(
-        std::vector<uint32_t>& result_buffer, 
+        uint32_t* result_buffer,
         const std::unordered_map<uint32_t, uint32_t>& mapping
     ) const;
     void serialize(
-        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
+        uint32_t* result_buffer, uint32_t* mem_buffer,
         const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output
     ) const override;
     void serialize(
-        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer,
+        uint32_t* result_buffer, uint32_t* mem_buffer,
         const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output
     ) const override;
 };
@@ -776,15 +776,15 @@ public:
         uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint32_t>& mem_buffer
     ) override;
     std::vector<uint64_t> serialize_helper(
-        std::vector<uint32_t>& result_buffer, 
+        uint32_t* result_buffer,
         const std::unordered_map<uint32_t, uint32_t>& mapping
     ) const;
     void serialize(
-        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
+        uint32_t* result_buffer, uint32_t* mem_buffer,
         const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output
     ) const override;
     void serialize(
-        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer,
+        uint32_t* result_buffer, uint32_t* mem_buffer,
         const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output
     ) const override;
 };
@@ -811,11 +811,11 @@ public:
         uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint32_t>& mem_buffer
     ) override;
     void serialize(
-        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
+        uint32_t* result_buffer, uint32_t* mem_buffer,
         const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output
     ) const override;
     void serialize(
-        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer,
+        uint32_t* result_buffer, uint32_t* mem_buffer,
         const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output
     ) const override;
 };
@@ -839,15 +839,15 @@ public:
         uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint32_t>& mem_buffer
     ) override;
     uint32_t serialize_helper(
-        std::vector<uint32_t>& result_buffer, 
+        uint32_t* result_buffer, 
         const std::unordered_map<uint32_t, uint32_t>& mapping
     ) const;
     void serialize(
-        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
+        uint32_t* result_buffer, uint32_t* mem_buffer,
         const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output
     ) const override;
     void serialize(
-        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer,
+        uint32_t* result_buffer, uint32_t* mem_buffer,
         const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output
     ) const override;
 };
@@ -871,15 +871,15 @@ public:
         uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint32_t>& mem_buffer
     ) override;
     void serialize_helper(
-        std::vector<uint32_t>& result_buffer, 
+        uint32_t* result_buffer,
         const std::unordered_map<uint32_t, uint32_t>& mapping
     ) const;
     void serialize(
-        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
+        uint32_t* result_buffer, uint32_t* mem_buffer,
         const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output
     ) const override;
     void serialize(
-        std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer,
+        uint32_t* result_buffer, uint32_t* mem_buffer,
         const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output
     ) const override;
 };

--- a/src/cpp/dtrace/action/break.cpp
+++ b/src/cpp/dtrace/action/break.cpp
@@ -54,7 +54,7 @@ actionize(uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint
  */
 void
 break_action::
-serialize(std::vector<uint32_t>&, std::vector<uint32_t>&, 
+serialize(uint32_t*, uint32_t*,
     const std::unordered_map<uint32_t, uint32_t>&, std::ostream&) const
 {
 }
@@ -70,7 +70,7 @@ serialize(std::vector<uint32_t>&, std::vector<uint32_t>&,
  */
 void
 break_action::
-serialize(std::vector<uint32_t>&, std::vector<uint32_t>&, 
+serialize(uint32_t*, uint32_t*,
     const std::unordered_map<uint32_t, uint32_t>&, json&) const
 {
 }

--- a/src/cpp/dtrace/action/count.cpp
+++ b/src/cpp/dtrace/action/count.cpp
@@ -78,7 +78,7 @@ actionize(uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint
  */
 uint32_t
 count_action::
-serialize_helper(std::vector<uint32_t>& result_buffer, 
+serialize_helper(uint32_t* result_buffer,
     const std::unordered_map<uint32_t, uint32_t>& mapping) const
 {
     uint32_t location = mapping.at(get_location(false));
@@ -99,7 +99,7 @@ serialize_helper(std::vector<uint32_t>& result_buffer,
  */
 void
 count_action::
-serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&, 
+serialize(uint32_t* result_buffer, uint32_t*,
     const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output) const
 {
     uint32_t result = count_action::serialize_helper(result_buffer, mapping);
@@ -118,7 +118,7 @@ serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&,
  */
 void
 count_action::
-serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&, 
+serialize(uint32_t* result_buffer, uint32_t*,
     const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output) const
 {
     uint32_t result = count_action::serialize_helper(result_buffer, mapping);

--- a/src/cpp/dtrace/action/host_timestamp.cpp
+++ b/src/cpp/dtrace/action/host_timestamp.cpp
@@ -80,7 +80,7 @@ actionize(uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint
  */
 uint64_t
 host_timestamp_action::
-serialize_helper(std::vector<uint32_t>& result_buffer, 
+serialize_helper(uint32_t* result_buffer,
     const std::unordered_map<uint32_t, uint32_t>& mapping) const
 {
     uint32_t location_h = mapping.at(get_location(false));
@@ -105,7 +105,7 @@ serialize_helper(std::vector<uint32_t>& result_buffer,
  */
 void
 host_timestamp_action::
-serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&, 
+serialize(uint32_t* result_buffer, uint32_t*,
     const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output) const
 {
     uint64_t result = host_timestamp_action::serialize_helper(result_buffer, mapping);
@@ -124,7 +124,7 @@ serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&,
  */
 void
 host_timestamp_action::
-serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&, 
+serialize(uint32_t* result_buffer, uint32_t*,
     const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output) const
 {
     uint64_t result = host_timestamp_action::serialize_helper(result_buffer, mapping);

--- a/src/cpp/dtrace/action/host_timestamps.cpp
+++ b/src/cpp/dtrace/action/host_timestamps.cpp
@@ -94,7 +94,7 @@ actionize(uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint
  */
 std::vector<uint64_t>
 host_timestamps_action::
-serialize_helper(std::vector<uint32_t>& result_buffer, 
+serialize_helper(uint32_t* result_buffer,
     const std::unordered_map<uint32_t, uint32_t>& mapping) const
 {
     std::vector<uint64_t> result;
@@ -123,7 +123,7 @@ serialize_helper(std::vector<uint32_t>& result_buffer,
  */
 void
 host_timestamps_action::
-serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&, 
+serialize(uint32_t* result_buffer, uint32_t*,
     const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output) const
 {
     std::vector<uint64_t> result = host_timestamps_action::serialize_helper(result_buffer, mapping);
@@ -149,7 +149,7 @@ serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&,
  */
 void
 host_timestamps_action::
-serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&, 
+serialize(uint32_t* result_buffer, uint32_t*,
     const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output) const
 {
     std::vector<uint64_t> result = host_timestamps_action::serialize_helper(result_buffer, mapping);

--- a/src/cpp/dtrace/action/mask_write_register.cpp
+++ b/src/cpp/dtrace/action/mask_write_register.cpp
@@ -139,7 +139,7 @@ actionize(uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint
  */
 void
 mask_write_reg_action::
-serialize_helper(std::vector<uint32_t>& mem_buffer) const
+serialize_helper(uint32_t* mem_buffer) const
 {
     if (m_mode == 2)
     {
@@ -162,7 +162,7 @@ serialize_helper(std::vector<uint32_t>& mem_buffer) const
  */
 void
 mask_write_reg_action::
-serialize(std::vector<uint32_t>&, std::vector<uint32_t>& mem_buffer, 
+serialize(uint32_t*, uint32_t* mem_buffer,
     const std::unordered_map<uint32_t, uint32_t>&, std::ostream&) const
 {
     mask_write_reg_action::serialize_helper(mem_buffer);
@@ -179,7 +179,7 @@ serialize(std::vector<uint32_t>&, std::vector<uint32_t>& mem_buffer,
  */
 void
 mask_write_reg_action::
-serialize(std::vector<uint32_t>&, std::vector<uint32_t>& mem_buffer, 
+serialize(uint32_t*, uint32_t* mem_buffer,
     const std::unordered_map<uint32_t, uint32_t>&, json&) const
 {
     mask_write_reg_action::serialize_helper(mem_buffer);

--- a/src/cpp/dtrace/action/mask_write_register.cpp
+++ b/src/cpp/dtrace/action/mask_write_register.cpp
@@ -113,9 +113,9 @@ actionize(uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint
     // write address
     control_buffer.push_back(std::stoul(m_arguments[0], nullptr, dtrace::dtrace_ctrl::hexadecimal_base));
     // mask value
-    control_buffer.push_back(std::stoul(m_arguments[1], nullptr, dtrace::dtrace_ctrl::hexadecimal_base));
+    control_buffer.push_back(std::stoul(m_arguments[1], nullptr, dtrace::dtrace_ctrl::decimal_hexadecimal_base));
     // write value
-    control_buffer.push_back(std::stoul(m_arguments[2], nullptr, dtrace::dtrace_ctrl::hexadecimal_base));
+    control_buffer.push_back(std::stoul(m_arguments[2], nullptr, dtrace::dtrace_ctrl::decimal_hexadecimal_base));
 
     if (m_mode == 2)
     {   // mem buffer 

--- a/src/cpp/dtrace/action/operation.cpp
+++ b/src/cpp/dtrace/action/operation.cpp
@@ -53,7 +53,7 @@ actionize(uint32_t, std::vector<uint32_t>&, std::vector<uint32_t>&)
  */
 void
 operation_action::
-serialize(std::vector<uint32_t>&, std::vector<uint32_t>&, 
+serialize(uint32_t*, uint32_t*,
     const std::unordered_map<uint32_t, uint32_t>&, std::ostream& script_output) const
 {
     // serialize string format
@@ -71,7 +71,7 @@ serialize(std::vector<uint32_t>&, std::vector<uint32_t>&,
  */
 void
 operation_action::
-serialize(std::vector<uint32_t>&, std::vector<uint32_t>&, 
+serialize(uint32_t*, uint32_t*,
     const std::unordered_map<uint32_t, uint32_t>&, json&) const
 {
 }

--- a/src/cpp/dtrace/action/print.cpp
+++ b/src/cpp/dtrace/action/print.cpp
@@ -98,7 +98,7 @@ actionize(uint32_t, std::vector<uint32_t>&, std::vector<uint32_t>&)
  */
 void
 print_action::
-serialize(std::vector<uint32_t>&, std::vector<uint32_t>&, 
+serialize(uint32_t*, uint32_t*,
     const std::unordered_map<uint32_t, uint32_t>&, std::ostream& script_output) const
 {
     // serialize string format
@@ -121,7 +121,7 @@ serialize(std::vector<uint32_t>&, std::vector<uint32_t>&,
  */
 void
 print_action::
-serialize(std::vector<uint32_t>&, std::vector<uint32_t>&, 
+serialize(uint32_t*, uint32_t*,
     const std::unordered_map<uint32_t, uint32_t>&, json&) const
 {
 }

--- a/src/cpp/dtrace/action/printa.cpp
+++ b/src/cpp/dtrace/action/printa.cpp
@@ -103,7 +103,6 @@ get_opcode(const uint32_t& value) const
  * serialize_helper() - Formats and prints the results from the result buffer.
  *
  * @param result_buffer 
- *  A vector of uint32_t values containing the result data.
  *
  * This function takes a vector of uint32_t values representing the result buffer,
  * calculates the total number of samples, and prints the formatted results to the
@@ -111,7 +110,7 @@ get_opcode(const uint32_t& value) const
  */
 std::string
 printa_action::
-serialize_helper(const std::vector<uint32_t>& result_buffer) const
+serialize_helper(const uint32_t* result_buffer) const
 {
     constexpr int name_width = 50;
     constexpr int samples_width = 16;
@@ -184,7 +183,7 @@ serialize_helper(const std::vector<uint32_t>& result_buffer) const
  */
 void
 printa_action::
-serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&, 
+serialize(uint32_t* result_buffer, uint32_t*,
     const std::unordered_map<uint32_t, uint32_t>&, std::ostream& script_output) const
 {
     // serialize string format
@@ -202,7 +201,7 @@ serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&,
  */
 void
 printa_action::
-serialize(std::vector<uint32_t>&, std::vector<uint32_t>&, 
+serialize(uint32_t*, uint32_t*,
     const std::unordered_map<uint32_t, uint32_t>&, json&) const
 {
 }

--- a/src/cpp/dtrace/action/profile.cpp
+++ b/src/cpp/dtrace/action/profile.cpp
@@ -73,7 +73,7 @@ actionize(uint32_t, std::vector<uint32_t>&, std::vector<uint32_t>&)
  */
 void
 profile_action::
-serialize(std::vector<uint32_t>&, std::vector<uint32_t>&, 
+serialize(uint32_t*, uint32_t*,
     const std::unordered_map<uint32_t, uint32_t>&, std::ostream&) const
 {
 }
@@ -89,7 +89,7 @@ serialize(std::vector<uint32_t>&, std::vector<uint32_t>&,
  */
 void
 profile_action::
-serialize(std::vector<uint32_t>&, std::vector<uint32_t>&, 
+serialize(uint32_t*, uint32_t*,
     const std::unordered_map<uint32_t, uint32_t>&, json&) const
 {
 }

--- a/src/cpp/dtrace/action/read_handshake.cpp
+++ b/src/cpp/dtrace/action/read_handshake.cpp
@@ -100,7 +100,7 @@ actionize(uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint
  */
 uint32_t
 read_handshake_action::
-serialize_helper(std::vector<uint32_t>& result_buffer, 
+serialize_helper(uint32_t* result_buffer,
     const std::unordered_map<uint32_t, uint32_t>& mapping) const
 {
     uint32_t location = mapping.at(get_location(false));
@@ -127,7 +127,7 @@ serialize_helper(std::vector<uint32_t>& result_buffer,
  */
 void
 read_handshake_action::
-serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&, 
+serialize(uint32_t* result_buffer, uint32_t*,
     const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output) const
 {
     uint32_t result = read_handshake_action::serialize_helper(result_buffer, mapping);
@@ -146,7 +146,7 @@ serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&,
  */
 void
 read_handshake_action::
-serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&, 
+serialize(uint32_t* result_buffer, uint32_t*,
     const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output) const
 {
     uint32_t result = read_handshake_action::serialize_helper(result_buffer, mapping);

--- a/src/cpp/dtrace/action/read_mem.cpp
+++ b/src/cpp/dtrace/action/read_mem.cpp
@@ -146,7 +146,7 @@ actionize(uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint
  */
 std::vector<uint32_t>
 read_mem_action::
-serialize_helper(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
+serialize_helper(uint32_t* result_buffer, uint32_t* mem_buffer,
     const std::unordered_map<uint32_t, uint32_t>& mapping) const
 {
     std::vector<uint32_t> result;
@@ -172,7 +172,7 @@ serialize_helper(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& me
  */
 void
 read_mem_action::
-serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
+serialize(uint32_t* result_buffer, uint32_t* mem_buffer,
     const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output) const
 {
     std::vector<uint32_t> result = read_mem_action::serialize_helper(result_buffer, mem_buffer, mapping);
@@ -198,7 +198,7 @@ serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffe
  */
 void
 read_mem_action::
-serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>& mem_buffer, 
+serialize(uint32_t* result_buffer, uint32_t* mem_buffer,
     const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output) const
 {
     std::vector<uint32_t> result = read_mem_action::serialize_helper(result_buffer, mem_buffer, mapping);

--- a/src/cpp/dtrace/action/read_register.cpp
+++ b/src/cpp/dtrace/action/read_register.cpp
@@ -90,7 +90,7 @@ actionize(uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint
  */
 uint32_t
 read_reg_action::
-serialize_helper(std::vector<uint32_t>& result_buffer, 
+serialize_helper(uint32_t* result_buffer,
     const std::unordered_map<uint32_t, uint32_t>& mapping) const
 {
     uint32_t location = mapping.at(get_location(false));
@@ -111,7 +111,7 @@ serialize_helper(std::vector<uint32_t>& result_buffer,
  */
 void
 read_reg_action::
-serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&, 
+serialize(uint32_t* result_buffer, uint32_t*,
     const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output) const
 {
     uint32_t result = read_reg_action::serialize_helper(result_buffer, mapping);
@@ -130,7 +130,7 @@ serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&,
  */
 void
 read_reg_action::
-serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&, 
+serialize(uint32_t* result_buffer, uint32_t*,
     const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output) const
 {
     uint32_t result = read_reg_action::serialize_helper(result_buffer, mapping);

--- a/src/cpp/dtrace/action/sleep.cpp
+++ b/src/cpp/dtrace/action/sleep.cpp
@@ -79,7 +79,7 @@ actionize(uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint
  */
 void
 sleep_action::
-serialize(std::vector<uint32_t>&, std::vector<uint32_t>&, 
+serialize(uint32_t*, uint32_t*,
     const std::unordered_map<uint32_t, uint32_t>&, std::ostream&) const
 {
 }
@@ -95,7 +95,7 @@ serialize(std::vector<uint32_t>&, std::vector<uint32_t>&,
  */
 void
 sleep_action::
-serialize(std::vector<uint32_t>&, std::vector<uint32_t>&, 
+serialize(uint32_t*, uint32_t*,
     const std::unordered_map<uint32_t, uint32_t>&, json&) const
 {
 }

--- a/src/cpp/dtrace/action/timestamp.cpp
+++ b/src/cpp/dtrace/action/timestamp.cpp
@@ -80,7 +80,7 @@ actionize(uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint
  */
 uint64_t
 timestamp_action::
-serialize_helper(std::vector<uint32_t>& result_buffer, 
+serialize_helper(uint32_t* result_buffer,
     const std::unordered_map<uint32_t, uint32_t>& mapping) const
 {
     uint32_t location_h = mapping.at(get_location(false));
@@ -105,7 +105,7 @@ serialize_helper(std::vector<uint32_t>& result_buffer,
  */
 void
 timestamp_action::
-serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&, 
+serialize(uint32_t* result_buffer, uint32_t*,
     const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output) const
 {
     uint64_t result = timestamp_action::serialize_helper(result_buffer, mapping);
@@ -124,7 +124,7 @@ serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&,
  */
 void
 timestamp_action::
-serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&, 
+serialize(uint32_t* result_buffer, uint32_t*,
     const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output) const
 {
     uint64_t result = timestamp_action::serialize_helper(result_buffer, mapping);

--- a/src/cpp/dtrace/action/timestamp32.cpp
+++ b/src/cpp/dtrace/action/timestamp32.cpp
@@ -78,7 +78,7 @@ actionize(uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint
  */
 uint32_t
 timestamp32_action::
-serialize_helper(std::vector<uint32_t>& result_buffer, 
+serialize_helper(uint32_t* result_buffer,
     const std::unordered_map<uint32_t, uint32_t>& mapping) const
 {
     uint32_t location = mapping.at(get_location(false));
@@ -99,7 +99,7 @@ serialize_helper(std::vector<uint32_t>& result_buffer,
  */
 void
 timestamp32_action::
-serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&, 
+serialize(uint32_t* result_buffer, uint32_t*,
     const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output) const
 {
     uint32_t result = timestamp32_action::serialize_helper(result_buffer, mapping);
@@ -118,7 +118,7 @@ serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&,
  */
 void
 timestamp32_action::
-serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&, 
+serialize(uint32_t* result_buffer, uint32_t*,
     const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output) const
 {
     uint32_t result = timestamp32_action::serialize_helper(result_buffer, mapping);

--- a/src/cpp/dtrace/action/timestamps.cpp
+++ b/src/cpp/dtrace/action/timestamps.cpp
@@ -94,7 +94,7 @@ actionize(uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint
  */
 std::vector<uint64_t>
 timestamps_action::
-serialize_helper(std::vector<uint32_t>& result_buffer, 
+serialize_helper(uint32_t* result_buffer,
     const std::unordered_map<uint32_t, uint32_t>& mapping) const
 {
     std::vector<uint64_t> result;
@@ -123,7 +123,7 @@ serialize_helper(std::vector<uint32_t>& result_buffer,
  */
 void
 timestamps_action::
-serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&, 
+serialize(uint32_t* result_buffer, uint32_t*,
     const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output) const
 {
     std::vector<uint64_t> result = timestamps_action::serialize_helper(result_buffer, mapping);
@@ -148,7 +148,7 @@ serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&,
  */
 void
 timestamps_action::
-serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&, 
+serialize(uint32_t* result_buffer, uint32_t*,
     const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output) const
 {
     std::vector<uint64_t> result = timestamps_action::serialize_helper(result_buffer, mapping);

--- a/src/cpp/dtrace/action/timestamps32.cpp
+++ b/src/cpp/dtrace/action/timestamps32.cpp
@@ -89,7 +89,7 @@ actionize(uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint
  */
 std::vector<uint32_t>
 timestamps32_action::
-serialize_helper(std::vector<uint32_t>& result_buffer, 
+serialize_helper(uint32_t* result_buffer,
     const std::unordered_map<uint32_t, uint32_t>& mapping) const
 {
     std::vector<uint32_t> result;
@@ -115,7 +115,7 @@ serialize_helper(std::vector<uint32_t>& result_buffer,
  */
 void
 timestamps32_action::
-serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&, 
+serialize(uint32_t* result_buffer, uint32_t*,
     const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream& script_output) const
 {
     std::vector<uint32_t> result = timestamps32_action::serialize_helper(result_buffer, mapping);
@@ -141,7 +141,7 @@ serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&,
  */
 void
 timestamps32_action::
-serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&, 
+serialize(uint32_t* result_buffer, uint32_t*,
     const std::unordered_map<uint32_t, uint32_t>& mapping, json& json_output) const
 {
     std::vector<uint32_t> result = timestamps32_action::serialize_helper(result_buffer, mapping);

--- a/src/cpp/dtrace/action/write_handshake.cpp
+++ b/src/cpp/dtrace/action/write_handshake.cpp
@@ -94,7 +94,7 @@ actionize(uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint
  */
 void
 write_handshake_action::
-serialize_helper(std::vector<uint32_t>& result_buffer, 
+serialize_helper(uint32_t* result_buffer,
     const std::unordered_map<uint32_t, uint32_t>& mapping) const
 {
     uint32_t location = mapping.at(get_location(false));
@@ -120,7 +120,7 @@ serialize_helper(std::vector<uint32_t>& result_buffer,
  */
 void
 write_handshake_action::
-serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&, 
+serialize(uint32_t* result_buffer, uint32_t*,
     const std::unordered_map<uint32_t, uint32_t>& mapping, std::ostream&) const
 {
     write_handshake_action::serialize_helper(result_buffer, mapping);
@@ -137,7 +137,7 @@ serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&,
  */
 void
 write_handshake_action::
-serialize(std::vector<uint32_t>& result_buffer, std::vector<uint32_t>&, 
+serialize(uint32_t* result_buffer, uint32_t*,
     const std::unordered_map<uint32_t, uint32_t>& mapping, json&) const
 {
     write_handshake_action::serialize_helper(result_buffer, mapping);

--- a/src/cpp/dtrace/action/write_handshake.cpp
+++ b/src/cpp/dtrace/action/write_handshake.cpp
@@ -78,7 +78,7 @@ actionize(uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint
     control_buffer.push_back(std::stoul(m_arguments[0]));
     set_location(control_buffer, false);
     // write value
-    control_buffer.push_back(std::stoul(m_arguments[1], nullptr, dtrace::dtrace_ctrl::hexadecimal_base));
+    control_buffer.push_back(std::stoul(m_arguments[1], nullptr, dtrace::dtrace_ctrl::decimal_hexadecimal_base));
 }
 
 //-------------------------write_handshake_action::serialize_helper-------------------------//

--- a/src/cpp/dtrace/action/write_mem.cpp
+++ b/src/cpp/dtrace/action/write_mem.cpp
@@ -106,7 +106,7 @@ actionize(uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint
  */
 void
 write_mem_action::
-serialize(std::vector<uint32_t>&, std::vector<uint32_t>&, 
+serialize(uint32_t*, uint32_t*,
     const std::unordered_map<uint32_t, uint32_t>&, std::ostream&) const
 {
 }
@@ -122,7 +122,7 @@ serialize(std::vector<uint32_t>&, std::vector<uint32_t>&,
  */
 void
 write_mem_action::
-serialize(std::vector<uint32_t>&, std::vector<uint32_t>&, 
+serialize(uint32_t*, uint32_t*,
     const std::unordered_map<uint32_t, uint32_t>&, json&) const
 {
 }

--- a/src/cpp/dtrace/action/write_register.cpp
+++ b/src/cpp/dtrace/action/write_register.cpp
@@ -67,7 +67,7 @@ actionize(uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint
     // write address
     control_buffer.push_back(std::stoul(m_arguments[0], nullptr, dtrace::dtrace_ctrl::hexadecimal_base));
     // write value
-    control_buffer.push_back(std::stoul(m_arguments[1], nullptr, dtrace::dtrace_ctrl::hexadecimal_base));
+    control_buffer.push_back(std::stoul(m_arguments[1], nullptr, dtrace::dtrace_ctrl::decimal_hexadecimal_base));
 }
 
 //-------------------------write_reg_action::serialize-------------------------//

--- a/src/cpp/dtrace/action/write_register.cpp
+++ b/src/cpp/dtrace/action/write_register.cpp
@@ -81,7 +81,7 @@ actionize(uint32_t last, std::vector<uint32_t>& control_buffer, std::vector<uint
  */
 void
 write_reg_action::
-serialize(std::vector<uint32_t>&, std::vector<uint32_t>&, 
+serialize(uint32_t*, uint32_t*,
     const std::unordered_map<uint32_t, uint32_t>&, std::ostream&) const
 {
 }
@@ -97,7 +97,7 @@ serialize(std::vector<uint32_t>&, std::vector<uint32_t>&,
  */
 void
 write_reg_action::
-serialize(std::vector<uint32_t>&, std::vector<uint32_t>&, 
+serialize(uint32_t*, uint32_t*,
     const std::unordered_map<uint32_t, uint32_t>&, json&) const
 {
 }

--- a/src/cpp/dtrace/control/control.cpp
+++ b/src/cpp/dtrace/control/control.cpp
@@ -342,22 +342,19 @@ populate_result_actions()
 
 //-------------------------control::create_result_file-------------------------//
 /**
- * create_result_file() - Creates a result file from the given result and memory buffers.
+ * create_result_file() - Creates a result file from the given buffer information map.
  *
- * @param result_buffers 
- *  Map containing result buffers indexed by uC.
- * @param mem_buffers 
- *  Map containing memory buffers indexed by uC.
+ * @param buffer_info_map
+ *  Map containing dtrace buffer information (buffer addresses and sizes) indexed by uC.
  * @param output_file 
  *  Path to the output file where the Python script will be written.
  *
- * This function generates a Python script that processes the provided result and 
- * memory buffers. Serializing the actions into the output file.
+ * This function generates a Python script that processes the provided buffer information
+ * map. Serializing the actions into the output file.
  */
 void 
 control::
-create_result_file(std::unordered_map<uint32_t, std::vector<uint32_t>>& result_buffers, 
-    std::unordered_map<uint32_t, std::vector<uint32_t>>& mem_buffers, 
+create_result_file(const std::unordered_map<uint32_t, dtrace_buffer_info>& buffer_info_map,
     const std::string& output_file) const
 {
     // Process actions based on output format
@@ -375,20 +372,21 @@ create_result_file(std::unordered_map<uint32_t, std::vector<uint32_t>>& result_b
         {
             const auto& action = item.first;
             uint32_t loop_uC_index = item.second;
-            try 
+            try
             {
+                const auto& buffer_info = buffer_info_map.at(loop_uC_index);
                 // Serialize action to build python script
                 action->serialize(
-                    result_buffers.at(loop_uC_index), 
-                    mem_buffers.at(loop_uC_index), 
+                    buffer_info.buffer_addr,
+                    buffer_info.buffer_addr + buffer_info.control_buffer.size(),
                     m_pager.get_action_location_mapping(loop_uC_index),
                     script_output
                 );
-            } 
-            catch (const std::exception& e) 
+            }
+            catch (const std::exception& e)
             {
-                DTRACE_ERROR("DTRACE_ACTION_SERIALIZE_FAILED", "Failed to serialize action " 
-                    << action->create_string() << " for uC index " << loop_uC_index << ". Exception: " << e.what() 
+                DTRACE_ERROR("DTRACE_ACTION_SERIALIZE_FAILED", "Failed to serialize action "
+                    << action->create_string() << " for uC index " << loop_uC_index << ". Exception: " << e.what()
                 );
             }
         }
@@ -405,11 +403,12 @@ create_result_file(std::unordered_map<uint32_t, std::vector<uint32_t>>& result_b
             const auto& action = item.first;
             uint32_t loop_uC_index = item.second;
             try
-            {
+            {                
+                const auto& buffer_info = buffer_info_map.at(loop_uC_index);
                 // Serialize action to build JSON result
                 action->serialize(
-                    result_buffers.at(loop_uC_index),
-                    mem_buffers.at(loop_uC_index),
+                    buffer_info.buffer_addr,
+                    buffer_info.buffer_addr + buffer_info.control_buffer.size(),
                     m_pager.get_action_location_mapping(loop_uC_index),
                     json_output
                 );
@@ -442,10 +441,8 @@ create_result_file(std::unordered_map<uint32_t, std::vector<uint32_t>>& result_b
 /**
  * create_result_buffer() - Serializes dtrace results into a JSON object.
  *
- * @param result_buffers
- *  Map containing result buffers indexed by uC.
- * @param mem_buffers
- *  Map containing memory buffers indexed by uC.
+ * @param buffer_info_map
+ *  Map containing dtrace buffer information (buffer addresses and sizes) indexed by uC.
  * @param json_output
  *  JSON object to populate with serialized action results.
  *
@@ -454,12 +451,11 @@ create_result_file(std::unordered_map<uint32_t, std::vector<uint32_t>>& result_b
  */
 void
 control::
-create_result_buffer(std::unordered_map<uint32_t, std::vector<uint32_t>>& result_buffers,
-    std::unordered_map<uint32_t, std::vector<uint32_t>>& mem_buffers,
+create_result_buffer(const std::unordered_map<uint32_t, dtrace_buffer_info>& buffer_info_map,
     nlohmann::ordered_json& json_output) const
 {
     if (m_output_format != dtrace::dtrace_output_format::json)
-        DTRACE_ERROR("DTRACE_OUTPUT_FORMAT_NOT_SUPPORTED", 
+        DTRACE_ERROR("DTRACE_OUTPUT_FORMAT_NOT_SUPPORTED",
             "Output format " << static_cast<int>(m_output_format) << " not supported for buffer result."
         );
 
@@ -470,9 +466,10 @@ create_result_buffer(std::unordered_map<uint32_t, std::vector<uint32_t>>& result
         uint32_t loop_uC_index = item.second;
         try
         {
+            const auto& buffer_info = buffer_info_map.at(loop_uC_index);
             action->serialize(
-                result_buffers.at(loop_uC_index),
-                mem_buffers.at(loop_uC_index),
+                buffer_info.buffer_addr,
+                buffer_info.buffer_addr + buffer_info.control_buffer.size(),
                 m_pager.get_action_location_mapping(loop_uC_index),
                 json_output
             );

--- a/src/cpp/dtrace/control/control.h
+++ b/src/cpp/dtrace/control/control.h
@@ -20,6 +20,24 @@
 
 namespace dtrace
 {
+
+/**
+ * @struct dtrace_buffer_info
+ *
+ * @brief
+ * Typed dtrace_buffer_info used to hold dtrace buffer information.
+ *
+ * @details
+ * Contains members that specify virtual and physical address of dtrace buffer,
+ * control buffer and the memory buffer.
+ */
+struct dtrace_buffer_info {
+    uint32_t* buffer_addr = nullptr;
+    uint64_t buffer_dma_addr = 0;
+    std::vector<uint32_t> control_buffer;
+    std::vector<uint32_t> mem_buffer;
+};
+
 //-------------------------Control-------------------------//
 /**
  * @class control
@@ -52,11 +70,11 @@ public:
     std::vector<uint32_t> create_control_buffer(uint32_t uC) const;
     std::vector<uint32_t> create_mem_buffer(uint32_t uC) const;
     void patch_control_buffer(const std::unordered_map<uint32_t, uint64_t>& mem_host_addr_map);
-    void create_result_file(std::unordered_map<uint32_t, std::vector<uint32_t>>& result_buffers, 
-        std::unordered_map<uint32_t, std::vector<uint32_t>>& mem_buffers, 
+    void create_result_file(
+        const std::unordered_map<uint32_t, dtrace_buffer_info>& buffer_info_map,
         const std::string& output_file) const;
-    void create_result_buffer(std::unordered_map<uint32_t, std::vector<uint32_t>>& result_buffers,
-        std::unordered_map<uint32_t, std::vector<uint32_t>>& mem_buffers,
+    void create_result_buffer(
+        const std::unordered_map<uint32_t, dtrace_buffer_info>& buffer_info_map,
         nlohmann::ordered_json& json_output) const;
 };
 

--- a/src/cpp/dtrace/dtrace.cpp
+++ b/src/cpp/dtrace/dtrace.cpp
@@ -16,23 +16,6 @@
 #include <vector>
 
 /**
- * @struct dtrace_buffer_info
- *
- * @brief 
- * Typed dtrace_buffer_info used to hold dtrace buffer information.
- *
- * @details
- * Contains members that specify virtual and physical address of dtrace buffer,
- * control buffer and the memory buffer.
- */
-struct dtrace_buffer_info {
-    uint32_t* buffer_addr = nullptr;
-    uint64_t buffer_dma_addr = 0;
-    std::vector<uint32_t> control_buffer; 
-    std::vector<uint32_t> mem_buffer;
-};
-
-/**
  * @struct dtrace_command_handle
  *
  * @brief 
@@ -46,7 +29,7 @@ struct dtrace_command_handle {
     // Intial parse to create control buffer and memory buffer
     std::unique_ptr<dtrace::control> g_control = nullptr;
     // multiple uC dtrace
-    std::unordered_map<uint32_t, dtrace_buffer_info> g_dtrace_buffer_info_map;
+    std::unordered_map<uint32_t, dtrace::dtrace_buffer_info> g_dtrace_buffer_info_map;
 };
 
 dtrace_handle_t
@@ -120,7 +103,7 @@ get_dtrace_buffer_size(dtrace_handle_t dtrace_handle, uint64_t* buffers)
         {
             // Get control buffer and memory buffer size and populate the map
             // with the dtrace_buffer_info for uC_index
-            dtrace_buffer_info l_dtrace_buffer_info;
+            dtrace::dtrace_buffer_info l_dtrace_buffer_info;
             l_dtrace_buffer_info.buffer_addr = nullptr;
             l_dtrace_buffer_info.buffer_dma_addr = 0; 
             l_dtrace_buffer_info.control_buffer = handle->g_control->create_control_buffer(uC_index);
@@ -160,7 +143,7 @@ populate_dtrace_buffer(dtrace_handle_t dtrace_handle, uint32_t* dtrace_buffer,
             for (const auto& uC_index : handle->g_control->m_control_uC_indices)
             {
                 // Get the dtrace_buffer_info for the given uC_index
-                dtrace_buffer_info& l_dtrace_buffer_info = handle->g_dtrace_buffer_info_map[uC_index];
+                dtrace::dtrace_buffer_info& l_dtrace_buffer_info = handle->g_dtrace_buffer_info_map[uC_index];
 
                 uC_buffer_dma_addr += l_dtrace_buffer_info.control_buffer.size() * sizeof(uint32_t);
                 if (!l_dtrace_buffer_info.mem_buffer.empty()) {
@@ -187,7 +170,7 @@ populate_dtrace_buffer(dtrace_handle_t dtrace_handle, uint32_t* dtrace_buffer,
         for (const auto& uC_index : handle->g_control->m_control_uC_indices)
         {    
             // Get the dtrace_buffer_info for the given uC_index
-            dtrace_buffer_info& l_dtrace_buffer_info = handle->g_dtrace_buffer_info_map[uC_index];
+            dtrace::dtrace_buffer_info& l_dtrace_buffer_info = handle->g_dtrace_buffer_info_map[uC_index];
 
             // Buffer address for the current uC index
             l_dtrace_buffer_info.buffer_addr = uC_buffer_addr;
@@ -228,60 +211,8 @@ get_dtrace_result_file(dtrace_handle_t dtrace_handle, const std::string& result_
         // dtrace handle
         auto* handle = static_cast<dtrace_command_handle*>(dtrace_handle);
 
-        // Initialize the result buffers and memory buffers vector
-        std::unordered_map<uint32_t, std::vector<uint32_t>> result_buffers;
-        std::unordered_map<uint32_t, std::vector<uint32_t>> mem_buffers;
-
-        // Iterate over all result buffer and memory buffer for each uC in global map
-        for (const auto& [uC_index, l_dtrace_buffer_info] : handle->g_dtrace_buffer_info_map)
-        {
-            std::vector<uint32_t> buffer(
-                l_dtrace_buffer_info.control_buffer.size() + l_dtrace_buffer_info.mem_buffer.size()
-            );
-
-            // Copy the buffer from the dtrace buffer address
-            std::memcpy(
-                buffer.data(),
-                l_dtrace_buffer_info.buffer_addr,
-                (l_dtrace_buffer_info.control_buffer.size() + l_dtrace_buffer_info.mem_buffer.size()) * sizeof(uint32_t)
-            );
-
-            // Get control_buffer and mem_buffer from the buffer
-            std::vector<uint32_t> control_buffer(
-                buffer.begin(),
-                buffer.begin() + l_dtrace_buffer_info.control_buffer.size() // NOLINT(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
-            );
-            std::vector<uint32_t> mem_buffer(
-                buffer.begin() + l_dtrace_buffer_info.control_buffer.size(), // NOLINT(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
-                buffer.end()
-            );
-            
-            // Populate result buffers and memory buffers vector
-            result_buffers[uC_index] = std::move(control_buffer);
-            mem_buffers[uC_index] = std::move(mem_buffer);
-        }
-
         // Create the result file
-        handle->g_control->create_result_file(result_buffers, mem_buffers, result_file);
-
-        // Iterate over and copy back modified buffers for each uC in global map
-        for (const auto& [uC_index, l_dtrace_buffer_info] : handle->g_dtrace_buffer_info_map)
-        {
-            std::vector<uint32_t> buffer;
-            buffer.insert(
-                buffer.end(), result_buffers[uC_index].begin(), result_buffers[uC_index].end()
-            );
-            buffer.insert(
-                buffer.end(), mem_buffers[uC_index].begin(), mem_buffers[uC_index].end()
-            );
-            
-            // Populate modified buffer back to the dtrace buffer address
-            std::memcpy(
-                l_dtrace_buffer_info.buffer_addr,
-                buffer.data(),
-                buffer.size() * sizeof(uint32_t)
-            );
-        }
+        handle->g_control->create_result_file(handle->g_dtrace_buffer_info_map, result_file);
     }
     catch (const std::exception& e)
     {
@@ -296,61 +227,9 @@ get_dtrace_result_buffer(dtrace_handle_t dtrace_handle)
     {
         auto* handle = static_cast<dtrace_command_handle*>(dtrace_handle);
 
-        // Extract result buffers and memory buffers from device-mapped memory
-        std::unordered_map<uint32_t, std::vector<uint32_t>> result_buffers;
-        std::unordered_map<uint32_t, std::vector<uint32_t>> mem_buffers;
-
-        // Iterate over all result buffer and memory buffer for each uC in global map
-        for (const auto& [uC_index, l_dtrace_buffer_info] : handle->g_dtrace_buffer_info_map)
-        {
-            std::vector<uint32_t> buffer(
-                l_dtrace_buffer_info.control_buffer.size() + l_dtrace_buffer_info.mem_buffer.size()
-            );
-
-            // Copy the buffer from the dtrace buffer address
-            std::memcpy(
-                buffer.data(),
-                l_dtrace_buffer_info.buffer_addr,
-                (l_dtrace_buffer_info.control_buffer.size() + l_dtrace_buffer_info.mem_buffer.size()) * sizeof(uint32_t)
-            );
-
-            // Get control_buffer and mem_buffer from the buffer
-            std::vector<uint32_t> control_buffer(
-                buffer.begin(),
-                buffer.begin() + l_dtrace_buffer_info.control_buffer.size() // NOLINT(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
-            );
-            std::vector<uint32_t> mem_buffer(
-                buffer.begin() + l_dtrace_buffer_info.control_buffer.size(), // NOLINT(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
-                buffer.end()
-            );
-
-            // Populate result buffers and memory buffers vector
-            result_buffers[uC_index] = std::move(control_buffer);
-            mem_buffers[uC_index] = std::move(mem_buffer);
-        }
-
-        // Create the result buffer as JSON object
+        // Update the result buffer with the given result key and result buffer data
         nlohmann::ordered_json result_json = nlohmann::ordered_json::object();
-        handle->g_control->create_result_buffer(result_buffers, mem_buffers, result_json);
-
-        // Iterate over and copy back modified buffers for each uC in global map
-        for (const auto& [uC_index, l_dtrace_buffer_info] : handle->g_dtrace_buffer_info_map)
-        {
-            std::vector<uint32_t> buffer;
-            buffer.insert(
-                buffer.end(), result_buffers[uC_index].begin(), result_buffers[uC_index].end()
-            );
-            buffer.insert(
-                buffer.end(), mem_buffers[uC_index].begin(), mem_buffers[uC_index].end()
-            );
-
-            // Populate modified buffer back to the dtrace buffer address
-            std::memcpy(
-                l_dtrace_buffer_info.buffer_addr,
-                buffer.data(),
-                buffer.size() * sizeof(uint32_t)
-            );
-        }
+        handle->g_control->create_result_buffer(handle->g_dtrace_buffer_info_map, result_json);
 
         // Return the result buffer as JSON string
         return result_json.dump();

--- a/test/dtrace_test/CMakeLists.txt
+++ b/test/dtrace_test/CMakeLists.txt
@@ -12,7 +12,7 @@ target_include_directories(${DTRACE_TESTNAME} PRIVATE ${AIEBU_SOURCE_DIR}/src/cp
 
 # Test single uc script
 add_test(NAME "dtrace_single_column"
-  COMMAND ${DTRACE_TESTNAME} "${AIEBU_SOURCE_DIR}/test/dtrace_test/single_col" "${CMAKE_CURRENT_BINARY_DIR}/control_buffer_single.dat"
+  COMMAND ${DTRACE_TESTNAME} "${AIEBU_SOURCE_DIR}/test/dtrace_test/single_col" "${CMAKE_CURRENT_BINARY_DIR}/control_buffer_single.dat" "python"
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   )
 
@@ -22,9 +22,17 @@ add_test(NAME "dtrace_single_column_md5sum"
   )
 set_tests_properties("dtrace_single_column_md5sum" PROPERTIES DEPENDS "dtrace_single_column")
 
+add_test(NAME "dtrace_single_column_result_md5sum"
+  COMMAND ${CMAKE_COMMAND} -E compare_files --ignore-eol 
+  "${CMAKE_CURRENT_BINARY_DIR}/control_buffer_single.py"
+  "${CMAKE_CURRENT_SOURCE_DIR}/single_col/gold_result.py"
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  )
+set_tests_properties("dtrace_single_column_result_md5sum" PROPERTIES DEPENDS "dtrace_single_column")
+
 # Test multi uc script and multi page control block
 add_test(NAME "dtrace_multi_column"
-  COMMAND ${DTRACE_TESTNAME} "${AIEBU_SOURCE_DIR}/test/dtrace_test/multi_col" "${CMAKE_CURRENT_BINARY_DIR}/control_buffer_multi.dat"
+  COMMAND ${DTRACE_TESTNAME} "${AIEBU_SOURCE_DIR}/test/dtrace_test/multi_col" "${CMAKE_CURRENT_BINARY_DIR}/control_buffer_multi.dat" "json"
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   )
 
@@ -33,6 +41,14 @@ add_test(NAME "dtrace_multi_column_md5sum"
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   )
 set_tests_properties("dtrace_multi_column_md5sum" PROPERTIES DEPENDS "dtrace_multi_column")
+
+add_test(NAME "dtrace_multi_column_result_md5sum"
+  COMMAND ${CMAKE_COMMAND} -E compare_files --ignore-eol 
+  "${CMAKE_CURRENT_BINARY_DIR}/control_buffer_multi.json"
+  "${CMAKE_CURRENT_SOURCE_DIR}/multi_col/gold_result.json"
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  )
+set_tests_properties("dtrace_multi_column_result_md5sum" PROPERTIES DEPENDS "dtrace_multi_column")
 
 # Test profile script
 add_test(NAME "dtrace_profile"

--- a/test/dtrace_test/dtrace_test.cpp
+++ b/test/dtrace_test/dtrace_test.cpp
@@ -14,9 +14,10 @@ static const uint64_t TRACE_CTRL_CODE_BASE = 0x200000;
 static const uint64_t TRACE_CTRL_CODE_SIZE = 16384; // 8kB
 static const uint32_t word_byte_shift = 32;
 
-int 
-run_dtrace_test(const std::string& script_file, 
-    const std::string& map_data, const std::string& output_file) 
+int
+run_dtrace_test(const std::string& script_file,
+    const std::string& map_data, const std::string& output_file,
+    const std::string& result_file, uint32_t output_fmt)
 {
     if (!std::filesystem::exists(script_file)) {
         std::cerr << "ERROR: test files not found: " << script_file;
@@ -25,24 +26,23 @@ run_dtrace_test(const std::string& script_file,
 
     uint32_t dtrace_buffer_length = 0;
     uint32_t buffers_length = 0;
-    uint32_t log_level = 0U;   // dtrace_error
-    uint32_t output_fmt = 0U;  // python format
+    uint32_t log_level = 0U;  // dtrace_error
 
-    // get dtrace handle using create_dtrace_handle api from libcert_dtrace
+    // get dtrace handle using create_dtrace_handle api
     void* dtrace_handle = create_dtrace_handle(script_file, map_data, log_level, output_fmt);
     if (!dtrace_handle) {
         std::cerr << "[ERROR]: dtrace compiler failed";
         return 1;
     }
     else {
-        // get dtrace number of column using get_dtrace_col_numbers api from libcert_dtrace
+        // get dtrace number of column using get_dtrace_col_numbers api
         get_dtrace_col_numbers(dtrace_handle, &buffers_length);
 
         // allocate dtrace information buffer
         std::unique_ptr<uint32_t[]> dtrace_buffer = std::make_unique<uint32_t[]>(TRACE_CTRL_CODE_SIZE); // NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
         std::unique_ptr<uint64_t[]> buffers = std::make_unique<uint64_t[]>(buffers_length); // NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
 
-        // get dtrace information using get_dtrace_buffer_size api from libcert_dtrace
+        // get dtrace information using get_dtrace_buffer_size api
         get_dtrace_buffer_size(dtrace_handle, buffers.get());
 
         for (uint32_t i = 0; i < buffers_length; ++i) {
@@ -51,13 +51,13 @@ run_dtrace_test(const std::string& script_file,
             dtrace_buffer_length += length;
         }
 
-        // create dtrace buffer using populate_dtrace_buffer api from libcert_dtrace
+        // create dtrace buffer using populate_dtrace_buffer api
         populate_dtrace_buffer(dtrace_handle, dtrace_buffer.get(), TRACE_CTRL_CODE_BASE);
 
         // create control_buffer.dat file
         if (dtrace_buffer_length > 0) {
             std::ofstream control_buffer_file(output_file, std::ios::binary);
-            control_buffer_file.write(reinterpret_cast<const char*>(dtrace_buffer.get()), 
+            control_buffer_file.write(reinterpret_cast<const char*>(dtrace_buffer.get()),
                 static_cast<std::streamsize>(dtrace_buffer_length * sizeof(uint32_t)));
             control_buffer_file.close();
         }
@@ -66,36 +66,55 @@ run_dtrace_test(const std::string& script_file,
             return 1;
         }
 
-        // destroy dtrace handle using destroy_dtrace_handle api from libcert_dtrace
+        // create result file using get_dtrace_result_file api
+        if (!result_file.empty()) {
+            get_dtrace_result_file(dtrace_handle, result_file);
+        }
+
+        // destroy dtrace handle using destroy_dtrace_handle api
         destroy_dtrace_handle(dtrace_handle);
         return 0;
     }
 }
 
-int main(int argc, char** argv) 
+int main(int argc, char** argv)
 {
     try {
-        if (argc != 3) {
-            std::cerr << "Usage: " << argv[0] << " <testcase_path> <output_file>";
+        if (argc < 3 || argc > 4) {
+            std::cerr << "Usage: " << argv[0] << " <testcase_path> <output_file> [python|json]";
             return 1;
         }
 
         std::string script_file = std::string(argv[1]) + "/script.ct";
         std::string map_file = std::string(argv[1]) + "/map.json";
         std::string output_file = argv[2];
+        std::string result_file;
+        uint32_t output_fmt = 0U;  // python format (default)
+
+        if (argc == 4) {
+            std::string fmt_arg = argv[3];
+            std::filesystem::path output_path(output_file);
+            if (fmt_arg == "python") {
+                output_fmt = 0U;
+                result_file = (output_path.parent_path() / output_path.stem()).string() + ".py";
+            } else if (fmt_arg == "json") {
+                output_fmt = 1U;
+                result_file = (output_path.parent_path() / output_path.stem()).string() + ".json";
+            }
+        }
 
         if (!std::filesystem::exists(map_file)) {
             throw std::runtime_error("[ERROR]: map file does not exist: " + map_file);
-            return 1; 
+            return 1;
         }
 
         std::ifstream map_file_stream(map_file, std::ios::binary);
-        std::vector<uint8_t> map_buffer((std::istreambuf_iterator<char>(map_file_stream)), 
+        std::vector<uint8_t> map_buffer((std::istreambuf_iterator<char>(map_file_stream)),
             std::istreambuf_iterator<char>());
         map_file_stream.close();
         std::string map_data = std::string(map_buffer.begin(), map_buffer.end());
 
-        int ret = run_dtrace_test(script_file, map_data, output_file);
+        int ret = run_dtrace_test(script_file, map_data, output_file, result_file, output_fmt);
         return ret;
     } catch (const std::exception& e) {
         std::cerr << "[ERROR]: Exception: " << e.what();

--- a/test/dtrace_test/multi_col/gold_result.json
+++ b/test/dtrace_test/multi_col/gold_result.json
@@ -1,0 +1,2027 @@
+{
+    "begin": {
+        "tss": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line4": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line5": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line6": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line7": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line8": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line9": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line10": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line11": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line12": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line13": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line14": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line15": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line16": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line17": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line18": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line19": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line20": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line21": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line22": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line23": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line24": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line25": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line26": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line27": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line28": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line32": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line33": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line34": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line35": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line36": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line37": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line38": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line39": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line40": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line41": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line42": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line43": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line44": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line45": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line46": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line47": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line48": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line49": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line50": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line51": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line52": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line53": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line54": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line55": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line56": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line57": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line61": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line62": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line63": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line64": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line65": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line66": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line67": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line68": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line69": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line70": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line71": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line72": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line73": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line74": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line75": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line76": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line77": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line78": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line79": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line80": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line81": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line82": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line83": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line84": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line85": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line86": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line87": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line91": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line92": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line93": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line94": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line95": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line96": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line97": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line98": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line99": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line100": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line101": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line102": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line103": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line104": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line105": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line106": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line107": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line108": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line109": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line110": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line111": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line112": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line113": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line114": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line115": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line116": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line117": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line121": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line122": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line123": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line124": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line125": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line126": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line127": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line128": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line129": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line130": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line131": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line132": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line133": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line134": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line135": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line136": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line137": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line138": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line139": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line140": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line141": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line142": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line143": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line144": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line145": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line146": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line150": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line151": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line152": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line153": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line154": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line155": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line156": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line157": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line158": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line159": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line160": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line161": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line162": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line163": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line164": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line165": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line166": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line167": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line168": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line169": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line170": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line171": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line172": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line173": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line174": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line175": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line176": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line180": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line181": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line182": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line183": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line184": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line185": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line186": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line187": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line188": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line189": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line190": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line191": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line192": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line193": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line194": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line195": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line196": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line197": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line198": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line199": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line200": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line201": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line202": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line203": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line204": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line205": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line206": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line210": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line211": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line212": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line213": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line214": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line215": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line216": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line217": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line218": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line219": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line220": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line221": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line222": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line223": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line224": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line225": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line226": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line227": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line228": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line229": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line230": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line231": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line232": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line233": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line234": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line235": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line236": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line240": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line241": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line242": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line243": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line244": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line245": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line246": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line247": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line248": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line249": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line250": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line251": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line252": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line253": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line254": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line255": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line256": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line257": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line258": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line259": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line260": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line261": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line262": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line263": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line264": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line265": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line266": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line270": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line271": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line272": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line273": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line274": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line275": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line276": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line277": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line278": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line279": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line280": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line281": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line282": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line283": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line284": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line285": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line286": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line287": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line288": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line289": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line290": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line291": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line292": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line293": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line294": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line295": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line299": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line300": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line301": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line302": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line303": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line304": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line305": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line306": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line307": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line308": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line309": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line310": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line311": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line312": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line313": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line314": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line315": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line316": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line317": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line318": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line319": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line320": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line321": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line325": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line326": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line327": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line328": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line329": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line330": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line331": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line332": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line333": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line334": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line335": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line336": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line337": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line338": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line339": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line340": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line341": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line342": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line343": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line344": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line345": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line346": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line347": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line348": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line349": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line353": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line354": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line355": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line356": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line357": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line358": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line359": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line360": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line361": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line362": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line363": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line364": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line365": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line366": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line367": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line368": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line369": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line370": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line371": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line372": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line373": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line374": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line375": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line376": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line377": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line378": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line382": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line383": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line384": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line385": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line386": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line387": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line388": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line389": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line390": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line391": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line392": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line393": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line394": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line395": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line396": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line397": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line398": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line399": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line400": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line401": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line402": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line403": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line404": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line405": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line406": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line407": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line408": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line412": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line413": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line414": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line415": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line416": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line417": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line418": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line419": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line420": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line421": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line422": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line423": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line424": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line425": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line426": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line427": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line428": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line429": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line430": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line431": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line432": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line433": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line434": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line435": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line436": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line437": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line441": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line442": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line443": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line444": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line445": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line446": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line447": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line448": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line449": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line450": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line451": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line452": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line453": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line454": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line455": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line456": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line457": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line458": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line459": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line460": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line461": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line462": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line463": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line464": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line465": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line466": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line467": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line471": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line472": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line473": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line474": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line475": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line476": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line477": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line478": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line479": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line480": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line481": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line482": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line483": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_elfs.asm:uc0:line484": {
+        "ts1": 4222470910
+    },
+    "jprobe:aie_asm_init.asm:uc0:line16": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line17": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line18": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line19": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line20": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line21": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line22": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line23": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line24": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line25": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line26": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line27": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line28": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line29": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line30": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line31": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line32": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line33": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line34": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line35": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line36": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line37": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line38": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line39": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line40": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line41": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line42": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line43": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line44": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line45": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line46": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line47": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line48": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line49": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line50": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line51": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line52": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line53": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line54": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line55": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line56": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line57": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line58": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line59": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line60": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line61": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line62": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line63": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line64": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line65": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line66": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line67": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line68": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line69": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line70": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line71": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line72": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line73": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line74": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line75": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line76": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line77": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line78": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line79": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line80": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line81": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line82": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line83": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line84": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line85": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line86": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line87": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line88": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line89": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line90": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line91": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line92": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line93": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line94": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line95": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line96": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line97": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line98": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line99": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line100": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line101": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line102": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line103": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line104": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line105": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line106": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line107": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line108": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line109": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line110": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line111": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line112": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line113": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line114": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line115": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line116": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line117": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line118": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line119": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line120": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line121": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line122": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line123": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line124": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line125": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line126": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line127": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line128": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line129": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line130": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line131": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line132": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line133": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line134": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line135": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line136": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line137": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line138": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line139": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line140": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line141": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line142": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line143": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line144": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line145": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line146": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line147": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line148": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line149": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line150": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line151": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line152": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line153": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line154": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line155": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line156": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line157": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line158": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line159": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line160": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line161": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line162": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line163": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line164": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line165": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line166": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line167": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line168": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line169": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line170": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line171": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line172": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line173": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line174": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line175": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line176": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line177": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line178": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line179": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_asm_init.asm:uc0:line180": {
+        "ts2": 18135374470983830270
+    },
+    "jprobe:aie_runtime_control1.asm:uc4:line12": {
+        "buf3": [
+            4222470910,
+            4222470910,
+            4222470910,
+            4222470910
+        ]
+    },
+    "jprobe:aie_runtime_control1.asm:uc4:line16": {
+        "buf3": [
+            4222470910,
+            4222470910,
+            4222470910,
+            4222470910
+        ]
+    },
+    "tracepoint:uc4:id4": {
+        "ts4": [
+            18135374470983830270,
+            18135374470983830270,
+            18135374470983830270
+        ]
+    },
+    "tracepoint:uc4:id5": {
+        "ts4": [
+            18135374470983830270,
+            18135374470983830270,
+            18135374470983830270
+        ]
+    },
+    "tracepoint:uc4:id6": {
+        "ts4": [
+            18135374470983830270,
+            18135374470983830270,
+            18135374470983830270
+        ]
+    },
+    "tracepoint:uc4:id7": {
+        "ts4": [
+            18135374470983830270,
+            18135374470983830270,
+            18135374470983830270
+        ]
+    },
+    "jprobe:aie_runtime_control2.asm:uc8:line5": {
+        "ts3": 4222470910
+    },
+    "jprobe:aie_runtime_control2.asm:uc8:line7": {
+        "ts3": 4222470910
+    },
+    "jprobe:aie_runtime_control2.asm:uc8:line9": {
+        "ts3": 4222470910
+    },
+    "jprobe:aie_runtime_control2.asm:uc8:line12": {
+        "ts3": 4222470910
+    },
+    "jprobe:aie_runtime_control2.asm:uc8:line17": {
+        "ts3": 4222470910
+    },
+    "jprobe:aie_runtime_control2.asm:uc8:line22": {
+        "ts3": 4222470910
+    },
+    "jprobe:aie_runtime_control2.asm:uc8:line24": {
+        "ts3": 4222470910
+    },
+    "tracepoint:uc8:id4": {
+        "ts4": [
+            18135374470983830270,
+            18135374470983830270,
+            18135374470983830270
+        ]
+    },
+    "tracepoint:uc8:id5": {
+        "ts4": [
+            18135374470983830270,
+            18135374470983830270,
+            18135374470983830270
+        ]
+    },
+    "tracepoint:uc8:id6": {
+        "ts4": [
+            18135374470983830270,
+            18135374470983830270,
+            18135374470983830270
+        ]
+    },
+    "tracepoint:uc8:id7": {
+        "ts4": [
+            18135374470983830270,
+            18135374470983830270,
+            18135374470983830270
+        ]
+    },
+    "jprobe:aie_runtime_control3.asm:uc12:line6": {
+        "ts3": 18135374470983830270
+    },
+    "jprobe:aie_runtime_control3.asm:uc12:line8": {
+        "ts3": 18135374470983830270
+    },
+    "jprobe:aie_runtime_control3.asm:uc12:line23": {
+        "ts3": 18135374470983830270
+    },
+    "tracepoint:uc12:id4": {
+        "ts4": [
+            18135374470983830270,
+            18135374470983830270,
+            18135374470983830270
+        ]
+    },
+    "tracepoint:uc12:id5": {
+        "ts4": [
+            18135374470983830270,
+            18135374470983830270,
+            18135374470983830270
+        ]
+    },
+    "tracepoint:uc12:id6": {
+        "ts4": [
+            18135374470983830270,
+            18135374470983830270,
+            18135374470983830270
+        ]
+    },
+    "tracepoint:uc12:id7": {
+        "ts4": [
+            18135374470983830270,
+            18135374470983830270,
+            18135374470983830270
+        ]
+    },
+    "jprobe:aie_runtime_control4.asm:uc16:line25": {
+        "v": 4222470910
+    },
+    "jprobe:aie_runtime_control4.asm:uc16:line26": {
+        "v": 4222470910
+    },
+    "tracepoint:uc16:id4": {
+        "ts4": [
+            18135374470983830270,
+            18135374470983830270,
+            18135374470983830270
+        ]
+    },
+    "tracepoint:uc16:id5": {
+        "ts4": [
+            18135374470983830270,
+            18135374470983830270,
+            18135374470983830270
+        ]
+    },
+    "tracepoint:uc16:id6": {
+        "ts4": [
+            18135374470983830270,
+            18135374470983830270,
+            18135374470983830270
+        ]
+    },
+    "tracepoint:uc16:id7": {
+        "ts4": [
+            18135374470983830270,
+            18135374470983830270,
+            18135374470983830270
+        ]
+    },
+    "tracepoint:uc20:id4": {
+        "ts4": [
+            18135374470983830270,
+            18135374470983830270,
+            18135374470983830270
+        ]
+    },
+    "tracepoint:uc20:id5": {
+        "ts4": [
+            18135374470983830270,
+            18135374470983830270,
+            18135374470983830270
+        ]
+    },
+    "tracepoint:uc20:id6": {
+        "ts4": [
+            18135374470983830270,
+            18135374470983830270,
+            18135374470983830270
+        ]
+    },
+    "tracepoint:uc20:id7": {
+        "ts4": [
+            18135374470983830270,
+            18135374470983830270,
+            18135374470983830270
+        ]
+    },
+    "end": {
+        "buf2": [
+            4222470910,
+            4222470910,
+            4222470910,
+            4222470910,
+            4222470910,
+            4222470910,
+            4222470910,
+            4222470910,
+            4222470910,
+            4222470910,
+            4222470910,
+            4222470910,
+            4222470910,
+            4222470910,
+            4222470910,
+            4222470910,
+            4222470910,
+            4222470910,
+            4222470910,
+            4222470910,
+            4222470910,
+            4222470910,
+            4222470910,
+            4222470910,
+            4222470910,
+            4222470910,
+            4222470910,
+            4222470910,
+            4222470910,
+            4222470910,
+            4222470910,
+            4222470910
+        ]
+    }
+}

--- a/test/dtrace_test/single_col/gold_result.py
+++ b/test/dtrace_test/single_col/gold_result.py
@@ -1,0 +1,134 @@
+#! /usr/bin/env python3
+import sys
+
+if __name__ == '__main__':
+  print("\ntracing started ...\n")
+  tss = 4222470910
+  print(f"begin ts: {tss:d}")
+  htss = 18135374470983830270
+  print(f"begin host ts = {htss:d}")
+  def factorial(n):
+      """Return the factorial of n."""
+      if n < 0:
+          return None
+      result = 1
+      for i in range(2, n + 1):
+          result *= i
+      return result
+  print(f"write 0xdeadbeef starting memtile offset 0x100010 and next 4 memory locations")
+  print(f"write 0xabcdabcd to handshake offset 0x20")
+  val = 4222470910
+  print(f"read handshake offset 0x20: {hex(val)}")
+  ts1 = 4222470910
+  operation = "UC_DMA_WRITE_DES_SYNC	 @UCBD_label_0"
+  print("opcode: {}".format(operation))
+  print("ucdma write ts: {:d}".format(ts1))
+  ts1 = 4222470910
+  operation = "UC_DMA_WRITE_DES_SYNC	 @UCBD_label_1"
+  print("opcode: {}".format(operation))
+  print("ucdma write ts: {:d}".format(ts1))
+  ts2 = 4222470910
+  print(f"mask write ts: {ts2:d}")
+  ts2 = 4222470910
+  print(f"mask write ts: {ts2:d}")
+  ts2 = 4222470910
+  print(f"mask write ts: {ts2:d}")
+  ts2 = 4222470910
+  print(f"mask write ts: {ts2:d}")
+  ts2 = 4222470910
+  print(f"mask write ts: {ts2:d}")
+  ts2 = 4222470910
+  print(f"mask write ts: {ts2:d}")
+  print(f"write 0xabcdabcd to memtile 0_1 offset 0")
+  print(f"mask write 0x12345678 to memtile 0_1 offset 0, mask value 0x0000FFFF")
+  ts3 = 18135374470983830270
+  operation = "UC_DMA_WRITE_DES_SYNC	 @UCBD_label_0"
+  print("opcode: {operation} timestamp: {ts3:d}")
+  ts3 = 18135374470983830270
+  operation = "APPLY_OFFSET_57	 @DMAWRITE_data_0, 1, 2"
+  print("opcode: {operation} timestamp: {ts3:d}")
+  ts3 = 18135374470983830270
+  operation = "UC_DMA_WRITE_DES_SYNC	 @UCBD_label_1"
+  print("opcode: {operation} timestamp: {ts3:d}")
+  ts3 = 18135374470983830270
+  operation = "APPLY_OFFSET_57	 @DMAWRITE_data_2, 1, 0"
+  print("opcode: {operation} timestamp: {ts3:d}")
+  ts3 = 18135374470983830270
+  operation = "UC_DMA_WRITE_DES_SYNC	 @UCBD_label_2"
+  print("opcode: {operation} timestamp: {ts3:d}")
+  ts3 = 18135374470983830270
+  operation = "MASK_POLL_32	 0x61d0604, 0x1, 0x1"
+  print("opcode: {operation} timestamp: {ts3:d}")
+  ts3 = 18135374470983830270
+  operation = "MASK_POLL_32	 0x1d0604, 0x1, 0x1"
+  print("opcode: {operation} timestamp: {ts3:d}")
+  ts3 = 18135374470983830270
+  operation = "UC_DMA_WRITE_DES_SYNC	 @UCBD_label_3"
+  print("opcode: {operation} timestamp: {ts3:d}")
+  ts3 = 18135374470983830270
+  operation = "MASK_POLL_32	 0x21d0604, 0x1, 0x1"
+  print("opcode: {operation} timestamp: {ts3:d}")
+  ts3 = 18135374470983830270
+  operation = "UC_DMA_WRITE_DES_SYNC	 @UCBD_label_4"
+  print("opcode: {operation} timestamp: {ts3:d}")
+  ts3 = 18135374470983830270
+  operation = "APPLY_OFFSET_57	 @DMAWRITE_data_8, 1, 1"
+  print("opcode: {operation} timestamp: {ts3:d}")
+  ts3 = 18135374470983830270
+  operation = "UC_DMA_WRITE_DES_SYNC	 @UCBD_label_5"
+  print("opcode: {operation} timestamp: {ts3:d}")
+  ts3 = 18135374470983830270
+  operation = "MASK_POLL_32	 0x400c604, 0x1, 0x1"
+  print("opcode: {operation} timestamp: {ts3:d}")
+  v = 4222470910
+  print(f"read from memtile 0_1 offset 0: {hex(v)}")
+  ts_start_job = 4222470910
+  axi_mm_offset = 4222470910
+  print(f"start job ts: {ts_start_job:d} axi_mm_offset: 0x{axi_mm_offset:x}")
+  cnt = 0
+  operation = "LOAD_PDI 0, @pdi"
+  print("opcode: {} count: {}".format(operation, cnt))
+  ts_end_job = 18135374470983830270
+  print("end job ts: {ts_end_job:d}")
+  v = 4222470910
+  print(f"read from memtile 1_1 offset 0: {hex(v)}")
+  ts4 = [18135374470983830270, 18135374470983830270, 18135374470983830270, 18135374470983830270, 18135374470983830270]
+  probename = "tracepoint:uc0:id4"
+  print(f"{probename}: page load timestamps: {ts4}")
+  ts10 = [18135374470983830270, 18135374470983830270, 18135374470983830270, 18135374470983830270, 18135374470983830270]
+  probename = "tracepoint:uc0:id4"
+  print(f"{probename}: page load host timestamps: {ts10}")
+  ts4 = [18135374470983830270, 18135374470983830270, 18135374470983830270, 18135374470983830270, 18135374470983830270]
+  probename = "tracepoint:uc0:id5"
+  print(f"{probename}: page load timestamps: {ts4}")
+  ts10 = [18135374470983830270, 18135374470983830270, 18135374470983830270, 18135374470983830270, 18135374470983830270]
+  probename = "tracepoint:uc0:id5"
+  print(f"{probename}: page load host timestamps: {ts10}")
+  ts5 = [4222470910, 4222470910, 4222470910, 4222470910, 4222470910]
+  probename = "tracepoint:uc0:id6"
+  print(f"{probename}: page execute start timestamps: {ts5}")
+  ts6 = [4222470910, 4222470910, 4222470910, 4222470910, 4222470910]
+  probename = "tracepoint:uc0:id7"
+  print(f"{probename}: page execute done timestamps: {ts6}")
+  ts7 = 18135374470983830270
+  probename = "tracepoint:uc0:id12"
+  print("{}: after control code running ts4: {:d}".format(probename, ts7))
+  ts8 = 18135374470983830270
+  probename = "tracepoint:uc0:id14"
+  print("{}: before hsa cmd completion ts5: {:d}".format(probename, ts8))
+  buf2 = "[0xfbadcafe, 0xfbadcafe, 0xfbadcafe, 0xfbadcafe]"
+  print(f"read mem = {buf2}")
+  print(f"buf3 result = {buf3}")
+  time_taken = [ts6[i] - ts5[i] for i in range(len(ts5))]
+  max_time = max(time_taken)
+  max_time_page = time_taken.index(max_time)
+  print("page time taken:", time_taken)
+  print(f"page {max_time_page} took the most time: {max_time}")
+  def main():
+      num = 5
+      print(f"[PYTHON] Factorial of {num} is {factorial(num)}")
+  main()
+  time = ts_end_job - ts_start_job
+  print(f"total time: {time:d}")
+  print("\ntracing ended !!\n")
+  sys.exit(0)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

- Eliminated unnecessary buffer copies in dtrace result serialization APIs (`get_dtrace_result_file` and `update_dtrace_result_buffer`). Previously, these functions performed multiple memory copies: reading device memory into temporary vectors, splitting into control/mem buffers, passing to internal APIs, then copying modified buffers back to device memory.

- Fixed read actions input format (decimal/hexadecimal) bug
 
- Skip empty result file creation when no probes fire and defer file creation until first probe fires

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

No bug fix. Performance optimization identified during code review of PR #295.

#### How problem was solved, alternative solutions (if any) and why they were rejected

- Changed `action::serialize()` and `control::create_result_file/create_result_buffer` to operate directly on device buffer addresses

- Changed `action::serialize()` methods to return bool to indicate probe fire status, result- zero empty files in scenarios like capturing intermediate multi run hangs

#### Risks (if any) associated the changes in the commit

Low

#### What has been tested and how, request additional testing if necessary

Simnow baremetal environment testcase
Tested on windows medusa board and the features work as expected
cmake testcase for python and json result output

#### Documentation impact (if any)

NA
