### PR TITLE
dynamic tracing compiler result buffer API refactor

### DIFF
--- a/src/cpp/dtrace/dtrace.cpp
+++ b/src/cpp/dtrace/dtrace.cpp
@@ -286,10 +286,8 @@ get_dtrace_result_file(dtrace_handle_t dtrace_handle, const std::string& result_
     }
 }
 
-/*
-void
-update_dtrace_result_buffer(dtrace_handle_t dtrace_handle, const std::string& result_key,
-    nlohmann::ordered_json& result_buffer)
+std::string
+get_dtrace_result_buffer(dtrace_handle_t dtrace_handle)
 {
     try
     {
@@ -328,10 +326,9 @@ update_dtrace_result_buffer(dtrace_handle_t dtrace_handle, const std::string& re
             mem_buffers[uC_index] = std::move(mem_buffer);
         }
 
-        // Update the result buffer with the given result key and result buffer data
+        // Create the result buffer as JSON object
         nlohmann::ordered_json result_json = nlohmann::ordered_json::object();
         handle->g_control->create_result_buffer(result_buffers, mem_buffers, result_json);
-        result_buffer[result_key] = std::move(result_json);
 
         // Iterate over and copy back modified buffers for each uC in global map
         for (const auto& [uC_index, l_dtrace_buffer_info] : handle->g_dtrace_buffer_info_map)
@@ -351,13 +348,16 @@ update_dtrace_result_buffer(dtrace_handle_t dtrace_handle, const std::string& re
                 buffer.size() * sizeof(uint32_t)
             );
         }
+
+        // Return the result buffer as JSON string
+        return result_json.dump();
     }
     catch (const std::exception& e)
     {
         std::cerr << e.what();
+        return "null";
     }
 }
-*/
 
 void
 destroy_dtrace_handle(dtrace_handle_t dtrace_handle)

--- a/src/cpp/dtrace/dtrace.cpp
+++ b/src/cpp/dtrace/dtrace.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (C) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.
 
-// This file implements the dtrace public APIs for creating dtrace control buffer, 
+// This file implements the dtrace public APIs for creating dtrace control buffer,
 // dtrace memory buffer and dtrace result file.
 #include "dtrace.h"
 #include "utils.h"
@@ -10,9 +10,10 @@
 
 #include <cstring>
 #include <exception>
-#include <filesystem>
+#include <iostream>
 #include <memory>
-#include <stdexcept>
+#include <unordered_map>
+#include <vector>
 
 /**
  * @struct dtrace_buffer_info

--- a/src/cpp/dtrace/dtrace.cpp
+++ b/src/cpp/dtrace/dtrace.cpp
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: MIT
-// Copyright (C) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.
 
 // This file implements the dtrace public APIs for creating dtrace control buffer, 
 // dtrace memory buffer and dtrace result file.
 #include "dtrace.h"
+#include "utils.h"
+
 #include "control/control.h"
 
 #include <cstring>

--- a/src/cpp/dtrace/dtrace.h
+++ b/src/cpp/dtrace/dtrace.h
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: MIT
-// Copyright (C) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.
 
 #ifndef TRACE_H
 #define TRACE_H
 
 // This header file contains the public APIs for creating control buffer, memory buffer, and result file
-#include "utils.h"
 
 #include <cstdint>
 #include <iostream>

--- a/src/cpp/dtrace/dtrace.h
+++ b/src/cpp/dtrace/dtrace.h
@@ -7,16 +7,7 @@
 // This header file contains the public APIs for creating control buffer, memory buffer, and result file
 
 #include <cstdint>
-#include <iostream>
 #include <string>
-#include <unordered_map>
-#include <vector>
-
-#ifdef _WIN32
-  #define DTRACE_EXPORT __declspec(dllexport)
-#else
-  #define DTRACE_EXPORT __attribute__((visibility("default")))
-#endif
 
 /*!
  * handle to a dynamic tracing context.
@@ -35,7 +26,6 @@ using dtrace_handle_t = void*;  // NOLINT
  * @return Opaque raw handle to the dynamic tracing context owned by the caller, or NULL on failure.
  * @note The caller must release this handle by calling destroy_dtrace_handle().
  */
-DTRACE_EXPORT
 dtrace_handle_t
 create_dtrace_handle(const std::string& script_file, const std::string& map_data, uint32_t log_level,
     uint32_t output_fmt);
@@ -49,7 +39,6 @@ create_dtrace_handle(const std::string& script_file, const std::string& map_data
  * This function calculates and returns the length of uC for dynamic tracing based
  * on the provided script file and map data.
  */
-DTRACE_EXPORT
 void
 get_dtrace_col_numbers(dtrace_handle_t dtrace_handle, uint32_t* buffers_length);
 
@@ -63,7 +52,6 @@ get_dtrace_col_numbers(dtrace_handle_t dtrace_handle, uint32_t* buffers_length);
  * This function calculates and returns the length of the control and memory buffers 
  * and uC index needed for dynamic tracing based on the provided script file and map data. 
  */
-DTRACE_EXPORT
 void
 get_dtrace_buffer_size(dtrace_handle_t dtrace_handle, uint64_t* buffers);
 
@@ -71,14 +59,13 @@ get_dtrace_buffer_size(dtrace_handle_t dtrace_handle, uint64_t* buffers);
  * populate_dtrace_buffer() - Creates a dynamic tracing buffers.
  *
  * @dtrace_handle:          Handle to the dynamic tracing context.
- * @control_buffer:         Address for control buffer and memory buffer containing 
+ * @dtrace_buffer:          Address for control buffer and memory buffer containing 
  *                          probe and action details and mem action details for multiple uC.
  * @dtrace_buffer_dma:      Physical address of the buffer, used to patch mem action host address
  *
  * This function initializes and allocates dynamic tracing buffers for each uC index. 
  * Each element in the control buffer represents a probe or its respective action.
  */
-DTRACE_EXPORT
 void 
 populate_dtrace_buffer(dtrace_handle_t dtrace_handle, uint32_t* dtrace_buffer, 
     uint64_t dtrace_buffer_dma);
@@ -92,7 +79,6 @@ populate_dtrace_buffer(dtrace_handle_t dtrace_handle, uint32_t* dtrace_buffer,
  * This function creates a result file by processing the result buffer and mem buffer, 
  * and writes the output to the specified result file.
  */
-DTRACE_EXPORT
 void
 get_dtrace_result_file(dtrace_handle_t dtrace_handle, const std::string& result_file);
 
@@ -105,7 +91,6 @@ get_dtrace_result_file(dtrace_handle_t dtrace_handle, const std::string& result_
  * This function extracts results by processing the result buffer and mem buffer,
  * and returns the result as JSON string.
  */
-DTRACE_EXPORT
 std::string
 get_dtrace_result_buffer(dtrace_handle_t dtrace_handle);
 
@@ -117,7 +102,6 @@ get_dtrace_result_buffer(dtrace_handle_t dtrace_handle);
 * This function releases all resources associated with the dynamic tracing handle. 
 * After this call, handle must not be used again.
 */
-DTRACE_EXPORT
 void
 destroy_dtrace_handle(dtrace_handle_t dtrace_handle);
 

--- a/src/cpp/dtrace/dtrace.h
+++ b/src/cpp/dtrace/dtrace.h
@@ -5,7 +5,6 @@
 #define TRACE_H
 
 // This header file contains the public APIs for creating control buffer, memory buffer, and result file
-// #include "json/nlohmann/json.hpp"
 #include "utils.h"
 
 #include <cstdint>
@@ -99,21 +98,17 @@ void
 get_dtrace_result_file(dtrace_handle_t dtrace_handle, const std::string& result_file);
 
 /*!
- * update_dtrace_result_buffer() - Stores dtrace result in an in-memory JSON object.
+ * get_dtrace_result_buffer() - Return dtrace result as JSON string.
  *
  * @dtrace_handle:    Handle to the dynamic tracing context.
- * @result_key:       Key to store the result under in the JSON object.
- * @result_buffer:    JSON object to store results.
+ * @return            JSON serialized result as string.
  *
- * This function extracts results from the device buffer (same as get_dtrace_result_file)
- * but serializes into the provided JSON object under result_key instead of writing to a file.
+ * This function extracts results by processing the result buffer and mem buffer,
+ * and returns the result as JSON string.
  */
-/*
 DTRACE_EXPORT
-void
-update_dtrace_result_buffer(dtrace_handle_t dtrace_handle, const std::string& result_key,
-    nlohmann::ordered_json& result_buffer);
-*/
+std::string
+get_dtrace_result_buffer(dtrace_handle_t dtrace_handle);
 
 /*!
 * destroy_dtrace_handle() - Destroys a dynamic tracing context.

--- a/src/cpp/dtrace/parser/parser.cpp
+++ b/src/cpp/dtrace/parser/parser.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (C) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.
 
 // This file contains the implementation of the parser class. The parser class is responsible for
 // parsing the input script file and generating the corresponding probe and action.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

Eliminate nlohmann JSON library dependency from aiebu's dtrace public API. Simplify `dtrace_result_buffer()` by using standard string return value semantics.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

No bug fix. Design improvement - aiebu was exposing nlohmann::ordered_json in dtrace public headers, forcing all clients to depend on that library.

#### How problem was solved, alternative solutions (if any) and why they were rejected

Changed `get_dtrace_result_buffer(handle)` to returns JSON as string directly.

#### Risks (if any) associated the changes in the commit

Low

#### What has been tested and how, request additional testing if necessary

 Verifed dtrace buffering works end-to-end in XRT on windows medusa board and simnow baremetal flow
 
#### Documentation impact (if any)

https://amd.atlassian.net/wiki/spaces/AIE/pages/779183759/cert+dynamic+tracing+dtrace+compiler+APIs
