### PR TITLE
dynamic tracing compiler temporary API block

### DIFF
--- a/src/cpp/dtrace/dtrace.cpp
+++ b/src/cpp/dtrace/dtrace.cpp
@@ -286,6 +286,7 @@ get_dtrace_result_file(dtrace_handle_t dtrace_handle, const std::string& result_
     }
 }
 
+/*
 void
 update_dtrace_result_buffer(dtrace_handle_t dtrace_handle, const std::string& result_key,
     nlohmann::ordered_json& result_buffer)
@@ -356,6 +357,7 @@ update_dtrace_result_buffer(dtrace_handle_t dtrace_handle, const std::string& re
         std::cerr << e.what();
     }
 }
+*/
 
 void
 destroy_dtrace_handle(dtrace_handle_t dtrace_handle)

--- a/src/cpp/dtrace/dtrace.h
+++ b/src/cpp/dtrace/dtrace.h
@@ -5,7 +5,7 @@
 #define TRACE_H
 
 // This header file contains the public APIs for creating control buffer, memory buffer, and result file
-#include "json/nlohmann/json.hpp"
+// #include "json/nlohmann/json.hpp"
 #include "utils.h"
 
 #include <cstdint>
@@ -108,10 +108,12 @@ get_dtrace_result_file(dtrace_handle_t dtrace_handle, const std::string& result_
  * This function extracts results from the device buffer (same as get_dtrace_result_file)
  * but serializes into the provided JSON object under result_key instead of writing to a file.
  */
+/*
 DTRACE_EXPORT
 void
 update_dtrace_result_buffer(dtrace_handle_t dtrace_handle, const std::string& result_key,
     nlohmann::ordered_json& result_buffer);
+*/
 
 /*!
 * destroy_dtrace_handle() - Destroys a dynamic tracing context.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

Temporary block the unused `update_dtrace_result_buffer` API for dtrace header file refactoring

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

https://github.com/Xilinx/XRT/pull/9876

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

Low

#### What has been tested and how, request additional testing if necessary

cmake build testcase

#### Documentation impact (if any)

NA
