### PR TITLE
aiebu: use $<TARGET_FILE:...> for generator executable commands

### DIFF
--- a/lib/src/CMakeLists.txt
+++ b/lib/src/CMakeLists.txt
@@ -42,7 +42,7 @@ file(MAKE_DIRECTORY ${AIEBU_GEN_DIR})
 
 add_custom_command(
   OUTPUT ${AIEBU_PREEMPT_GEN_FILES}
-  COMMAND ${AIEBU_PREEMPTION_EXE}
+  COMMAND $<TARGET_FILE:${AIEBU_PREEMPTION_EXE}>
   DEPENDS ${AIEBU_PREEMPTION_EXE}
   COMMENT "Generating save/restore ctrlcode stubs in directory ${AIEBU_GEN_DIR}"
   VERBATIM
@@ -79,7 +79,7 @@ endif()
 
 add_custom_command(
   OUTPUT ${AIEBU_COPY_GEN_FILES}
-  COMMAND ${AIEBU_COPY_EXE}
+  COMMAND $<TARGET_FILE:${AIEBU_COPY_EXE}>
   DEPENDS ${AIEBU_COPY_EXE}
   COMMENT "Generating copy ctrlcode stubs in directory ${AIEBU_GEN_DIR}"
   VERBATIM


### PR DESCRIPTION
CMake's add_custom_command(COMMAND <target>) expands the bare target name as the command string in some generators/configurations, rather than the full path to the built executable.  In a cross-compilation environment the host-built generator binaries are not on PATH, so the command fails with "No such file or directory".

Use the $<TARGET_FILE:tgt> generator expression which always expands to the absolute path of the built executable, making the custom commands work correctly in both native and cross builds.

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Compilation problems in cross-compilation environments like BuildRoot.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Use the $<TARGET_FILE:tgt> generator expression in add_custom_commands() making the custom commands work correctly in both native and cross builds.

#### What has been tested and how, request additional testing if necessary
Change was successfully compiled under a BuildRoot, cross-compile build and a native build under Ubuntu 24.04.

Successfully ran 'ctest -C Release -j4' and 'ctest -C Release -L benchmark' under Ubuntu 24.04.

Request a Windows build test to ensure nothing has been broken.
