### PR TITLE
fix decode_opcode test to use same ELFIO as aiebu_static (built with XRT)

### DIFF
--- a/test/aie2ps-ctrlcode/decode_opcode/CMakeLists.txt
+++ b/test/aie2ps-ctrlcode/decode_opcode/CMakeLists.txt
@@ -6,7 +6,7 @@ add_executable(${DECODE_OPCODE_TEST} decode_opcode.cpp)
 target_link_libraries(${DECODE_OPCODE_TEST} PRIVATE aiebu_static)
 target_include_directories(${DECODE_OPCODE_TEST} PRIVATE
   ${AIEBU_SOURCE_DIR}/src/cpp/include
-  ${AIEBU_SOURCE_DIR}/src/cpp/ELFIO
+  ${AIEBU_ELFIO_SRC_DIR}
 )
 if (NOT WIN32)
   target_link_libraries(${DECODE_OPCODE_TEST} PRIVATE pthread)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
The decode_opcode test hardcoded ${AIEBU_SOURCE_DIR}/src/cpp/ELFIO as its ELFIO include path. When built as an XRT submodule, aiebu_static is compiled with XRT's ELFIO (via AIEBU_ELFIO_SRC_DIR), so the test and aiebu_static end up with two different elfio.hpp definitions in the same binary, causing undefined behavior and the test to fail with "failed to parse ELF".

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Decode_opcode testcase fails when aiebu is built as part of XRT, but passes with standalone aiebu. Added fix for decode_opcode test to use same ELFIO as aiebu_static
#### How problem was solved, alternative solutions (if any) and why they were rejected
use ${AIEBU_ELFIO_SRC_DIR} so the test always uses the same ELFIO headers as aiebu_static.
